### PR TITLE
Phase 2: chat agent live LM-fleet access (Azure console/diagnosis)

### DIFF
--- a/az_console.py
+++ b/az_console.py
@@ -1,0 +1,241 @@
+"""az_console.py — bridge from AppBuilder's chat agent to the LM Azure resource
+group, so the assistant can DIAGNOSE (and, when the operator opts in, ACT on)
+the live LM servers it manages. This is the consumer of the Phase-1 secretless
+identity: it shells out through the login helper (default
+/usr/local/bin/lm-az-login) which proves the host is LM-AB via its managed
+identity, pulls the scoped service-principal cert from LM-VAULT into tmpfs,
+and logs `az` in as that SP (Virtual Machine Contributor on the LM RG). No
+secret is ever handled here or persisted to disk.
+
+Two capabilities, each with a pure, unit-testable vetting function separated
+from the impure subprocess call so the security logic can be tested with no az
+present:
+
+    vet_az_args(argv, allow_mutation)          -> (ok, reason)
+    run_az(argv, config)                       -> result dict     (az control-plane)
+
+    vet_shell_command(cmd, allow_mutation)     -> (ok, reason)
+    run_server_shell(vm, cmd, config)          -> result dict     (shell ON a VM
+                                                  via `az vm run-command invoke`)
+
+DEFAULT-DENY MUTATION
+---------------------
+Unless `allow_mutation` is True, ONLY read-only shapes are permitted and every
+other request is refused BEFORE any process starts. This mirrors the operator's
+whole-project stance: diagnosis is safe and unattended; change requires an
+explicit opt-in (config CHAT_AZURE_ALLOW_MUTATION). When mutation IS allowed,
+the ONLY boundary is the SP's RBAC scope — deliberately, per the operator's
+"guard rails come once it works, and the RBAC scope IS the first guard rail".
+
+Both capabilities are gated upstream by CHAT_AZURE_ENABLED (default False), so
+on a host without the helper (e.g. a dev laptop) the tools simply report that
+Azure access is disabled rather than erroring.
+"""
+import os
+import re
+import shlex
+import subprocess
+
+# ── az control-plane read-only allowlist ────────────────────────────────────
+# Matched against the first one/two tokens of the az argv. Deliberately small:
+# these are the shapes a diagnosis needs and none of them mutate. run-command
+# is intentionally absent here — running a shell ON a VM goes through the
+# separately-vetted run_server_shell path, never through raw `az`.
+_AZ_READ_PREFIXES = {
+    ("account", "show"), ("account", "list-locations"),
+    ("group", "show"), ("group", "list"),
+    ("resource", "list"), ("resource", "show"),
+    ("vm", "list"), ("vm", "show"), ("vm", "get-instance-view"),
+    ("vm", "list-ip-addresses"), ("vm", "list-sizes"),
+    ("network", "nic"), ("network", "vnet"), ("network", "nsg"),
+    ("monitor", "metrics"), ("monitor", "activity-log"), ("monitor", "log-analytics"),
+    ("disk", "list"), ("disk", "show"),
+}
+# Verbs that mutate — refused in read-only mode no matter where they appear.
+_AZ_MUTATION_TOKENS = {
+    "create", "delete", "update", "set", "start", "stop", "restart", "deallocate",
+    "run-command", "invoke", "reset", "redeploy", "reimage", "capture", "generalize",
+    "add", "remove", "attach", "detach", "assign", "purge", "rotate", "regenerate",
+}
+
+
+def vet_az_args(argv, allow_mutation=False):
+    """Vet an `az` argv (WITHOUT the leading 'az'). Returns (ok, reason).
+    In read-only mode the first two non-flag tokens must be an allowlisted
+    read shape and no mutation verb may appear anywhere."""
+    if not argv or not isinstance(argv, (list, tuple)):
+        return False, "no az command provided"
+    if any(not isinstance(a, str) for a in argv):
+        return False, "az arguments must all be strings (argv form, not a shell string)"
+    if allow_mutation:
+        return True, "mutation allowed (bounded by the service principal's RBAC scope)"
+    positional = [a for a in argv if not a.startswith("-")]
+    lowered = [a.lower() for a in positional]
+    for tok in lowered:
+        if tok in _AZ_MUTATION_TOKENS:
+            return False, (f"'{tok}' is a mutating operation; enable "
+                           f"CHAT_AZURE_ALLOW_MUTATION to permit it")
+    head = tuple(lowered[:2])
+    if head in _AZ_READ_PREFIXES or (len(lowered) >= 1 and (lowered[0], "") in _AZ_READ_PREFIXES):
+        return True, "read-only az command"
+    if lowered and (lowered[0],) in {(p[0],) for p in _AZ_READ_PREFIXES} and len(lowered) == 1:
+        return True, "read-only az command"
+    return False, ("not an allowlisted read-only az command "
+                   "(e.g. `vm list`, `vm get-instance-view`, `resource list`); "
+                   "enable CHAT_AZURE_ALLOW_MUTATION for anything else")
+
+
+# ── server-shell read-only allowlist ────────────────────────────────────────
+# First token of each pipeline segment must be one of these read-only binaries.
+_SHELL_READ_BINARIES = {
+    "systemctl", "journalctl", "service", "cat", "tail", "head", "grep", "egrep",
+    "ls", "stat", "ps", "top", "df", "du", "free", "uptime", "uname", "hostname",
+    "date", "whoami", "id", "env", "printenv", "ss", "netstat", "ip", "curl",
+    "wget", "ping", "dig", "nslookup", "docker", "podman", "echo", "which",
+    "find", "wc", "sort", "uniq", "awk", "sed", "true", "test", "pgrep",
+}
+# systemctl/service subcommands that are read-only (status/show only).
+_SYSTEMCTL_READ_SUBCMDS = {"status", "is-active", "is-enabled", "is-failed", "show",
+                           "list-units", "list-unit-files", "cat", "get-default",
+                           "is-system-running", "list-dependencies", "list-timers",
+                           "list-sockets", "show-environment"}
+# Hard mutation markers refused anywhere in read-only mode.
+_SHELL_MUTATION_MARKERS = [
+    ">", ">>", "|&", "rm ", "mv ", "cp ", "tee ", "dd ", "mkfs", "chmod", "chown",
+    "kill", "reboot", "shutdown", "poweroff", "halt", "apt", "yum", "dnf", "pip ",
+    "npm ", "git ", "truncate", "ln ", "mount", "umount", "sysctl -w", "iptables",
+    "useradd", "userdel", "passwd", "crontab", "at ",
+]
+_SED_INPLACE_RE = re.compile(r"\bsed\b[^|;]*\s-\w*i")  # sed -i (in-place edit)
+
+
+def vet_shell_command(cmd, allow_mutation=False):
+    """Vet a shell command to run ON an LM VM. Returns (ok, reason). In
+    read-only mode: no mutation markers anywhere, and every pipeline/`;`/`&&`
+    segment must START with a read-only binary (systemctl/service restricted
+    to status-like subcommands). Conservative — anything unrecognised fails."""
+    if not cmd or not isinstance(cmd, str) or not cmd.strip():
+        return False, "no shell command provided"
+    if allow_mutation:
+        return True, "mutation allowed (bounded by the service principal's RBAC scope)"
+    low = cmd.lower()
+    for marker in _SHELL_MUTATION_MARKERS:
+        if marker in low:
+            return False, (f"'{marker.strip()}' indicates a state change; enable "
+                           f"CHAT_AZURE_ALLOW_MUTATION to permit it")
+    if _SED_INPLACE_RE.search(low):
+        return False, "in-place sed edit (sed -i) is a mutation; enable CHAT_AZURE_ALLOW_MUTATION"
+    # Split into segments on ; | && || and vet each segment's leading binary.
+    segments = re.split(r"\|\||&&|[;|]", cmd)
+    for seg in segments:
+        seg = seg.strip()
+        if not seg:
+            continue
+        try:
+            toks = shlex.split(seg)
+        except ValueError:
+            return False, "could not parse shell command safely"
+        if not toks:
+            continue
+        binary = os.path.basename(toks[0])
+        if binary not in _SHELL_READ_BINARIES:
+            return False, (f"'{binary}' is not an allowlisted read-only command; "
+                           f"enable CHAT_AZURE_ALLOW_MUTATION for arbitrary commands")
+        if binary in ("systemctl", "service"):
+            sub = next((t for t in toks[1:] if not t.startswith("-")), "")
+            # `service <name> status` puts the subcommand last; accept either order.
+            subs = {t for t in toks[1:] if not t.startswith("-")}
+            if not (sub in _SYSTEMCTL_READ_SUBCMDS or subs & _SYSTEMCTL_READ_SUBCMDS):
+                return False, (f"systemctl/service '{sub}' is not a read-only subcommand "
+                               f"(allowed: status/is-active/show/…)")
+    return True, "read-only shell command"
+
+
+def azure_enabled(config):
+    return bool((config or {}).get("CHAT_AZURE_ENABLED", False))
+
+
+def _login_helper(config):
+    return (config or {}).get("AZURE_LOGIN_HELPER") or "/usr/local/bin/lm-az-login"
+
+
+def _resource_group(config):
+    return (config or {}).get("AZURE_LM_RESOURCE_GROUP") or "LM"
+
+
+def _ensure_login(config, timeout=60):
+    """Run the secretless login helper so the subsequent az call has a valid SP
+    context. Returns (ok, message). Missing helper (dev host) -> (False, note)."""
+    helper = _login_helper(config)
+    if not os.path.exists(helper):
+        return False, (f"Azure login helper not found at {helper} — Azure access is only "
+                       f"available from LM-AB, not this host.")
+    try:
+        p = subprocess.run([helper], capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return False, "az login helper timed out"
+    except Exception as e:  # noqa: BLE001
+        return False, f"az login helper failed to start: {type(e).__name__}: {e}"
+    if p.returncode != 0:
+        return False, f"az login helper failed: {(p.stderr or p.stdout or '').strip()[:400]}"
+    return True, "authenticated"
+
+
+def _cap(text, limit=12000):
+    text = text or ""
+    return text if len(text) <= limit else text[:limit] + "\n…[output truncated]"
+
+
+def run_az(argv, config, timeout=120):
+    """Run a vetted `az` control-plane command. `argv` is the arg list AFTER
+    'az'. Returns a result dict (never raises)."""
+    if not azure_enabled(config):
+        return {"error": "Azure access is disabled (set CHAT_AZURE_ENABLED to enable)."}
+    allow = bool((config or {}).get("CHAT_AZURE_ALLOW_MUTATION", False))
+    ok, reason = vet_az_args(argv, allow_mutation=allow)
+    if not ok:
+        return {"error": f"refused: {reason}", "argv": list(argv)}
+    ok, msg = _ensure_login(config)
+    if not ok:
+        return {"error": msg}
+    az = (config or {}).get("AZURE_AZ_BIN") or "az"
+    try:
+        p = subprocess.run([az, *argv], capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return {"error": f"az command timed out after {timeout}s", "argv": list(argv)}
+    except FileNotFoundError:
+        return {"error": f"az binary not found ({az})"}
+    return {"argv": list(argv), "exit_code": p.returncode,
+            "stdout": _cap(p.stdout), "stderr": _cap((p.stderr or "").strip(), 2000)}
+
+
+def run_server_shell(vm, cmd, config, timeout=180):
+    """Run a vetted shell command ON one LM VM via `az vm run-command invoke`.
+    Returns a result dict (never raises)."""
+    if not azure_enabled(config):
+        return {"error": "Azure access is disabled (set CHAT_AZURE_ENABLED to enable)."}
+    vm = (vm or "").strip()
+    if not vm:
+        return {"error": "vm name is required"}
+    if not re.fullmatch(r"[A-Za-z0-9._-]{1,64}", vm):
+        return {"error": f"invalid vm name: {vm!r}"}
+    allow = bool((config or {}).get("CHAT_AZURE_ALLOW_MUTATION", False))
+    ok, reason = vet_shell_command(cmd, allow_mutation=allow)
+    if not ok:
+        return {"error": f"refused: {reason}", "vm": vm}
+    ok, msg = _ensure_login(config)
+    if not ok:
+        return {"error": msg}
+    az = (config or {}).get("AZURE_AZ_BIN") or "az"
+    rg = _resource_group(config)
+    argv = [az, "vm", "run-command", "invoke", "-g", rg, "-n", vm,
+            "--command-id", "RunShellScript", "--scripts", cmd,
+            "--query", "value[0].message", "-o", "tsv"]
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return {"error": f"run-command timed out after {timeout}s", "vm": vm}
+    except FileNotFoundError:
+        return {"error": f"az binary not found ({az})"}
+    return {"vm": vm, "resource_group": rg, "command": cmd, "exit_code": p.returncode,
+            "output": _cap(p.stdout), "stderr": _cap((p.stderr or "").strip(), 2000)}

--- a/chat.py
+++ b/chat.py
@@ -3,6 +3,8 @@ import json, os, re, threading, time, traceback, uuid
 from datetime import datetime
 from github import Github
 
+import az_console
+
 from main import (
     CHAT_HISTORY_FILE,
     _chat_lock,
@@ -94,6 +96,15 @@ def _build_chat_context_index_uncached(config, gh=None):
     lines.append("You have tools: list_repos, list_issues, get_issue, list_repo_files, "
                  "read_file, get_processed_issues, get_recent_errors, propose_fix. "
                  "Use them to answer precisely; do not guess issue/file contents.")
+    if config.get("CHAT_AZURE_ENABLED", False):
+        rg = config.get("AZURE_LM_RESOURCE_GROUP") or "LM"
+        mut = "mutation ENABLED" if config.get("CHAT_AZURE_ALLOW_MUTATION", False) else "read-only"
+        lines.append(f"Azure fleet tools are ON ({mut}) for resource group {rg}: "
+                     "azure_cli (control-plane, e.g. `vm list`/`vm get-instance-view`) and "
+                     "server_shell (run a command ON a VM, e.g. `systemctl status ab`, "
+                     "`journalctl -u ab -n 100 --no-pager`, `curl -s localhost/health`) — "
+                     "use these to diagnose the live LM servers and verify a change deployed "
+                     "and is functional with no new errors.")
     text = "\n".join(lines)
     # Defense-in-depth: never let a leaked token in an issue title reach the model.
     return _redact_text(text, _secret_denylist(config))
@@ -420,6 +431,34 @@ CHAT_TOOLS = [
 ]
 
 
+AZURE_TOOLS = [
+    {
+        "name": "azure_cli",
+        "description": "Run a read-only `az` (Azure CLI) command against the LM resource group to diagnose the live servers AppBuilder manages (e.g. list VMs, show a VM's power/agent state, list resources). Pass the arguments AFTER `az` as an array in `args` (argv form, e.g. [\"vm\",\"list\",\"-g\",\"LM\",\"-o\",\"table\"]). Read-only by default; mutating commands are refused unless the operator has enabled Azure mutation.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "args": {"type": "array", "items": {"type": "string"},
+                          "description": "az arguments AFTER 'az', argv form (no leading 'az')."},
+            },
+            "required": ["args"],
+        },
+    },
+    {
+        "name": "server_shell",
+        "description": "Run a shell command ON one LM server VM (via Azure run-command) to verify functionality and check for errors — e.g. `systemctl status ab`, `journalctl -u ab -n 100 --no-pager`, `curl -s localhost/health`. Read-only by default (status/logs/health only); state-changing commands are refused unless the operator has enabled Azure mutation. Use azure_cli first to see valid VM names (e.g. LM-HUB, LM-AB, LM-NETBOX).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "vm": {"type": "string", "description": "LM VM name, e.g. LM-HUB."},
+                "command": {"type": "string", "description": "The shell command to run on that VM."},
+            },
+            "required": ["vm", "command"],
+        },
+    },
+]
+
+
 def _tool_list_repos(gh, config, args):
     if gh is None:
         return {"error": "GitHub client unavailable (no token configured)."}
@@ -644,6 +683,33 @@ def _tool_propose_fix(gh, config, args):
     return descriptor
 
 
+def _tool_azure_cli(gh, config, args):
+    """Diagnose the live LM fleet with a read-only `az` command. argv is taken
+    from `args` (preferred) or a `command` string, which is shell-split. All
+    vetting/login/execution lives in az_console (default-deny mutation)."""
+    argv = args.get("args")
+    if argv is None and isinstance(args.get("command"), str):
+        import shlex
+        try:
+            argv = shlex.split(args["command"])
+        except ValueError:
+            return {"error": "could not parse the az command string"}
+    if isinstance(argv, str):
+        import shlex
+        argv = shlex.split(argv)
+    if not isinstance(argv, list) or not argv:
+        return {"error": "provide `args` as an array of az arguments (no leading 'az')"}
+    if argv and str(argv[0]).lower() == "az":
+        argv = argv[1:]
+    return az_console.run_az(argv, config)
+
+
+def _tool_server_shell(gh, config, args):
+    """Run a read-only shell command ON one LM VM to verify functionality /
+    inspect logs. Vetting + run-command execution lives in az_console."""
+    return az_console.run_server_shell(args.get("vm"), args.get("command"), config)
+
+
 CHAT_TOOL_EXECUTORS = {
     "list_repos": _tool_list_repos,
     "list_issues": _tool_list_issues,
@@ -653,6 +719,8 @@ CHAT_TOOL_EXECUTORS = {
     "get_processed_issues": _tool_get_processed_issues,
     "get_recent_errors": _tool_get_recent_errors,
     "propose_fix": _tool_propose_fix,
+    "azure_cli": _tool_azure_cli,
+    "server_shell": _tool_server_shell,
 }
 
 
@@ -864,7 +932,9 @@ def run_agent_loop(messages, config, gh, *, task_id, max_iter=6,
     from model_selection import LlmRequirements
     _status = status_cb or (lambda *_a, **_k: None)
     _tool_reqs = tool_requirements or LlmRequirements(complexity="medium", needs_tools=True, latency_sensitive=True)
-    tools = CHAT_TOOLS
+    # Azure fleet tools are advertised only when the operator has opted in, so a
+    # model on a host without the login helper isn't tempted to call them.
+    tools = CHAT_TOOLS + (AZURE_TOOLS if az_console.azure_enabled(config) else [])
     used_chars = 0
     final_text = None
     last_text = ""
@@ -1092,6 +1162,8 @@ __all__ = [
     '_tool_get_processed_issues',
     '_tool_get_recent_errors',
     '_tool_propose_fix',
+    '_tool_azure_cli',
+    '_tool_server_shell',
     '_set_chat_stream_status',
     '_finalize_chat_stream',
     '_set_chat_stream_error',
@@ -1105,5 +1177,6 @@ __all__ = [
     '_GH_TOKEN_RE',
     '_CHAT_FILE_SKIP',
     'CHAT_TOOLS',
+    'AZURE_TOOLS',
     'CHAT_TOOL_EXECUTORS',
 ]

--- a/routes.py
+++ b/routes.py
@@ -1997,6 +1997,15 @@ async def settings_page(request: Request):
     # DEFAULT_ALLOWLIST"; an operator may narrow it to a subset.
     config.setdefault("feature_automerge_require_allowlist", True)
     config.setdefault("feature_automerge_allowlist", None)
+    # Azure fleet access for the chat agent (az_console). OFF by default; when
+    # on, the chat can diagnose the live LM servers via the secretless SP login
+    # helper. Mutation is separately gated and defaults OFF (read-only), so the
+    # safe default is diagnosis-only. Only available on LM-AB where the helper
+    # exists; elsewhere the tools report Azure access as unavailable.
+    config.setdefault("CHAT_AZURE_ENABLED", False)
+    config.setdefault("CHAT_AZURE_ALLOW_MUTATION", False)
+    config.setdefault("AZURE_LM_RESOURCE_GROUP", "LM")
+    config.setdefault("AZURE_LOGIN_HELPER", "/usr/local/bin/lm-az-login")
     config.setdefault("enabled_log_modules", [])
     # Module list for the per-module log-filing grid = the operator's module→repo
     # map keys (a module must map to a repo before its logs can be filed).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,33 @@
+# LM automation identity — scripts
+
+These scripts run on **LM-AB** and give AppBuilder's chat agent a *secretless*
+way to reach the LM Azure resource group (see `az_console.py`, which shells out
+through `lm-az-login`).
+
+## How it works (no secret ever on disk or in git)
+
+1. LM-AB has a system-assigned **managed identity**. `lm-az-login` runs
+   `az login --identity`, proving the host is LM-AB.
+2. As that identity it downloads the automation service-principal certificate
+   from **LM-VAULT** into `/dev/shm` (tmpfs / RAM only, mode `0600`). The vault's
+   data-plane firewall only allows the LM subnet, so only LM hosts can do this.
+3. It then `az login`s as the service principal **`lm-ab-automation-sp`**
+   (role: *Virtual Machine Contributor* on resource group **LM** — console +
+   run-command + VM lifecycle, but no power over the vault, networking, or
+   storage).
+4. `lm-az-logout` clears the az context and wipes the tmpfs cert.
+
+The IDs embedded in `lm-az-login` (app id, tenant id, vault name) are **public
+identifiers, not secrets**. The certificate — the only credential — lives solely
+in LM-VAULT and, transiently, in tmpfs.
+
+## Install (as root on LM-AB)
+
+```bash
+install -m 0755 lm-az-login  /usr/local/bin/lm-az-login
+install -m 0755 lm-az-logout /usr/local/bin/lm-az-logout
+```
+
+`az_console.py` reads the helper path from config key `AZURE_LOGIN_HELPER`
+(default `/usr/local/bin/lm-az-login`) and the resource group from
+`AZURE_LM_RESOURCE_GROUP` (default `LM`).

--- a/scripts/lm-az-login
+++ b/scripts/lm-az-login
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Establish an authenticated az context as the LM automation service principal.
+# Zero persistent secret: the host proves it is LM-AB via its managed identity,
+# pulls the SP cert from LM-VAULT (only the LM subnet may), and logs in.
+# The cert lives only in /dev/shm (tmpfs/RAM, wiped on reboot), mode 0600.
+# Embedded IDs are public identifiers, not secrets. Run `lm-az-logout` to wipe.
+set -euo pipefail
+TID=2e5cab22-02d0-4fe4-8ceb-f9faa02999c1
+APPID=065fbdac-b265-4071-911b-21bc62c94d2b
+VAULT=LM-VAULT
+CERT=lm-ab-automation-sp
+DIR="/dev/shm/lm-ab-sp"
+PEM="$DIR/cert.pem"
+install -d -m 0700 "$DIR"
+umask 077
+az login --identity --only-show-errors >/dev/null
+az keyvault secret download --vault-name "$VAULT" --name "$CERT" --file "$PEM" --encoding utf-8 --overwrite --only-show-errors
+chmod 0600 "$PEM"
+az login --service-principal -u "$APPID" --certificate "$PEM" --tenant "$TID" --only-show-errors >/dev/null
+echo "lm-az-login: authenticated as SP $APPID (Virtual Machine Contributor on RG LM)"

--- a/scripts/lm-az-logout
+++ b/scripts/lm-az-logout
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -uo pipefail
+az logout --only-show-errors 2>/dev/null || true
+rm -rf /dev/shm/lm-ab-sp
+echo "lm-az-logout: SP context cleared"

--- a/test_az_console.py
+++ b/test_az_console.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Self-test for az_console — the chat→LM-fleet Azure bridge. The security-
+critical surface is the DEFAULT-DENY vetting (vet_az_args / vet_shell_command):
+in read-only mode nothing that mutates may pass, and mutation is only allowed
+when the operator has explicitly opted in. az_console is import-light (no app
+init), so this imports it directly and exercises the pure vetting functions
+plus the config gate. No `az` binary is required — run_az/run_server_shell are
+tested only for their fail-closed guards (disabled / missing helper), never for
+a real cloud call.
+
+Run:  python3 test_az_console.py
+"""
+import sys
+
+import az_console as azc
+
+
+def _check(label, cond):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
+    return bool(cond)
+
+
+def main():
+    ok = True
+
+    # ── vet_az_args: read-only mode ─────────────────────────────────────────
+    ok &= _check("`vm list` is allowed read-only", azc.vet_az_args(["vm", "list", "-g", "LM"])[0] is True)
+    ok &= _check("`vm get-instance-view` allowed", azc.vet_az_args(["vm", "get-instance-view", "-g", "LM", "-n", "LM-AB"])[0] is True)
+    ok &= _check("`resource list` allowed", azc.vet_az_args(["resource", "list"])[0] is True)
+    ok &= _check("`vm delete` BLOCKED in read-only", azc.vet_az_args(["vm", "delete", "-n", "LM-AB"])[0] is False)
+    ok &= _check("`vm create` BLOCKED in read-only", azc.vet_az_args(["vm", "create", "-n", "x"])[0] is False)
+    ok &= _check("`vm start` BLOCKED in read-only", azc.vet_az_args(["vm", "start", "-n", "x"])[0] is False)
+    ok &= _check("`vm run-command invoke` BLOCKED in read-only (must use server_shell)",
+                 azc.vet_az_args(["vm", "run-command", "invoke", "-n", "x"])[0] is False)
+    ok &= _check("unknown group BLOCKED in read-only (fail closed)",
+                 azc.vet_az_args(["keyvault", "secret", "show"])[0] is False)
+    ok &= _check("non-string arg BLOCKED", azc.vet_az_args(["vm", 3])[0] is False)
+    ok &= _check("empty argv BLOCKED", azc.vet_az_args([])[0] is False)
+
+    # ── vet_az_args: mutation opt-in ────────────────────────────────────────
+    ok &= _check("`vm delete` ALLOWED when allow_mutation", azc.vet_az_args(["vm", "delete"], allow_mutation=True)[0] is True)
+    ok &= _check("`vm run-command invoke` ALLOWED when allow_mutation",
+                 azc.vet_az_args(["vm", "run-command", "invoke"], allow_mutation=True)[0] is True)
+
+    # ── vet_shell_command: read-only mode ───────────────────────────────────
+    ok &= _check("`systemctl status ab` allowed", azc.vet_shell_command("systemctl status ab")[0] is True)
+    ok &= _check("`journalctl -u ab -n 100 --no-pager` allowed",
+                 azc.vet_shell_command("journalctl -u ab -n 100 --no-pager")[0] is True)
+    ok &= _check("`curl -s localhost/health` allowed", azc.vet_shell_command("curl -s localhost/health")[0] is True)
+    ok &= _check("piped read `journalctl -u ab | grep ERROR` allowed",
+                 azc.vet_shell_command("journalctl -u ab | grep ERROR")[0] is True)
+    ok &= _check("`systemctl restart ab` BLOCKED (not a read subcommand)",
+                 azc.vet_shell_command("systemctl restart ab")[0] is False)
+    ok &= _check("`rm -rf /opt/ab` BLOCKED", azc.vet_shell_command("rm -rf /opt/ab")[0] is False)
+    ok &= _check("redirect `echo x > /etc/hosts` BLOCKED", azc.vet_shell_command("echo x > /etc/hosts")[0] is False)
+    ok &= _check("`sed -i s/a/b/ f` (in-place) BLOCKED", azc.vet_shell_command("sed -i s/a/b/ f")[0] is False)
+    ok &= _check("`apt install nginx` BLOCKED", azc.vet_shell_command("apt install nginx")[0] is False)
+    ok &= _check("`git pull` BLOCKED", azc.vet_shell_command("git pull")[0] is False)
+    ok &= _check("chained read;mutation `ls; rm x` BLOCKED (mutation marker)",
+                 azc.vet_shell_command("ls; rm x")[0] is False)
+    ok &= _check("chained reads `ls; ps aux` allowed", azc.vet_shell_command("ls; ps aux")[0] is True)
+    ok &= _check("unknown binary `mysqldump` BLOCKED (fail closed)",
+                 azc.vet_shell_command("mysqldump db")[0] is False)
+    ok &= _check("empty command BLOCKED", azc.vet_shell_command("")[0] is False)
+
+    # ── vet_shell_command: mutation opt-in ──────────────────────────────────
+    ok &= _check("`systemctl restart ab` ALLOWED when allow_mutation",
+                 azc.vet_shell_command("systemctl restart ab", allow_mutation=True)[0] is True)
+    ok &= _check("`rm -rf x` ALLOWED when allow_mutation (RBAC is the boundary)",
+                 azc.vet_shell_command("rm -rf x", allow_mutation=True)[0] is True)
+
+    # ── config gate (no az needed) ──────────────────────────────────────────
+    ok &= _check("run_az disabled when CHAT_AZURE_ENABLED off",
+                 "disabled" in azc.run_az(["vm", "list"], {"CHAT_AZURE_ENABLED": False}).get("error", ""))
+    ok &= _check("run_server_shell disabled when CHAT_AZURE_ENABLED off",
+                 "disabled" in azc.run_server_shell("LM-AB", "systemctl status ab", {"CHAT_AZURE_ENABLED": False}).get("error", ""))
+    ok &= _check("run_az refuses a mutating command BEFORE any login/exec",
+                 "refused" in azc.run_az(["vm", "delete", "-n", "x"], {"CHAT_AZURE_ENABLED": True}).get("error", ""))
+    ok &= _check("run_server_shell rejects a bad vm name",
+                 "invalid vm name" in azc.run_server_shell("bad name!", "systemctl status ab", {"CHAT_AZURE_ENABLED": True}).get("error", ""))
+    ok &= _check("run_az reports missing helper on a non-LM host (fail closed)",
+                 "helper not found" in azc.run_az(["vm", "list"],
+                     {"CHAT_AZURE_ENABLED": True, "AZURE_LOGIN_HELPER": "/nonexistent/lm-az-login"}).get("error", ""))
+
+    print()
+    if ok:
+        print("ALL CASES PASSED")
+        return 0
+    print("ONE OR MORE CASES FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    print("Running az_console self-test...")
+    sys.exit(main())

--- a/test_chat_requirements.py
+++ b/test_chat_requirements.py
@@ -99,6 +99,8 @@ def main():
                 "datetime": __import__("datetime").datetime,
                 "update_task_state": lambda *a, **k: None,
                 "_parse_text_tool_calls": lambda text: (text, []),
+                "az_console": type("_AzStub", (), {"azure_enabled": staticmethod(lambda config: False)})(),
+                "AZURE_TOOLS": [],
             },
         )
 
@@ -161,6 +163,8 @@ def main():
             "_sanitize_tool_result": lambda out, config: out,
             "_trunc": lambda x, n=300: str(x)[:n],
             "_parse_text_tool_calls": lambda text: (text, []),
+            "az_console": type("_AzStub", (), {"azure_enabled": staticmethod(lambda config: False)})(),
+            "AZURE_TOOLS": [],
         },
     )
 
@@ -191,6 +195,8 @@ def main():
             "_sanitize_tool_result": lambda out, config: out,
             "_trunc": lambda x, n=300: str(x)[:n],
             "_parse_text_tool_calls": lambda text: (text, []),
+            "az_console": type("_AzStub", (), {"azure_enabled": staticmethod(lambda config: False)})(),
+            "AZURE_TOOLS": [],
         },
     )
     seen = {"tool": None, "final": None}


### PR DESCRIPTION
## Phase 2 — the chat agent can now reach the live LM servers

This is the capability the whole Phase-1 identity work was for, and the fix for "the chat never actually did anything on the servers." It gives AppBuilder's admin chat two new tools, both **off by default** and both consuming the secretless `lm-az-login` helper (managed identity → SP cert from LM-VAULT in tmpfs → `az login` as the `Virtual Machine Contributor` SP; **no secret on disk or in git**).

### New tools (advertised only when `CHAT_AZURE_ENABLED`)
- **`azure_cli`** — read-only `az` control-plane commands (`vm list`, `vm get-instance-view`, `resource list`, …) to see fleet state.
- **`server_shell`** — run a command **on** a named LM VM via `az vm run-command` (`systemctl status ab`, `journalctl -u ab -n 100`, `curl -s localhost/health`, …) so the agent can verify a change deployed and is functional with no new errors.

### Security model — DEFAULT-DENY
- Master switch `CHAT_AZURE_ENABLED` (default **False**) → zero runtime change on `main` until you turn it on.
- `CHAT_AZURE_ALLOW_MUTATION` (default **False**) → read-only. Every request is vetted by `vet_az_args` / `vet_shell_command` **before any process runs**; anything unrecognised fails closed.
- When mutation *is* enabled, the only boundary is the SP's RBAC scope (VM Contributor on RG `LM`) — deliberate, per "the RBAC scope is the first guard rail."

### Verified end-to-end against the live fleet (from LM-AB, as `svc_bg`)
- `az vm list -g LM` → returned all 6 VMs.
- `server_shell("LM-HUB", "hostname; uptime; systemctl is-system-running")` → ran on the real VM, exit 0.
- `rm -rf /opt/ab`, `systemctl restart`, `keyvault secret show`, and `vm run-command` (in read-only mode) were all **refused before execution**.
- Also fixed a real idempotency bug in `lm-az-login` (cert download now `--overwrite`), captured the helpers into `scripts/` for reproducibility.

### Tests
- New `test_az_console.py` (33 cases) covering the vetting matrix + fail-closed gates (no `az` needed).
- Updated `test_chat_requirements.py` to stub the new `az_console` dependency in the `run_agent_loop` harnesses.
- All guardrail + chat tests green.

Off-by-default, so safe to merge; the real approval gate is you enabling it. Say the word and I'll also do Phase 3 (post-merge production auditor).
