### PR TITLE
security: edge HTTPS-scanner detection → report to hub NSG

### DIFF
--- a/hub_agent.py
+++ b/hub_agent.py
@@ -428,6 +428,36 @@ class HubAgentClient:
         finally:
             self._pending.pop(msg_id, None)
 
+    def report_probe(self, source_ip: str, path: str, method: str) -> None:
+        """Fire-and-forget: relay a detected HTTPS-port scanner probe up to the
+        hub (``HTTP_PROBE_REPORT``) so it auto-blocks the source centrally on the
+        NSG — one deny protects every edge. Thread-safe: called from the FastAPI
+        request thread, it schedules the signed send on the agent's own loop. A
+        no-op when not connected/approved (best-effort; the hub also detects
+        probes on its own :443). The hub re-classifies the path server-side and
+        rate-caps this reporter, so a report can never be abused to block an
+        arbitrary victim."""
+        loop = self.loop
+        if loop is None or self._ws is None or self.signer is None or not self._approved:
+            return
+        data = {"source_ip": source_ip or "", "path": path, "method": method,
+                "node": self.spoke_id or "appbuilder"}
+
+        async def _send():
+            try:
+                msg = {"header": {"message_id": str(uuid.uuid4()),
+                                  "timestamp": round(time.time(), 6),
+                                  "sender_id": self.spoke_id, "destination_id": "hub"},
+                       "payload": {"type": "HTTP_PROBE_REPORT", "data": data}}
+                await self._ws.send(encode_frame(self.signer, msg))
+            except Exception as e:  # noqa: BLE001
+                logger.debug("HTTP_PROBE_REPORT send failed: %s", e)
+
+        try:
+            asyncio.run_coroutine_threadsafe(_send(), loop)
+        except Exception:  # noqa: BLE001 — never break the request path over telemetry
+            pass
+
     async def _handle_analyze_logs(self, msg, data):
         """The LM hub has no LLM of its own, so it delegates Log Analysis to us (we
         own the models + already read hub logs). Run analyze_logs off the event-loop

--- a/main.py
+++ b/main.py
@@ -329,6 +329,51 @@ async def catch_exceptions_mid(request: Request, call_next):
             content={"message": "Internal Server Error. Check ab.log for details.", "error": str(e)}
         )
 
+
+from probe_signatures import looks_like_probe  # noqa: E402 — edge scanner classifier
+
+
+def _probe_client_ip(request: Request) -> str:
+    """Best-effort real client IP for a scanner report. If a front proxy stamped
+    X-Forwarded-For, the leftmost entry is the origin; else the direct peer."""
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        first = xff.split(",")[0].strip()
+        if first:
+            return first
+    return (request.client.host if request.client else "") or ""
+
+
+def _probe_detection_enabled() -> bool:
+    """Per-node toggle for edge HTTPS-port scanner detection. ON unless the
+    operator sets AB_PROBE_DETECTION to a falsey value (env is the reliable
+    per-node switch; inherently safe since it's report-only and the hub's
+    auto-block is itself opt-in and exempts trusted IPs)."""
+    v = str(os.environ.get("AB_PROBE_DETECTION", "")).strip().lower()
+    return v not in ("0", "false", "no", "off")
+
+
+@app.middleware("http")
+async def detect_https_probe(request: Request, call_next):
+    # HTTPS-port scanner detection at the AppBuilder edge. A request for a path we
+    # never serve (PHP/dotfiles/DB-admin panels/app-server consoles) is a scanner
+    # fingerprinting THIS box, not a real client. Report it up the authenticated
+    # hub tunnel so the hub blocks the source centrally on the NSG, and answer a
+    # bare 404 instead of the SPA. Registered LAST so it is the OUTERMOST
+    # middleware (runs BEFORE require_login) — a scanner is caught pre-auth and
+    # never sees a login redirect. Shares the hub's scanner signatures
+    # (probe_signatures.looks_like_probe), so real in-app routes never trip it.
+    if _probe_detection_enabled() and looks_like_probe(request.url.path):
+        try:
+            from workers import _get_hub_agent_client
+            client = _get_hub_agent_client()
+            if client is not None:
+                client.report_probe(_probe_client_ip(request), request.url.path, request.method)
+        except Exception:  # noqa: BLE001 — telemetry must never break the request
+            logger.debug("probe report failed", exc_info=True)
+        return JSONResponse(status_code=404, content={"detail": "Not Found"})
+    return await call_next(request)
+
 # Shared mutable application state + task-state locks + update_task_state live in
 # app_state.py. Imported here (after config_store + llm_client names are already
 # re-exported into main's namespace, which app_state builds `state` from) and

--- a/probe_signatures.py
+++ b/probe_signatures.py
@@ -1,0 +1,52 @@
+"""Shared HTTPS-port probe / scanner signature classifier.
+
+Single source of truth for "does this request path look like an automated
+vulnerability scanner fingerprinting the port?" — used by the hub HTTP
+middleware (``core/src/api.py``) AND by every edge component that serves its own
+HTTPS surface (the reverse proxy, AppBuilder, role-hosted spoke UIs). Keeping
+the signature lists in ONE importable module (rather than a copy per edge) means
+a new scanner signature added here is picked up everywhere at once — there is no
+twin to drift out of sync.
+
+The components that import this all serve a Python API + a static JS SPA over
+:443 — they never serve PHP/ASP/JSP/CGI, dotfiles, DB admin panels, or
+app-server consoles. A request for any of those is a scanner, not a real client
+(the SPA catch-all would otherwise answer 200 index.html and hide the probe).
+High-confidence signatures only: SPA deep-links and static assets
+(``.js``/``.css``/``.svg``/...) never match, so a mistyped in-app route is not
+mistaken for an attack.
+"""
+
+from __future__ import annotations
+
+# Path SUFFIXES a legitimate SPA/API never serves. Extension-based scanner
+# fingerprints (PHP/ASP/JSP/CGI stacks, secret/backup files).
+PROBE_SUFFIXES = (
+    ".php", ".php5", ".php7", ".phtml", ".asp", ".aspx", ".jsp", ".jspx",
+    ".cgi", ".env", ".sql", ".bak", ".htaccess", ".htpasswd",
+)
+
+# Path SUBSTRINGS that only appear in scanner traffic (CMS probes, VCS/secret
+# dirs, DB admin panels, app-server consoles, known-CVE endpoints).
+PROBE_TOKENS = (
+    "/wp-", "/wordpress/", "/.git", "/.env", "/.aws", "/.ssh/", "/.svn",
+    "/phpmyadmin", "/pma/", "/adminer", "/dbadmin", "/mysql", "/xmlrpc",
+    "/actuator/", "/solr/", "/jenkins/", "/manager/html", "/vendor/",
+    "/phpunit", "/eval-stdin", "/.vscode", "/.idea", "/boaform", "/hnap1",
+    "/owa/", "/autodiscover/", "/cgi-bin/",
+)
+
+
+def looks_like_probe(path: str) -> bool:
+    """True when ``path`` matches a known external-scanner signature that none
+    of our HTTPS surfaces legitimately serves.
+
+    High-confidence only — SPA deep-links and static assets never match, so a
+    mistyped in-app route is not mistaken for an attack.
+    """
+    p = (path or "").lower()
+    if not p:
+        return False
+    if any(p.endswith(sfx) for sfx in PROBE_SUFFIXES):
+        return True
+    return any(tok in p for tok in PROBE_TOKENS)

--- a/test_probe_detection.py
+++ b/test_probe_detection.py
@@ -1,0 +1,102 @@
+"""AppBuilder edge HTTPS-port scanner detection.
+
+AppBuilder serves a FastAPI SPA on :443. A request for a path it never serves
+(PHP/dotfiles/DB-admin panels/...) is a scanner fingerprinting the box, not a
+real client. The FastAPI middleware answers a bare 404 and reports the probe up
+the authenticated hub tunnel (``HubAgentClient.report_probe`` →
+``HTTP_PROBE_REPORT``) so the hub blocks the source centrally on the NSG.
+
+These tests pin the vendored classifier (byte-twin of the hub's) and the
+fire-and-forget reporter's frame shape + safe no-op when not connected.
+
+Run:  python3 -m pytest test_probe_detection.py
+"""
+import asyncio
+import json
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+import probe_signatures  # noqa: E402
+import hub_agent  # noqa: E402
+
+
+# ── vendored classifier (must match the hub's signatures) ───────────────────
+def test_scanner_paths_flagged():
+    for p in ["/wp-login.php", "/.env", "/.git/config", "/phpmyadmin/index.php",
+              "/xmlrpc.php", "/actuator/health", "/cgi-bin/x.cgi", "/config.bak"]:
+        assert probe_signatures.looks_like_probe(p), p
+
+
+def test_app_paths_not_flagged():
+    for p in ["/", "/index.html", "/assets/app.js?v=1", "/api/tasks",
+              "/login", "/setup-admin", "/chat"]:
+        assert not probe_signatures.looks_like_probe(p), p
+
+
+# ── reporter frame shape ────────────────────────────────────────────────────
+def _client_with_loop(approved=True, ws=None):
+    c = hub_agent.HubAgentClient.__new__(hub_agent.HubAgentClient)
+    c.spoke_id = "ab-1"
+    c.signer = hub_agent.MessageSigner("s3cr3t")
+    c._approved = approved
+    c._ws = ws
+    loop = asyncio.new_event_loop()
+    threading.Thread(target=loop.run_forever, daemon=True).start()
+    c.loop = loop
+    return c, loop
+
+
+def test_report_probe_sends_http_probe_report():
+    captured = {}
+
+    class _WS:
+        async def send(self, wire):
+            captured["wire"] = wire
+
+    c, loop = _client_with_loop(ws=_WS())
+    try:
+        c.report_probe("203.0.113.7", "/wp-login.php", "POST")
+        time.sleep(0.1)  # let the scheduled coroutine run on the loop thread
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+    assert "wire" in captured
+    _sig, _, body = captured["wire"].partition(".")
+    msg = json.loads(body)
+    assert msg["payload"]["type"] == "HTTP_PROBE_REPORT"
+    assert msg["payload"]["data"] == {"source_ip": "203.0.113.7",
+                                      "path": "/wp-login.php", "method": "POST",
+                                      "node": "ab-1"}
+    assert msg["header"]["destination_id"] == "hub"
+
+
+def test_report_probe_noop_when_not_approved():
+    class _WS:
+        def __init__(self):
+            self.sent = False
+
+        async def send(self, wire):
+            self.sent = True
+
+    ws = _WS()
+    c, loop = _client_with_loop(approved=False, ws=ws)
+    try:
+        c.report_probe("203.0.113.7", "/.env", "GET")
+        time.sleep(0.05)
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+    assert ws.sent is False
+
+
+def test_report_probe_noop_without_connection():
+    c = hub_agent.HubAgentClient.__new__(hub_agent.HubAgentClient)
+    c.spoke_id = "ab-1"
+    c.signer = hub_agent.MessageSigner("s")
+    c._approved = True
+    c._ws = None
+    c.loop = None
+    # No loop / no socket → must return cleanly, never raise.
+    c.report_probe("203.0.113.7", "/.env", "GET")


### PR DESCRIPTION
Extends the LM hub's HTTPS-port scanner detection to the AppBuilder edge so a scan of a path AB never serves is caught locally and fed back to the hub for central NSG blocking (pairs with lm commit 8e8c03ca).

## What
- **`probe_signatures.py`** — byte-identical vendored copy of the hub's scanner classifier (`lm/core/src/security/probe_signatures.py`); the `ab` repo can't import `lm/core` at runtime. Kept in lockstep via the dual-copy-guard pair.
- **Outermost FastAPI middleware** (runs before `require_login`) — a probe path is answered a bare **404** and reported via `HubAgentClient.report_probe` over the authenticated hub tunnel (`HTTP_PROBE_REPORT`). Per-node `AB_PROBE_DETECTION` toggle (default ON).
- **`HubAgentClient.report_probe`** — thread-safe fire-and-forget signed frame; no-op when not connected/approved.

## Abuse hardening
The hub re-classifies the reported path server-side, rate-caps the reporter, and exempts trusted IPs — so a compromised edge can't forge reports to block an arbitrary victim (enforced hub-side in the paired lm change).

## Tests
`test_probe_detection.py` (5) — vendored classifier + reporter frame shape + safe no-ops.