### PR TITLE
Fix chat hallucination: stop tool-less orchestrator from preempting grounded loop

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -29,6 +29,28 @@ _CHAT_INDEX_CACHE = {}            # key("gh"|"notoken") -> {"ts": float, "text":
 _CHAT_INDEX_LOCK = threading.Lock()
 
 
+# Appended to the grounded chat system prompt. AppBuilder's chat manages real
+# production systems, so a confident hallucination (a fabricated "security scan"
+# naming repos that don't exist, or invented results) is actively harmful. This
+# forces the model to stay grounded in what the tools actually returned.
+_CHAT_GROUNDING_RULE = (
+    "GROUNDING RULES (mandatory):\n"
+    "- You are AppBuilder (AB), an autonomous agent that manages a specific set "
+    "of real repositories and servers. The ONLY repositories you manage are "
+    "those returned by the list_repos tool — never reference placeholder or "
+    "example repos (e.g. octocat/Hello-World, exampleUser/ProjectX).\n"
+    "- State only facts you obtained from a tool call in THIS conversation. Never "
+    "invent repository names, file paths, file contents, commands, tool output, "
+    "or scan/audit results.\n"
+    "- To do real work (scan code, read a file, inspect an issue, diagnose a "
+    "server), you MUST call the appropriate tool and base your answer on its "
+    "actual result. If a needed tool or capability is unavailable, say so plainly "
+    "instead of describing hypothetical results.\n"
+    "- If you could not complete something, report what you actually did and what "
+    "remains — do not fill gaps with plausible-sounding fabrication."
+)
+
+
 def _build_chat_context_index_uncached(config, gh=None):
     lines = ["## AppBuilder Context (snapshot — may be up to ~60s stale; use tools for live detail)"]
     monitored = get_monitored_repos(config)
@@ -862,6 +884,22 @@ def _run_chat_reply_orchestrated(chat_id, config):
         import agent_orchestrator
         progress = {"parts": []}
 
+        # This path only runs when there is no GitHub token (no tool grounding),
+        # so the orchestrator can't scan anything — but it must at least KNOW
+        # which real repos/servers AB manages and must not fabricate. Prepend the
+        # AB context index + grounding rule so its agents answer about AB, not
+        # invented placeholder repos.
+        try:
+            index_text = build_chat_context_index(config, gh=None)
+        except Exception:
+            index_text = ""
+        grounded_request = request_text
+        if index_text:
+            grounded_request = (
+                f"{index_text}\n\n{_CHAT_GROUNDING_RULE}\n\n"
+                f"User request:\n{request_text}"
+            )
+
         def _progress(ev):
             kind = ev.get("event")
             if kind == "planned":
@@ -880,7 +918,7 @@ def _run_chat_reply_orchestrated(chat_id, config):
                 _set_chat_stream_status(chat_id, "Merging results…")
 
         result = agent_orchestrator.orchestrate(
-            request_text, config, progress_cb=_progress, task_id=chat_id,
+            grounded_request, config, progress_cb=_progress, task_id=chat_id,
         )
         final = result.final_text or ""
         # Only annotate when the request actually fanned out, so single-agent
@@ -1058,7 +1096,18 @@ def run_chat_reply(chat_id):
     """
     try:
         config = load_config()
-        if config.get("ORCHESTRATOR_ENABLED", False):
+        token = config.get("GITHUB_TOKEN") or os.getenv("GITHUB_TOKEN")
+        gh = Github(token) if token else None
+
+        # The multi-agent orchestrator has NO tools and NO AppBuilder context —
+        # its agents answer from the raw prompt alone. When it front-ran chat it
+        # fabricated grounded work (e.g. a "security scan" that invented repos
+        # like octocat/Hello-World and fake npm-audit results instead of scanning
+        # the real monitored repos). It must therefore NEVER preempt the grounded
+        # tool loop below: only use it when there is genuinely no tool grounding
+        # available (no GitHub token) AND the operator opted in. Anything that can
+        # be grounded with real tools goes through run_agent_loop.
+        if gh is None and config.get("ORCHESTRATOR_ENABLED", False):
             if _run_chat_reply_orchestrated(chat_id, config):
                 return
             logger.warning("orchestrated chat turn failed; falling back to the standard path")
@@ -1077,12 +1126,9 @@ def run_chat_reply(chat_id):
             _set_chat_stream_error(chat_id, "Conversation not found")
             return
 
-        token = config.get("GITHUB_TOKEN") or os.getenv("GITHUB_TOKEN")
-        gh = Github(token) if token else None
-
         # Index gives awareness even without tools; gh passed so issue titles fill in.
         index_text = build_chat_context_index(config, gh=gh)
-        system_prompt = base_system + "\n\n" + index_text
+        system_prompt = base_system + "\n\n" + index_text + "\n\n" + _CHAT_GROUNDING_RULE
         history = conv.get("messages", [])
         window = history[-window_size:]
         messages = [{"role": "system", "content": system_prompt}] + list(window)

--- a/test_chat_requirements.py
+++ b/test_chat_requirements.py
@@ -37,7 +37,8 @@ def _load_ns(func_names, extra_ns):
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name in func_names:
             segs.append(ast.get_source_segment(src, node))
-    ns = {"json": json, "logger": _NoLog(), "traceback": __import__("traceback")}
+    ns = {"json": json, "logger": _NoLog(), "traceback": __import__("traceback"),
+          "_CHAT_GROUNDING_RULE": "(grounding rules)"}
     ns.update(extra_ns)
     exec("\n\n".join(segs), ns)
     return ns
@@ -219,6 +220,72 @@ def main():
                  seen["tool"] is my_tool)
     ok &= _check("run_agent_loop: final_requirements passed through to the forced final turn",
                  seen["final"] is my_final)
+
+    # ---- orchestrator gating: must NOT preempt when tools are available ----
+    # Regression guard for the hallucination incident: the tool-less multi-agent
+    # orchestrator fabricated a "security scan" (invented repos/results) because
+    # it front-ran the grounded tool loop. run_chat_reply must only invoke the
+    # orchestrator when there is no GitHub token (no grounding possible); with a
+    # token present it must go straight to the grounded run_agent_loop.
+    def _make_gating_ns():
+        state = {"orchestrated": 0, "agent_loop": 0}
+
+        def _stub_orchestrated(chat_id, config):
+            state["orchestrated"] += 1
+            return True  # pretend it "handled" the turn
+
+        def _stub_agent_loop(*a, **k):
+            state["agent_loop"] += 1
+            return "grounded answer"
+
+        ns = _load_ns(
+            {"run_chat_reply"},
+            {
+                "load_config": lambda: {"CHAT_TOOLS_ENABLED": True, "CHAT_HISTORY_WINDOW": 20,
+                                        "ORCHESTRATOR_ENABLED": True,
+                                        "GITHUB_TOKEN": _make_gating_ns.token},
+                "load_chats": lambda: {},
+                "get_conversation": lambda store, chat_id: {"messages": [{"role": "user", "content": "scan all repos"}]},
+                "os": __import__("os"),
+                "Github": lambda token: object() if token else None,
+                "build_chat_context_index": lambda config, gh=None: "(index)",
+                "call_llm": lambda *a, **k: "x",
+                "run_agent_loop": _stub_agent_loop,
+                "_run_chat_reply_orchestrated": _stub_orchestrated,
+                "_run_chat_reply_simple": lambda chat_id, config: None,
+                "_register_fix_proposal": lambda *a, **k: None,
+                "_confirm_fix_marker": lambda d: "",
+                "CHAT_TOOLS": [{"type": "function", "function": {"name": "noop"}}],
+                "_set_chat_stream_status": lambda chat_id, msg: None,
+                "_set_chat_stream_error": lambda chat_id, msg: None,
+                "_finalize_chat_stream": lambda chat_id, reply: None,
+                "append_chat_message": lambda chat_id, msg: None,
+                "datetime": __import__("datetime").datetime,
+                "_parse_text_tool_calls": lambda text: (text, []),
+                "update_task_state": lambda *a, **k: None,
+                "az_console": type("_AzStub", (), {"azure_enabled": staticmethod(lambda config: False)})(),
+                "AZURE_TOOLS": [],
+            },
+        )
+        return ns, state
+
+    # token present -> grounded loop, orchestrator NOT invoked
+    _make_gating_ns.token = "tok"
+    ns_g1, st1 = _make_gating_ns()
+    ns_g1["run_chat_reply"]("cg1")
+    ok &= _check("orchestrator gating: token present -> orchestrator NOT invoked",
+                 st1["orchestrated"] == 0)
+    ok &= _check("orchestrator gating: token present -> grounded run_agent_loop used",
+                 st1["agent_loop"] == 1)
+
+    # no token -> orchestrator (opt-in) IS invoked, grounded loop not reached
+    _make_gating_ns.token = None
+    ns_g2, st2 = _make_gating_ns()
+    ns_g2["run_chat_reply"]("cg2")
+    ok &= _check("orchestrator gating: no token + enabled -> orchestrator invoked",
+                 st2["orchestrated"] == 1)
+    ok &= _check("orchestrator gating: no token -> grounded loop not reached",
+                 st2["agent_loop"] == 0)
 
     print()
     if ok:


### PR DESCRIPTION
## Problem

The chat produced a **fabricated security-scan report** — inventing repos (`octocat/Hello-World`, `exampleUser/ProjectX`), fake paths (`/opt/ab/config.yaml`), and fake `npm audit` results — with a footer showing *"Handled by 4 agents"* on free/flash models. The chat clearly had **no knowledge of AB** and did **no real work**.

## Root cause

`chat.py:run_chat_reply` invoked `_run_chat_reply_orchestrated` **before** the grounded `run_agent_loop`. The orchestrator (`agent_orchestrator.orchestrate`) fans out to sub-agents that receive **no tools** and **no AB context index** — they answer from the raw prompt alone, then return `True` on hallucinated "success", so the grounded path (which has both the real repo/issue index **and** `CHAT_TOOLS`) was never reached.

## Fix

- **Gate the orchestrator** so it can never preempt the grounded tool loop: only used when there is no GitHub token (no grounding possible) **and** the operator opted in. With a token present, chat always uses the grounded `run_agent_loop`.
- **Anti-fabrication rule** (`_CHAT_GROUNDING_RULE`) appended to the grounded system prompt: only state tool-derived facts, never invent repos/paths/results, only reference repos from `list_repos`.
- **Ground the residual path**: inject the AB context index + grounding rule into the no-token orchestrator path too.
- **Tests**: new regression cases asserting the orchestrator does not preempt when a token is present, and is only used when no token is available.

## Verification

`python3 test_chat_requirements.py` — all 18 cases pass (incl. new gating cases). Related guardrail/az_console self-tests still green.