### PR TITLE
fix: let AppBuilder's human-escalation signal reach its handler (issue #441 triage)

### DIFF
--- a/fix_engine.py
+++ b/fix_engine.py
@@ -1554,6 +1554,16 @@ def apply_ai_fix(repo_path, issue_body, error_context=None, task_id=None, files_
                         enable_native_tools=_native,
                         json_schema=_FIX_GENERATION_JSON_SCHEMA,
                         requirements=requirements, used_model_out=used_model_out)
+    except (llm_client.LlmHumanEscalationNeeded, llm_client.LLMCreditExhausted):
+        # Typed control-flow signals from the picker must reach the fix loop's
+        # dedicated handlers with their type intact. Wrapping them in a bare
+        # Exception here erased LlmHumanEscalationNeeded's type, so the loop's
+        # `except LlmHumanEscalationNeeded` (which posts the clean "held for
+        # human review" note and stops) never fired — the escalation fell to the
+        # generic per-attempt error path, was retried, and finally surfaced as a
+        # raw, truncated "No candidate satisfies requirements (reqs=LlmRequire…"
+        # repr dumped onto the issue. Re-raise unchanged.
+        raise
     except Exception as e:
         raise Exception(f"Fix generation failed: {e}")
 

--- a/test_apply_ai_fix_escalation_passthrough.py
+++ b/test_apply_ai_fix_escalation_passthrough.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Regression test for apply_ai_fix's exception handling.
+
+fix_engine.py imports `main` (heavy app-init side effects — see
+test_llm_client_requirements_path.py's docstring), so this extracts just
+apply_ai_fix by source via ast and execs it with stubbed dependencies,
+following the established extraction pattern used across the AB test suite.
+
+The bug: apply_ai_fix's tail wrapped EVERY exception from the picker in a
+bare `Exception(f"Fix generation failed: {e}")`. That erased the type of
+llm_client.LlmHumanEscalationNeeded — the typed signal the fix loop raises
+when NO configured model meets a fix's requirements — so the loop's dedicated
+`except LlmHumanEscalationNeeded` handler (post a clean "held for human
+review" note and stop) never fired. The escalation was mis-handled as a
+generic per-attempt provider error, retried up to max_attempts, and finally
+dumped onto the issue as a raw, truncated
+"No candidate satisfies requirements (reqs=LlmRequirements(complexity='large'…"
+repr. This test pins the fix: the typed control exceptions propagate
+unchanged, while ordinary errors are still wrapped.
+
+Run:  python3 ab/test_apply_ai_fix_escalation_passthrough.py
+"""
+import ast
+import os
+import sys
+import tempfile
+
+
+def _check(label, cond):
+    print(("PASS" if cond else "FAIL") + f": {label}")
+    return bool(cond)
+
+
+def _load_apply_ai_fix(call_llm_stub, llm_client_stub):
+    src = open("fix_engine.py").read()
+    tree = ast.parse(src)
+    seg = None
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "apply_ai_fix":
+            seg = ast.get_source_segment(src, node)
+            break
+    if seg is None:
+        raise AssertionError("apply_ai_fix not found in fix_engine.py")
+
+    class _NoLog:
+        def __getattr__(self, _):
+            return lambda *a, **k: None
+
+    ns = {
+        "load_config": lambda: {},
+        "CHAT_CONFIG_DEFAULTS": {
+            "FIX_MAX_FILES": 10,
+            "FIX_MAX_FILE_CHARS": 10000,
+            "FIX_MAX_CONTEXT_CHARS": 50000,
+        },
+        "identify_files_to_fix": lambda *a, **k: [],
+        "_issue_identifiers": lambda *a, **k: [],
+        "os": os,
+        "logger": _NoLog(),
+        "call_llm": call_llm_stub,
+        "llm_client": llm_client_stub,
+        "_FIX_GENERATION_JSON_SCHEMA": {},
+    }
+    exec(compile(seg, "fix_engine.py:apply_ai_fix", "exec"), ns)
+    return ns["apply_ai_fix"]
+
+
+class _LlmClientStub:
+    class LlmHumanEscalationNeeded(Exception):
+        pass
+
+    class LLMCreditExhausted(Exception):
+        pass
+
+
+def main():
+    ok = True
+    tmp = tempfile.mkdtemp()
+
+    # A typed human-escalation signal must propagate UNCHANGED (not re-wrapped).
+    def _raise_escalation(*a, **k):
+        raise _LlmClientStub.LlmHumanEscalationNeeded(
+            "No candidate satisfies requirements (reqs=LlmRequirements(...))")
+
+    fn = _load_apply_ai_fix(_raise_escalation, _LlmClientStub)
+    try:
+        fn(tmp, "some issue", files_override=["nope.py"])
+        ok &= _check("LlmHumanEscalationNeeded propagates (raised something)", False)
+    except _LlmClientStub.LlmHumanEscalationNeeded:
+        ok &= _check("LlmHumanEscalationNeeded propagates with type intact", True)
+    except Exception as e:  # noqa: BLE001
+        ok &= _check(f"LlmHumanEscalationNeeded NOT re-wrapped (got {type(e).__name__}: {e})", False)
+
+    # A credit-exhausted signal must likewise propagate unchanged.
+    def _raise_credit(*a, **k):
+        raise _LlmClientStub.LLMCreditExhausted("out of credit")
+
+    fn = _load_apply_ai_fix(_raise_credit, _LlmClientStub)
+    try:
+        fn(tmp, "some issue", files_override=["nope.py"])
+        ok &= _check("LLMCreditExhausted propagates (raised something)", False)
+    except _LlmClientStub.LLMCreditExhausted:
+        ok &= _check("LLMCreditExhausted propagates with type intact", True)
+    except Exception as e:  # noqa: BLE001
+        ok &= _check(f"LLMCreditExhausted NOT re-wrapped (got {type(e).__name__})", False)
+
+    # An ORDINARY error is still wrapped as "Fix generation failed: …".
+    def _raise_value(*a, **k):
+        raise ValueError("boom")
+
+    fn = _load_apply_ai_fix(_raise_value, _LlmClientStub)
+    try:
+        fn(tmp, "some issue", files_override=["nope.py"])
+        ok &= _check("ordinary error wrapped (raised something)", False)
+    except _LlmClientStub.LlmHumanEscalationNeeded:
+        ok &= _check("ordinary error NOT mistaken for escalation", False)
+    except Exception as e:  # noqa: BLE001
+        ok &= _check("ordinary error wrapped as 'Fix generation failed: …'",
+                     str(e).startswith("Fix generation failed:") and "boom" in str(e))
+
+    print("\nALL PASS" if ok else "\nSOME FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Triage of the issue #441 "AppBuilder Failure"

The failure comment was:
> **Final Error:** `Error during fix after 3 attempt(s) — Fix generation failed: No candidate satisfies requirements (reqs=LlmRequirements(complexity='large', needs_tools=False, needs_native_agentic_tools=False, needs_…`
… cut off mid-repr.

### What actually happened
1. Fixes run with `LlmRequirements(complexity='large', …, must_escalate_to_human=True)` (`fix_engine.py:2188`).
2. When the picker can't find a large-capable, not-excluded, available model, `select_model()` returns `None`; because `must_escalate_to_human=True`, `call_llm` **raises `llm_client.LlmHumanEscalationNeeded`** (by design — hold for a human instead of silently dropping to the safety floor).
3. **The bug:** `apply_ai_fix`'s tail caught *every* exception and re-raised it as a bare `Exception("Fix generation failed: {e}")`, **erasing the type**. So the loop's dedicated `except LlmHumanEscalationNeeded` handler (`fix_engine.py:2406` — posts a clean *"held for human review"* note, labels `ab-needs-human`, stops) never fired.
4. Instead the escalation was treated as a generic per-attempt provider error, **retried up to 3×**, then dumped onto the issue as the raw, truncated `LlmRequirements(...)` repr — the message you saw.

### Why no candidate met the requirements (root, deployment-side)
Each failed attempt adds the just-tried model to `exclude_models` (a **hard** filter, `model_selection.py:213`). With only a small `large`-capable roster (e.g. Claude CLI + Copilot), attempts 2–3 exclude them all → `select_model` returns `None` on the final attempt. (A very large injected fix prompt — bug-report console/DOM artifacts + skills + regression context — can also push `min_context_tokens` past every model's window and filter them all.)

## Fix (this PR)
Re-raise the typed control-flow signals (`LlmHumanEscalationNeeded`, `LLMCreditExhausted`) unchanged so the intended clean **"held for human review"** hold happens instead of a confusing, retried, truncated raw-repr failure. Ordinary errors are still wrapped as `Fix generation failed: …`.

+ `test_apply_ai_fix_escalation_passthrough.py` (ast-extraction harness matching the suite convention): asserts both typed signals propagate with type intact and that ordinary errors are still wrapped. Passes; would fail against the old single-`except`.

## Operator note (to make #441 actually get *fixed*, not just cleanly held)
Configure **≥3 distinct `large`-capable models** in the LLM Vault (e.g. Claude Opus via CLI + GitHub Copilot + one cloud frontier) so the exclude-on-retry policy doesn't exhaust the roster before attempt 3.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>