### PR TITLE
Default-deny additive allowlist gate for feature auto-merge

### DIFF
--- a/feature_allowlist.py
+++ b/feature_allowlist.py
@@ -1,0 +1,259 @@
+"""
+feature_allowlist.py — pure, standalone DEFAULT-DENY allowlist matcher for
+AppBuilder's auto-merge gate (pr_review.py's _automerge_decision).
+
+WHY THIS EXISTS (design intent, operator-authored)
+---------------------------------------------------
+feature_boundary.py answers "does this diff touch something we must NEVER
+build without a human?" — a deny-list. That is necessary but not sufficient:
+the operator's policy is DEFAULT-DENY, i.e. *nothing* auto-merges unless it
+is a small, additive, provably-safe change. This module answers the opposite,
+positive question: "is this diff one of the few additive shapes we are
+willing to merge with no human?".
+
+The gate composition in _automerge_decision is therefore:
+
+    auto-merge  ==  (all existing panel/confidence/state gates pass)
+                AND (boundary_hits is empty)          # deny-list  (feature_boundary)
+                AND (classify(...) is auto-approvable) # allow-list (this module)
+
+Because this is added as an *additional required* condition, it can only ever
+make auto-merge MORE restrictive. A false negative here (we fail to recognise
+a genuinely-safe change) costs only "a human approves it" — which is the
+operator's explicit safe default for anything behaviour-changing. A false
+positive is the dangerous direction, so every detector below is deliberately
+conservative and fails closed on ANY ambiguity (missing patch text, mixed
+categories, an unexpected line shape → not auto-approvable).
+
+WHAT IS AUTO-APPROVABLE (must be provable from the diff alone)
+-------------------------------------------------------------
+  - docs-only     : every changed file is documentation (*.md/*.rst/docs/**).
+  - log-only      : purely additive logging — only added `logger.*` calls,
+                    zero deletions, no other added code.
+  - tooltip-only  : only tooltip / label copy attributes changed
+                    (title=/aria-label=/placeholder=/label text), no logic.
+
+WHAT IS DELIBERATELY *NOT* AUTO-APPROVABLE HERE (routes to human)
+----------------------------------------------------------------
+  - new-client-simulation : a real sim touches shared orchestrators/config
+        (see the add-simulation skill — ~15 coordinated edits, many of them
+        MODIFICATIONS to existing shared files). "additive & isolated" cannot
+        be proven from the diff, so a new-sim PR is built + reviewed and then
+        waits for a human. Promoting it to auto-approve needs a semantic
+        classifier signal, not a path heuristic — intentionally future work.
+  - report-only : a "read-only" report cannot be proven side-effect-free from
+        a diff alone, so it also routes to human approval.
+
+Navigation / button / form-handler / route-logic changes are, by
+construction, none of the categories above → not auto-approvable → human.
+That is the operator rule "behaviour-changing → build but gate" enforced
+mechanically rather than by trust.
+
+No app imports (mirrors feature_boundary.py / secrets_scan.py): this is a
+deterministic, import-light, directly-unit-testable pure module.
+
+File record shape (dict) — a normalised view of one PyGithub PR file:
+    {
+        "path": "ab/docs/foo.md",      # filename
+        "status": "modified",          # added|modified|removed|renamed
+        "additions": 3,
+        "deletions": 0,
+        "patch": "@@ ... @@\n+...\n",   # unified diff hunk text, may be None
+    }
+"""
+import fnmatch
+
+# ── category ids (stable slugs, referenced in config + merge reasons) ────────
+DOCS_ONLY = "docs-only"
+LOG_ONLY = "log-only"
+TOOLTIP_ONLY = "tooltip-only"
+
+# The categories this diff-level classifier is willing to auto-approve. The
+# operator narrows (never widens beyond) this from config key
+# `feature_automerge_allowlist`; an empty/absent config list means "use this
+# default set". Categories the classifier can never *prove* from a diff
+# (new-client-simulation, report-only) are intentionally not in this set.
+DEFAULT_ALLOWLIST = [DOCS_ONLY, LOG_ONLY, TOOLTIP_ONLY]
+
+# Documentation file shapes — edits here cannot change runtime behaviour.
+_DOC_GLOBS = [
+    "*.md", "**/*.md", "*.rst", "**/*.rst", "*.txt", "**/*.txt",
+    "**/docs/**", "docs/**", "README*", "**/README*", "CHANGELOG*", "**/CHANGELOG*",
+]
+
+
+def _path_hit(path, patterns):
+    return any(fnmatch.fnmatch(path, pat) for pat in patterns)
+
+
+def _added_lines(patch):
+    """Content lines the diff ADDS (leading '+', excluding the '+++' header).
+    Returns each line's text WITHOUT the leading '+'."""
+    out = []
+    for ln in (patch or "").splitlines():
+        if ln.startswith("+") and not ln.startswith("+++"):
+            out.append(ln[1:])
+    return out
+
+
+def _removed_lines(patch):
+    """Content lines the diff REMOVES (leading '-', excluding the '---'
+    header), each WITHOUT the leading '-'."""
+    out = []
+    for ln in (patch or "").splitlines():
+        if ln.startswith("-") and not ln.startswith("---"):
+            out.append(ln[1:])
+    return out
+
+
+# A logging call: logger./logging./log./self.log. + a level method + '('.
+# Deliberately anchored to the START of the (stripped) added line so a line
+# that merely *mentions* logging inside other code does not qualify.
+_LOG_PREFIXES = ("logger.", "logging.", "log.", "self.logger.", "self.log.", "_log.", "LOG.")
+_LOG_METHODS = ("debug(", "info(", "warning(", "warn(", "error(", "critical(", "exception(")
+
+
+def _is_pure_log_added_line(text):
+    """True if an added line is blank, a comment, or a single logging call.
+    Conservative: the line must START with a known logger prefix AND contain a
+    level method call — assignments, conditionals, or logger *configuration*
+    (addHandler/setLevel/getLogger) do NOT qualify."""
+    s = text.strip()
+    if s == "" or s.startswith("#"):
+        return True
+    if not s.startswith(_LOG_PREFIXES):
+        return False
+    return any(m in s for m in _LOG_METHODS)
+
+
+# Attribute-copy tokens that carry no behaviour — pure human-visible text.
+_TOOLTIP_TOKENS = ("title=", "aria-label=", "aria-describedby=", "placeholder=",
+                   "data-tooltip=", "data-bs-title=", "label=", "helptext=", "help_text=")
+
+
+def _is_pure_tooltip_line(text):
+    """True if a changed (added or removed) line only carries tooltip/label
+    copy. Blank/comment lines pass; otherwise the line must contain a tooltip
+    token AND must not contain code-flow punctuation that would indicate real
+    logic (assignment to a variable, a call other than the attribute, etc.).
+    Conservative by design — anything it is unsure about fails the category."""
+    s = text.strip()
+    if s == "":
+        return True
+    if not any(tok in s.casefold() for tok in _TOOLTIP_TOKENS):
+        return False
+    # Reject lines that look like control flow / real statements rather than a
+    # markup attribute or a simple copy assignment.
+    lowered = s.casefold()
+    for bad in ("def ", "return ", "import ", "if ", "for ", "while ", "lambda",
+                "os.", "subprocess", "eval(", "exec(", "->"):
+        if bad in lowered:
+            return False
+    return True
+
+
+def _all_docs(files):
+    return bool(files) and all(_path_hit(f.get("path", ""), _DOC_GLOBS) for f in files)
+
+
+def _all_log_only(files):
+    """Purely additive logging across EVERY changed file: no deletions
+    anywhere, and every added line is blank/comment or a bare logging call.
+    A file with no patch text (binary / patch unavailable) fails closed."""
+    if not files:
+        return False
+    for f in files:
+        if f.get("status") in ("removed", "renamed"):
+            return False
+        patch = f.get("patch")
+        if not patch:
+            return False
+        if _removed_lines(patch):
+            return False
+        added = _added_lines(patch)
+        if not added:
+            return False
+        if not all(_is_pure_log_added_line(a) for a in added):
+            return False
+    return True
+
+
+def _all_tooltip_only(files):
+    """Only tooltip/label copy changed across EVERY changed file. Both added
+    and removed lines must be pure tooltip lines; a missing patch fails
+    closed; there must be at least one real tooltip line so an empty/no-op
+    diff does not masquerade as this category."""
+    if not files:
+        return False
+    saw_real = False
+    for f in files:
+        if f.get("status") in ("removed", "renamed"):
+            return False
+        patch = f.get("patch")
+        if not patch:
+            return False
+        changed = _added_lines(patch) + _removed_lines(patch)
+        if not changed:
+            return False
+        for c in changed:
+            if not _is_pure_tooltip_line(c):
+                return False
+            if c.strip():
+                saw_real = True
+    return saw_real
+
+
+def classify(files, allowlist=None):
+    """Classify a PR's real changed-file records into at most ONE additive
+    allowlist category, honouring the operator's enabled-category `allowlist`
+    (defaults to DEFAULT_ALLOWLIST). Returns:
+
+        {"category": str|None, "auto_approvable": bool, "reason": str}
+
+    `auto_approvable` is True ONLY when a category matched AND that category
+    is enabled in `allowlist`. Any ambiguity, mixed categories, missing patch
+    text, or unrecognised shape → category None, auto_approvable False, and a
+    reason explaining the safe fallback to human approval."""
+    enabled = list(allowlist) if allowlist else list(DEFAULT_ALLOWLIST)
+
+    if not files:
+        return {"category": None, "auto_approvable": False,
+                "reason": "no changed files to classify (fail closed)"}
+
+    # Order matters only for reason clarity; the detectors are mutually
+    # exclusive in practice (a docs file is not a .py logging change).
+    if _all_docs(files):
+        cat = DOCS_ONLY
+    elif _all_log_only(files):
+        cat = LOG_ONLY
+    elif _all_tooltip_only(files):
+        cat = TOOLTIP_ONLY
+    else:
+        return {"category": None, "auto_approvable": False,
+                "reason": "diff is not a recognised additive allowlist shape "
+                          "(docs-only / log-only / tooltip-only) — routes to human approval"}
+
+    if cat not in enabled:
+        return {"category": cat, "auto_approvable": False,
+                "reason": f"matched additive category '{cat}' but it is not enabled "
+                          f"in feature_automerge_allowlist — routes to human approval"}
+
+    return {"category": cat, "auto_approvable": True,
+            "reason": f"additive allowlist category '{cat}' (auto-approvable)"}
+
+
+def files_from_pr_files(pr_files):
+    """Normalise an iterable of PyGithub PR file objects (pr.get_files())
+    into the plain-dict records classify() expects. Kept here (not in
+    pr_review) so the normalisation is unit-testable without importing the
+    live app."""
+    out = []
+    for f in pr_files or []:
+        out.append({
+            "path": getattr(f, "filename", "") or "",
+            "status": getattr(f, "status", "") or "",
+            "additions": getattr(f, "additions", 0) or 0,
+            "deletions": getattr(f, "deletions", 0) or 0,
+            "patch": getattr(f, "patch", None),
+        })
+    return out

--- a/feature_boundary.py
+++ b/feature_boundary.py
@@ -94,6 +94,41 @@ DEFAULT_BOUNDARIES = [
         "keywords": ["fernet", "encryption key", "data_dir"],
         "hard": True, "enabled": True,
     },
+    {
+        "id": "auth-onboarding",
+        "label": "Auth / sessions / OIDC / spoke onboarding",
+        "rule": "Never change login, session handling, OIDC/SSO, or the "
+                "spoke-onboarding / setup handshake (who is allowed in and how "
+                "a spoke first joins) without a human designing the change.",
+        "paths": ["**/auth.py", "**/auth*.py", "**/oidc.py", "**/*onboard*",
+                  "**/routes/setup*", "**/setup_routes*", "**/session*"],
+        "keywords": ["oidc", "sso", "onboarding", "login session", "session cookie",
+                     "enrollment token", "join token"],
+        "hard": True, "enabled": True,
+    },
+    {
+        "id": "installers",
+        "label": "Installers / provisioning / uninstall scripts",
+        "rule": "Never change fleet provisioning, install/uninstall, or "
+                "bootstrap scripts as a side effect of a feature — a bug here "
+                "can brick a host at install/upgrade time.",
+        "paths": ["**/install*.sh", "**/setup.sh", "**/uninstall*.sh",
+                  "**/bootstrap*.sh", "**/*_setup.py"],
+        "keywords": ["installer", "provisioning script", "systemd unit", "bootstrap"],
+        "hard": True, "enabled": True,
+    },
+    {
+        "id": "control-plane",
+        "label": "Hub↔spoke control plane / command dispatch",
+        "rule": "Never change the messaging control plane or how commands are "
+                "dispatched to spokes (what a hub can tell a fleet of spokes to "
+                "do) without a human designing the change.",
+        "paths": ["**/control_plane*", "**/messaging/**", "**/command_dispatch*",
+                  "**/hub_agent.py"],
+        "keywords": ["control plane", "command dispatch", "broadcast command",
+                     "remote command", "fleet command"],
+        "hard": True, "enabled": True,
+    },
 ]
 
 

--- a/pr_review.py
+++ b/pr_review.py
@@ -64,6 +64,7 @@ from datetime import timedelta
 from github_ops import get_monitored_repos
 from app_state import update_task_state, record_pr_review, update_pr_review, mark_pr_approved, state
 import feature_boundary
+import feature_allowlist
 from pr_actions import approve_pr, merge_pr
 from secrets_scan import check_secrets
 from check_tooltips import find_missing_tooltips_in_files
@@ -776,7 +777,7 @@ def _resolve_cross_repo_twins(gh, findings, since=None):
 _FEATURE_DRIVE_MARKER_RE = re.compile(r"<!--\s*ab-feature-drive:\s*([^\s>]+)#(\d+)\s*-->")
 
 
-def _automerge_decision(rec, changed_paths, config, pr_meta, state_flags=None):
+def _automerge_decision(rec, changed_paths, config, pr_meta, state_flags=None, changed_files=None):
     """Pure function — the SINGLE choke point for whether feature auto-drive
     auto-approves + auto-merges a PR instead of waiting for a human. Returns
     (should_merge: bool, reason: str).
@@ -862,6 +863,20 @@ def _automerge_decision(rec, changed_paths, config, pr_meta, state_flags=None):
         ids = ", ".join(h.get("id", "?") for h in hits)
         return False, f"diff touches configured boundary path(s): {ids}"
 
+    # DEFAULT-DENY allowlist (feature_allowlist) — the positive counterpart to
+    # the boundary deny-list above. Even a fully-reviewed, boundary-clean, high-
+    # confidence PR only auto-merges if its diff is one of the small, provably-
+    # additive shapes the operator is willing to merge unattended (docs-only /
+    # log-only / tooltip-only). Everything behaviour-changing routes to a human.
+    # `changed_files` carries the per-file patch text this needs; when absent
+    # (a caller that only has path strings) classify() fails closed. This gate
+    # can only ever make auto-merge MORE restrictive.
+    if config.get("feature_automerge_require_allowlist", True):
+        verdict = feature_allowlist.classify(changed_files or [],
+                                             config.get("feature_automerge_allowlist"))
+        if not verdict.get("auto_approvable"):
+            return False, "not on additive auto-approve allowlist: " + verdict.get("reason", "")
+
     score = min(conf1, conf2)
     return True, f"cleared: both panels Approve, min confidence {score:.2f} >= threshold {threshold:.2f}, no boundary touched"
 
@@ -879,7 +894,9 @@ def _maybe_auto_merge(gh, repo, pr, config):
     try:
         key = "%s#%s" % (repo.full_name, pr.number)
         rec = (state.get("pr_reviews") or {}).get(key) or {}
-        changed_paths = [f.filename for f in pr.get_files()]
+        pr_files = list(pr.get_files())
+        changed_paths = [f.filename for f in pr_files]
+        changed_files = feature_allowlist.files_from_pr_files(pr_files)
         marker_match = _FEATURE_DRIVE_MARKER_RE.search(pr.body or "")
         pr_meta = {
             "repo": repo.full_name,
@@ -889,7 +906,7 @@ def _maybe_auto_merge(gh, repo, pr, config):
             "mergeable": getattr(pr, "mergeable", None),
         }
         state_flags = {"paused": bool(state.get("paused")), "blackout": bool(state.get("blackout"))}
-        should_merge, reason = _automerge_decision(rec, changed_paths, config, pr_meta, state_flags)
+        should_merge, reason = _automerge_decision(rec, changed_paths, config, pr_meta, state_flags, changed_files)
         if not should_merge:
             logger.debug("pr_review: auto-merge skipped for %s (%s)", key, reason)
             return

--- a/routes.py
+++ b/routes.py
@@ -1989,6 +1989,14 @@ async def settings_page(request: Request):
     config.setdefault("feature_automerge_repos", [])
     config.setdefault("feature_automerge_min_confidence", 1.0)
     config.setdefault("feature_automerge_require_clean", True)
+    # DEFAULT-DENY allowlist gate (feature_allowlist): even a clean, high-
+    # confidence, boundary-free PR only auto-merges if its diff is a provably-
+    # additive shape (docs-only / log-only / tooltip-only). On by default so
+    # the safe fallback for anything behaviour-changing is human approval.
+    # `feature_automerge_allowlist` = None means "use feature_allowlist's
+    # DEFAULT_ALLOWLIST"; an operator may narrow it to a subset.
+    config.setdefault("feature_automerge_require_allowlist", True)
+    config.setdefault("feature_automerge_allowlist", None)
     config.setdefault("enabled_log_modules", [])
     # Module list for the per-module log-filing grid = the operator's module→repo
     # map keys (a module must map to a repo before its logs can be filed).

--- a/test_feature_allowlist.py
+++ b/test_feature_allowlist.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Self-test for feature_allowlist — the DEFAULT-DENY positive allowlist that,
+together with feature_boundary's deny-list, gates AppBuilder auto-merge.
+
+Run:  python3 ab/test_feature_allowlist.py
+
+feature_allowlist is a pure, import-light module (like feature_boundary), so
+this imports it directly. The safety-critical direction is FALSE POSITIVES
+(auto-approving something behaviour-changing), so most cases assert
+auto_approvable is False; the few True cases are the deliberately-narrow
+additive shapes."""
+import sys
+
+import feature_allowlist as fa
+
+
+def _check(label, cond):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
+    return cond
+
+
+def _f(path, status="modified", patch="", additions=0, deletions=0):
+    return {"path": path, "status": status, "patch": patch,
+            "additions": additions, "deletions": deletions}
+
+
+def main():
+    ok = True
+
+    # ── fail-closed basics ──────────────────────────────────────────────────
+    ok &= _check("empty file list -> not auto-approvable",
+                 fa.classify([])["auto_approvable"] is False)
+
+    # ── docs-only ───────────────────────────────────────────────────────────
+    ok &= _check("all-markdown diff -> docs-only auto-approvable",
+                 fa.classify([_f("ab/docs/x.md", patch="@@\n+hi\n"),
+                              _f("README.md", patch="@@\n-a\n+b\n")]) == {
+                     "category": "docs-only", "auto_approvable": True,
+                     "reason": "additive allowlist category 'docs-only' (auto-approvable)"})
+    ok &= _check("docs + one code file -> NOT docs-only (mixed) -> blocked",
+                 fa.classify([_f("ab/docs/x.md", patch="@@\n+hi\n"),
+                              _f("ab/routes.py", patch="@@\n+code()\n")])["auto_approvable"] is False)
+
+    # ── log-only ────────────────────────────────────────────────────────────
+    ok &= _check("pure added logger.* line -> log-only auto-approvable",
+                 fa.classify([_f("ab/routes.py",
+                                 patch="@@ -1 +1,2 @@\n context\n+    logger.info('x')\n")])["category"] == "log-only")
+    ok &= _check("added logging.debug across two files -> log-only",
+                 fa.classify([_f("a.py", patch="@@\n+logger.debug('a')\n"),
+                              _f("b.py", patch="@@\n+logging.warning('b')\n")])["auto_approvable"] is True)
+    ok &= _check("added log line PLUS a real code line -> NOT log-only -> blocked",
+                 fa.classify([_f("a.py", patch="@@\n+logger.info('x')\n+x = compute()\n")])["auto_approvable"] is False)
+    ok &= _check("a DELETION present -> NOT log-only (not purely additive) -> blocked",
+                 fa.classify([_f("a.py", patch="@@\n-old_call()\n+logger.info('x')\n")])["auto_approvable"] is False)
+    ok &= _check("logger CONFIG (setLevel/addHandler) is not a log CALL -> blocked",
+                 fa.classify([_f("a.py", patch="@@\n+logger.setLevel(10)\n")])["auto_approvable"] is False)
+    ok &= _check("missing patch text -> fail closed (not log-only)",
+                 fa.classify([_f("a.py", patch=None)])["auto_approvable"] is False)
+    ok &= _check("removed/renamed file -> never log-only",
+                 fa.classify([_f("a.py", status="removed", patch="@@\n-logger.info('x')\n")])["auto_approvable"] is False)
+
+    # ── tooltip-only ────────────────────────────────────────────────────────
+    ok &= _check("only a title= attribute changed -> tooltip-only",
+                 fa.classify([_f("t.html", patch="@@\n-<i title=\"Old\">\n+<i title=\"New\">\n")])["category"] == "tooltip-only")
+    ok &= _check("aria-label copy change -> tooltip-only auto-approvable",
+                 fa.classify([_f("t.html", patch="@@\n+<button aria-label=\"Close dialog\">\n")])["auto_approvable"] is True)
+    ok &= _check("tooltip token but real logic on the line -> blocked",
+                 fa.classify([_f("t.py", patch="@@\n+if title==x: return os.system('rm')\n")])["auto_approvable"] is False)
+    ok &= _check("empty/no-op diff can't masquerade as tooltip-only",
+                 fa.classify([_f("t.html", patch="@@\n context only\n")])["auto_approvable"] is False)
+
+    # ── config-driven narrowing ─────────────────────────────────────────────
+    ok &= _check("category matched but disabled in allowlist subset -> blocked",
+                 fa.classify([_f("README.md", patch="@@\n+x\n")], allowlist=["log-only"])["auto_approvable"] is False)
+    ok &= _check("category matched AND enabled in subset -> auto-approvable",
+                 fa.classify([_f("README.md", patch="@@\n+x\n")], allowlist=["docs-only"])["auto_approvable"] is True)
+
+    # ── behaviour-changing shapes are NEVER a category ──────────────────────
+    ok &= _check("a route-handler diff -> no category -> human approval",
+                 fa.classify([_f("ab/routes.py", patch="@@\n+@app.route('/x')\n+def x(): return go()\n")])["auto_approvable"] is False)
+
+    print()
+    if ok:
+        print("ALL CASES PASSED")
+        return 0
+    print("ONE OR MORE CASES FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    print("Running feature-allowlist self-test...")
+    sys.exit(main())

--- a/test_feature_automerge_gate.py
+++ b/test_feature_automerge_gate.py
@@ -19,6 +19,7 @@ import ast
 import sys
 
 import feature_boundary as real_feature_boundary
+import feature_allowlist as real_feature_allowlist
 
 
 def _load_ns():
@@ -30,7 +31,8 @@ def _load_ns():
             seg = ast.get_source_segment(src, node)
             break
     assert seg, "_automerge_decision not found in pr_review.py"
-    ns = {"feature_boundary": real_feature_boundary}
+    ns = {"feature_boundary": real_feature_boundary,
+          "feature_allowlist": real_feature_allowlist}
     exec(seg, ns)
     return ns
 
@@ -49,6 +51,10 @@ def _clean_config(**overrides):
         "feature_automerge_repos": ["owner/repo"],
         "feature_automerge_min_confidence": 0.90,
         "feature_automerge_require_clean": True,
+        # Existing cases below isolate ONE non-allowlist gate each, so keep the
+        # DEFAULT-DENY allowlist gate off in this baseline; it has its own
+        # dedicated section at the end of main(). (In production it defaults ON.)
+        "feature_automerge_require_allowlist": False,
         "feature_boundaries": [],
     }
     cfg.update(overrides)
@@ -169,6 +175,39 @@ def main():
                             _clean_config(feature_boundaries=[{**boundaries[0], "enabled": False}]),
                             _clean_pr_meta())
     ok &= _check("a DISABLED boundary rule never blocks even with a matching path", should is True)
+
+    # ── DEFAULT-DENY allowlist gate (feature_allowlist) ─────────────────────
+    # When require_allowlist is ON, a fully-cleared PR still only auto-merges
+    # if its diff is a provably-additive shape. This is the positive gate that
+    # makes "behaviour-changing -> human" mechanical, not trust-based.
+    docs_files = [{"path": "ab/docs/foo.md", "status": "modified",
+                   "additions": 2, "deletions": 1, "patch": "@@ -1 +1,2 @@\n-old\n+new\n+more\n"}]
+    code_files = [{"path": "ab/routes.py", "status": "modified", "additions": 5,
+                   "deletions": 0, "patch": "@@ -1 +1,5 @@\n+def handler():\n+    return do_thing()\n"}]
+    log_files = [{"path": "ab/routes.py", "status": "modified", "additions": 1,
+                  "deletions": 0, "patch": "@@ -1 +1,2 @@\n+    logger.info('started thing')\n"}]
+
+    should, reason = decide(_clean_rec(), ["ab/routes.py"],
+                            _clean_config(feature_automerge_require_allowlist=True),
+                            _clean_pr_meta())
+    ok &= _check("allowlist ON but NO changed_files supplied -> blocked (fail closed)", should is False)
+    should, reason = decide(_clean_rec(), ["ab/routes.py"],
+                            _clean_config(feature_automerge_require_allowlist=True),
+                            _clean_pr_meta(), None, code_files)
+    ok &= _check("allowlist ON + behaviour-changing code diff -> blocked (routes to human)", should is False)
+    should, reason = decide(_clean_rec(), ["ab/docs/foo.md"],
+                            _clean_config(feature_automerge_require_allowlist=True),
+                            _clean_pr_meta(), None, docs_files)
+    ok &= _check("allowlist ON + docs-only diff -> auto-merge approved", should is True)
+    should, reason = decide(_clean_rec(), ["ab/routes.py"],
+                            _clean_config(feature_automerge_require_allowlist=True),
+                            _clean_pr_meta(), None, log_files)
+    ok &= _check("allowlist ON + pure log-only diff -> auto-merge approved", should is True)
+    should, reason = decide(_clean_rec(), ["ab/docs/foo.md"],
+                            _clean_config(feature_automerge_require_allowlist=True,
+                                          feature_automerge_allowlist=["log-only"]),
+                            _clean_pr_meta(), None, docs_files)
+    ok &= _check("allowlist ON but docs-only NOT in the enabled subset -> blocked", should is False)
 
     print()
     if ok:

--- a/test_feature_boundary.py
+++ b/test_feature_boundary.py
@@ -104,6 +104,25 @@ def main():
     ok &= _check("None renders empty string, no crash",
                 fb.render_boundaries_for_prompt(None) == "")
 
+    # --- DEFAULT_BOUNDARIES covers the core hard-deny surfaces ---------------
+    # These must flag (auto-merge/auto-build → human) if a diff touches them.
+    defaults = fb.DEFAULT_BOUNDARIES
+    for path, expect_id in [
+        ("ab/auth.py", "auth-onboarding"),
+        ("ab/oidc.py", "auth-onboarding"),
+        ("lm/routes/onboarding.py", "auth-onboarding"),
+        ("ab/install.sh", "installers"),
+        ("lm/uninstall.sh", "installers"),
+        ("lm/messaging/control_plane.py", "control-plane"),
+        ("ab/hub_agent.py", "psk-hardcode"),
+        ("lm/watchdog.py", "self-update"),
+    ]:
+        hit_ids = {h["id"] for h in fb.boundary_hits([path], defaults)}
+        ok &= _check(f"DEFAULT_BOUNDARIES flags {path} (expects '{expect_id}')",
+                    expect_id in hit_ids)
+    ok &= _check("every DEFAULT_BOUNDARIES rule is hard + enabled (no soft/off core rule)",
+                all(b.get("hard") and b.get("enabled") for b in defaults))
+
     print()
     if ok:
         print("ALL CASES PASSED")


### PR DESCRIPTION
## What & why
Implements the **default-deny guardrail** we discussed: *nothing* auto-merges unless it is a small, provably-additive change. Adds `feature_allowlist.py` — the positive counterpart to `feature_boundary.py`'s deny-list.

The auto-merge gate is now:

```
auto-merge == (all panel/confidence/state gates pass)
           AND boundary_hits empty            # deny-list  (feature_boundary)
           AND classify(...) auto-approvable  # allow-list (feature_allowlist)  <- new
```

Because it's an **additional required** gate, it can only ever make auto-merge *more* restrictive.

## Three tiers (as agreed)
- **Auto-merge**: `docs-only`, `log-only` (purely additive `logger.*`), `tooltip-only` (title/aria-label/label copy) — auto-approve only if boundary-clean AND reviewer confidence >= threshold.
- **Build but gate**: navigation, buttons, route/handler logic, anything behaviour-changing — built + reviewed, then waits for a human.
- **Hard-deny**: security/core via `feature_boundary` — blocked from the pipeline.

`new-client-simulation` and `report-only` are **intentionally not** diff-auto-approvable — a real sim modifies shared orchestrators/config, and "read-only" can't be proven from a diff, so both route to human approval. Promoting them needs a semantic-classifier signal (future work).

## Safety
- On by default: `feature_automerge_require_allowlist=True`. Operators may narrow enabled categories via `feature_automerge_allowlist`.
- Every detector **fails closed** on ambiguity (missing patch text, mixed categories, deletions, unrecognised shape).
- No new app imports; pure, unit-testable module.

## Tests
- New `test_feature_allowlist.py` (17 cases, pure module).
- Extended the safety-critical `test_feature_automerge_gate.py` with a dedicated allowlist-gate section; existing "break exactly one thing" cases preserved.
- All pass; `test_feature_boundary`, `test_feature_drive_classify`, `test_feature_settings_roundtrip` still pass.

Held for your approval — not merged.
