### PR TITLE
Show all configured LLM endpoints in the Providers chip; tier Copilot models per-model

### DIFF
--- a/llm_migrate.py
+++ b/llm_migrate.py
@@ -172,6 +172,12 @@ def migrate(config):
             config["model_registry"] = _topped
             logger.info("LLM registry: added per-model claude_cli capability rules %s "
                         "(Haiku=medium, Sonnet/Opus=large) during migration.", _added_cc)
+        _topped, _added_copilot = model_registry.upgrade_copilot_model_rules(config["model_registry"])
+        if _added_copilot:
+            config["model_registry"] = _topped
+            logger.info("LLM registry: added per-model copilot capability rules %s "
+                        "(Opus/Sonnet/GPT-5=frontier, Haiku/GPT-4/mini=cheap) during migration.",
+                        _added_copilot)
         _topped, _added_router = model_registry.upgrade_openrouter_free_router_rule(config["model_registry"])
         if _added_router:
             config["model_registry"] = _topped

--- a/model_registry.py
+++ b/model_registry.py
@@ -166,7 +166,59 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "cheap", "max_complexity": "large", "context_window": 64000,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "enabled": True,
+     "notes": "generic fallback for Copilot models with no class rule below. Copilot is NOT "
+              "free — every call spends a premium request — so this stays 'cheap', never 'free'."},
+    # Per-model capability tiers for the GitHub Copilot roster. Copilot bills a
+    # premium request per call and the multiplier is PER MODEL, spanning ~80x:
+    # Opus 27x and GPT-5.5 57x at the top, GPT-4o / mini / Haiku 0.33x at the
+    # bottom. The single `*` rule above therefore priced Opus-via-Copilot the
+    # same as GPT-4o-via-Copilot, which broke the picker in BOTH directions:
+    # `cheap` made it reach for Opus on trivial work (burning the priciest
+    # request there is), while prefer_capable ranks frontier ABOVE cheap, so the
+    # strongest model was skipped for exactly the hard jobs it exists for. These
+    # mirror the anthropic/claude_cli ladders so one model is tiered the same way
+    # whichever provider serves it. More-specific match beats the generic `*`.
+    {"id": "copilot-opus", "provider": "copilot", "match": "*opus*", "label": "Claude Opus (via Copilot)",
+     "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
+     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True,
+     "notes": "27x premium-request multiplier — the most expensive model Copilot serves. "
+              "frontier/large matches anthropic-opus and claude-cli-opus so the picker "
+              "RESERVES it for the hardest work instead of spending it on triage."},
+    {"id": "copilot-sonnet", "provider": "copilot", "match": "*sonnet*", "label": "Claude Sonnet (via Copilot)",
+     "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
+     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "9x multiplier; frontier/large mirrors anthropic-sonnet"},
+    {"id": "copilot-haiku", "provider": "copilot", "match": "*haiku*", "label": "Claude Haiku (via Copilot)",
+     "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
+     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "0.33x multiplier; cheap/medium mirrors anthropic-haiku"},
+    {"id": "copilot-gemini-pro", "provider": "copilot", "match": "*gemini*pro*", "label": "Gemini Pro (via Copilot)",
+     "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
+     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "6x multiplier; frontier/large mirrors google-pro"},
+    # `gpt-5*mini*` is deliberately MORE specific than `gpt-5*` so gpt-5-mini
+    # (0.33x) stays cheap instead of inheriting the gpt-5 frontier tier.
+    {"id": "copilot-gpt5-mini", "provider": "copilot", "match": "gpt-5*mini*", "label": "GPT-5 mini (via Copilot)",
+     "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
+     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "0.33x multiplier — the cheapest GPT-5 variant"},
+    {"id": "copilot-gpt5", "provider": "copilot", "match": "gpt-5*", "label": "GPT-5 class (via Copilot)",
+     "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
+     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "6x base / 57x for GPT-5.5 — priced as frontier so it is reserved"},
+    {"id": "copilot-gpt4", "provider": "copilot", "match": "gpt-4*", "label": "GPT-4 class (via Copilot)",
+     "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
+     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "0.33x multiplier (gpt-4o / gpt-4o-mini)"},
     {"id": "anthropic-haiku", "provider": "anthropic", "match": "*haiku*", "label": "Claude Haiku class",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 200000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
@@ -391,16 +443,15 @@ _CLAUDE_CLI_MODEL_RULE_IDS = frozenset({
 })
 
 
-def upgrade_claude_cli_model_rules(rules):
-    """Return (new_rules, added_ids): a COPY of `rules` with any missing
-    per-model claude_cli rules (_CLAUDE_CLI_MODEL_RULE_IDS) appended.
+def _append_missing_default_rules(rules, wanted_ids):
+    """Return (new_rules, added_ids): a COPY of `rules` with any DEFAULT rule
+    whose id is in `wanted_ids` appended when it is missing.
 
-    These categorize the claude_cli roster by model strength so Haiku (capped
-    at medium) is never treated like Opus/Sonnet (large) — the generic `*`
-    claude_cli rule alone gives every model the same large ceiling. Append-only
+    Shared by the per-model upgrade helpers (claude_cli, copilot). Append-only
     and skipped when the rule id already exists OR the operator already curated
-    a rule for that exact (provider, match). Never reorders or mutates existing
-    rules; the more-specific match wins by specificity (see resolve())."""
+    a rule for that exact (provider, match), so a hand-tuned registry is never
+    overridden. Never reorders or mutates existing rules; the more-specific
+    match wins by specificity (see resolve())."""
     rules = list(rules or [])
     existing_ids = {r.get("id") for r in rules if isinstance(r, dict)}
     existing_pairs = {
@@ -409,7 +460,7 @@ def upgrade_claude_cli_model_rules(rules):
     }
     added_ids = []
     for default in DEFAULT_MODEL_RULES:
-        if default.get("id") not in _CLAUDE_CLI_MODEL_RULE_IDS:
+        if default.get("id") not in wanted_ids:
             continue
         if default.get("id") in existing_ids:
             continue
@@ -422,6 +473,41 @@ def upgrade_claude_cli_model_rules(rules):
         existing_ids.add(default.get("id"))
         existing_pairs.add(pair)
     return rules, added_ids
+
+
+def upgrade_claude_cli_model_rules(rules):
+    """Return (new_rules, added_ids): a COPY of `rules` with any missing
+    per-model claude_cli rules (_CLAUDE_CLI_MODEL_RULE_IDS) appended.
+
+    These categorize the claude_cli roster by model strength so Haiku (capped
+    at medium) is never treated like Opus/Sonnet (large) — the generic `*`
+    claude_cli rule alone gives every model the same large ceiling."""
+    return _append_missing_default_rules(rules, _CLAUDE_CLI_MODEL_RULE_IDS)
+
+
+#: Per-model copilot capability rules (see DEFAULT_MODEL_RULES). Appended to an
+#: already-persisted registry for the same reason as the claude_cli set: without
+#: them the generic copilot `*` rule prices EVERY Copilot model as "cheap",
+#: including Claude Opus — whose Copilot premium-request multiplier (27x) makes
+#: it the single most expensive model available.
+_COPILOT_MODEL_RULE_IDS = frozenset({
+    "copilot-opus", "copilot-sonnet", "copilot-haiku", "copilot-gemini-pro",
+    "copilot-gpt5-mini", "copilot-gpt5", "copilot-gpt4",
+})
+
+
+def upgrade_copilot_model_rules(rules):
+    """Return (new_rules, added_ids): a COPY of `rules` with any missing
+    per-model copilot rules (_COPILOT_MODEL_RULE_IDS) appended.
+
+    An operator who configured Copilot before this ladder existed has the old
+    single `*` rule frozen into config["model_registry"], which (a) let the
+    cost-first picker spend a 27x Opus request on trivial work and (b) ranked
+    Opus BELOW frontier models under prefer_capable, skipping it for the hard
+    jobs it exists for. Append-only and idempotent, exactly like the claude_cli
+    upgrade — an operator's own copilot rule for the same match is left
+    untouched."""
+    return _append_missing_default_rules(rules, _COPILOT_MODEL_RULE_IDS)
 
 
 def upgrade_openrouter_free_router_rule(rules):

--- a/routes.py
+++ b/routes.py
@@ -2091,6 +2091,7 @@ async def settings_page(request: Request):
     _curated, _mr_added_cap = _registry.upgrade_capable_local_rules(_curated)
     _curated, _mr_claude_paid = _registry.reclassify_claude_cli_paid(_curated)
     _curated, _mr_claude_models = _registry.upgrade_claude_cli_model_rules(_curated)
+    _curated, _mr_copilot_models = _registry.upgrade_copilot_model_rules(_curated)
     _curated, _mr_or_router = _registry.upgrade_openrouter_free_router_rule(_curated)
     _registry_rules_json = json.dumps(_curated, indent=2)
     _auto = config.get("model_registry_auto") or []
@@ -2497,6 +2498,8 @@ async def save_settings(request: Request):
             config_data["model_registry"], _ = _registry_save.reclassify_claude_cli_paid(
                 config_data["model_registry"])
             config_data["model_registry"], _ = _registry_save.upgrade_claude_cli_model_rules(
+                config_data["model_registry"])
+            config_data["model_registry"], _ = _registry_save.upgrade_copilot_model_rules(
                 config_data["model_registry"])
             config_data["model_registry"], _ = _registry_save.upgrade_openrouter_free_router_rule(
                 config_data["model_registry"])

--- a/routes.py
+++ b/routes.py
@@ -2790,6 +2790,23 @@ async def copilot_models(provider: str = "copilot"):
         return {"models": [], "error": str(e)}
 
 
+def _refresh_llm_endpoints():
+    """Kick an immediate re-probe of the configured LLM endpoints.
+
+    Without this, `state["llm_endpoints_online"]` — which the header Providers
+    chip renders from — was only rebuilt by connectivity_worker's 15-minute
+    tick, so a just-added provider/model did not appear until then. Imported
+    lazily because workers imports main, and a module-level import here would
+    close an import cycle. Best-effort: never let a refresh failure break the
+    save that triggered it.
+    """
+    try:
+        from workers import refresh_llm_endpoints_async
+        refresh_llm_endpoints_async()
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"_refresh_llm_endpoints failed: {e}")
+
+
 @router.post("/api/llm/entries")
 async def create_llm_entry(request: Request):
     """Create a new named provider/model entry."""
@@ -2815,6 +2832,7 @@ async def create_llm_entry(request: Request):
     config = load_config()
     config.setdefault("llm_entries", []).append(entry)
     save_config(config)
+    _refresh_llm_endpoints()
     return {"status": "ok", "entry": entry}
 
 
@@ -2847,6 +2865,7 @@ async def update_llm_entry(entry_id: str, request: Request):
             if "enabled" in data:
                 e["enabled"] = bool(data.get("enabled"))
             save_config(config)
+            _refresh_llm_endpoints()
             return {"status": "ok", "entry": e}
     return JSONResponse(status_code=404, content={"error": "entry not found"})
 
@@ -2857,6 +2876,7 @@ async def delete_llm_entry(entry_id: str):
     config = load_config()
     config["llm_entries"] = [e for e in (config.get("llm_entries") or []) if e.get("id") != entry_id]
     save_config(config)
+    _refresh_llm_endpoints()
     return {"status": "ok"}
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -300,32 +300,42 @@
                  title="LLM endpoints actively serving calls — click for the full providers table">
                 <span class="text-[10px] uppercase tracking-widest text-white/50">Providers</span>
                 {% if state.llm_endpoints_online %}
-                {% set used_eps = state.llm_endpoints_online | selectattr('used') | list %}
-                {% set online_eps = used_eps | selectattr('online') | list %}
-                {% if used_eps %}
+                {# Show EVERY configured endpoint, not only those that have already
+                   served a call. Filtering on `used` meant a newly added LLM (0 runs,
+                   not currently serving) stayed invisible here until it happened to be
+                   picked — indistinguishable from "my new provider never registered".
+                   Endpoints that are serving/have served sort first; the rest list as
+                   idle, so adding a provider gives immediate visible feedback. #}
+                {% set all_eps = state.llm_endpoints_online %}
+                {% set online_eps = all_eps | selectattr('online') | list %}
+                {% set sorted_eps = (all_eps | selectattr('used') | list) + (all_eps | rejectattr('used') | list) %}
+                {% if all_eps %}
                 <span class="inline-flex items-center gap-1.5">
-                    <span class="w-2 h-2 rounded-full {{ 'bg-emerald-400' if online_eps|length == used_eps|length else ('bg-amber-400' if online_eps|length else 'bg-red-400') }}"></span>
-                    <span class="text-xs font-semibold text-white/80 tabular-nums">{{ online_eps|length }}/{{ used_eps|length }}</span>
+                    <span class="w-2 h-2 rounded-full {{ 'bg-emerald-400' if online_eps|length == all_eps|length else ('bg-amber-400' if online_eps|length else 'bg-red-400') }}"></span>
+                    <span class="text-xs font-semibold text-white/80 tabular-nums">{{ online_eps|length }}/{{ all_eps|length }}</span>
                 </span>
-                <!-- Hover detail: one line per endpoint currently serving. -->
+                <!-- Hover detail: one line per configured endpoint. -->
                 <div class="absolute top-full right-0 mt-2 hidden group-hover:block bg-slate-800 text-white text-[10px] p-2 rounded shadow-xl z-50 border border-slate-700 min-w-[220px] text-left normal-case tracking-normal">
-                    <div class="opacity-50 mb-1">Endpoints serving calls</div>
-                    {% for ep in used_eps %}
+                    <div class="opacity-50 mb-1">Configured LLM endpoints</div>
+                    {% for ep in sorted_eps %}
                     <div class="flex items-center gap-2 py-0.5">
                         <span class="w-1.5 h-1.5 rounded-full shrink-0 {{ 'bg-emerald-400' if ep.online else 'bg-red-400' }}"></span>
                         <span class="font-mono truncate">{{ ep.provider }} · {{ ep.model }}</span>
-                        <span class="opacity-50 ml-auto shrink-0">{{ (ep.runs ~ ' runs') if ep.runs else 'serving' }}</span>
+                        <span class="opacity-50 ml-auto shrink-0">{{ (ep.runs ~ ' runs') if ep.runs else ('serving' if ep.used else 'idle') }}</span>
                     </div>
                     {% endfor %}
                 </div>
                 {% else %}
-                <span class="text-[11px] text-white/40" title="No endpoint has served a call yet">—</span>
+                <span class="text-[11px] text-white/40" title="No LLM endpoints configured yet">—</span>
                 {% endif %}
                 {% else %}
-                {# Legacy fallback (no routable entries reported): collapse the
-                   configured slots to the same online/total count chip. #}
+                {# Startup-only fallback: fires just until connectivity_worker first
+                   populates llm_endpoints_online. Counts the legacy env-var slots,
+                   which now run 1-8 (code 1-4, log 5-6, review 7-8) — the old
+                   [1,2,3,4] literal under-reported an 8-slot config. Slots whose
+                   state keys are absent read as Undefined (falsy) and are skipped. #}
                 {% set slot_ns = namespace(total=0, online=0) %}
-                {% for n in [1, 2, 3, 4] %}
+                {% for n in [1, 2, 3, 4, 5, 6, 7, 8] %}
                 {% if state['provider_' ~ n ~ '_configured'] %}
                 {% set slot_ns.total = slot_ns.total + 1 %}
                 {% if state['provider_' ~ n ~ '_online'] %}{% set slot_ns.online = slot_ns.online + 1 %}{% endif %}

--- a/test_llm_credential_redaction.py
+++ b/test_llm_credential_redaction.py
@@ -78,6 +78,10 @@ def _load_ns():
     ns = {
         "logger": _NoLog(), "load_config": load_config, "save_config": save_config,
         "JSONResponse": _JSONResponse, "Request": _FakeRequest,
+        # Side-effect collaborator: the entry routes kick an endpoint re-probe so
+        # a newly added LLM shows in the header immediately. Stubbed out here —
+        # this test is about credential redaction, not connectivity probing.
+        "_refresh_llm_endpoints": lambda: None,
     }
     exec("\n\n".join(segs), ns)
     ns["_FakeRequest"] = _FakeRequest

--- a/test_model_registry.py
+++ b/test_model_registry.py
@@ -100,6 +100,25 @@ def main():
                 and reg.resolve("anthropic", "claude-sonnet-5", {})["cost_tier"] == "frontier"
                 and reg.resolve("anthropic", "claude-opus-4-8", {})["cost_tier"] == "frontier")
 
+    # --- copilot per-model ladder (Copilot is NOT free — premium request per
+    # call, multiplier is per-model: Opus 27x vs gpt-4o 0.33x) ---------------
+
+    ok &= _check("copilot opus/sonnet are frontier, haiku/gpt-4 are cheap",
+                reg.resolve("copilot", "claude-opus-4.6", {})["cost_tier"] == "frontier"
+                and reg.resolve("copilot", "claude-sonnet-4.6", {})["cost_tier"] == "frontier"
+                and reg.resolve("copilot", "claude-haiku-4.5", {})["cost_tier"] == "cheap"
+                and reg.resolve("copilot", "gpt-4o", {})["cost_tier"] == "cheap")
+    ok &= _check("copilot Opus is tiered the SAME as anthropic/claude_cli Opus (frontier+large)",
+                reg.resolve("copilot", "claude-opus-4.6", {})["cost_tier"]
+                == reg.resolve("anthropic", "claude-opus-4-8", {})["cost_tier"]
+                == reg.resolve("claude_cli", "opus", {})["cost_tier"] == "frontier"
+                and reg.resolve("copilot", "claude-opus-4.6", {})["max_complexity"] == "large")
+    ok &= _check("copilot gpt-5-mini (0.33x) stays cheap — 'gpt-5*mini*' outranks 'gpt-5*'",
+                reg.resolve("copilot", "gpt-5-mini", {})["cost_tier"] == "cheap"
+                and reg.resolve("copilot", "gpt-5", {})["cost_tier"] == "frontier")
+    ok &= _check("copilot is never 'free' — an unmatched model still falls back to cheap",
+                reg.resolve("copilot", "some-unknown-model", {})["cost_tier"] == "cheap")
+
     # --- _model_param_b / _complexity_from_param_b (ollama size derivation) -
 
     ok &= _check("_model_param_b parses 'qwen2.5-coder:14b' -> 14.0",
@@ -343,6 +362,31 @@ def main():
     _, cc_own_added = reg.upgrade_claude_cli_model_rules(cc_own)
     ok &= _check("claude_cli per-model top-up never overrides an operator's own (provider, match) rule",
                 "claude-cli-haiku" not in cc_own_added)
+
+    # --- upgrade_copilot_model_rules: an install frozen with only the generic
+    # copilot `*` rule priced Opus (27x premium request) as "cheap" ----------
+
+    frozen_copilot = [{"id": "copilot", "provider": "copilot", "match": "*",
+                       "cost_tier": "cheap", "max_complexity": "large",
+                       "context_window": 64000, "enabled": True}]
+    ok &= _check("frozen generic copilot rule mis-prices Opus as cheap (the bug)",
+                reg.resolve("copilot", "claude-opus-4.6",
+                            {"model_registry": frozen_copilot})["cost_tier"] == "cheap")
+    cp_top, cp_added = reg.upgrade_copilot_model_rules(frozen_copilot)
+    ok &= _check("copilot top-up injects the per-model rules into a frozen registry",
+                "copilot-opus" in cp_added
+                and reg.resolve("copilot", "claude-opus-4.6",
+                                {"model_registry": cp_top})["cost_tier"] == "frontier")
+    _, cp_added2 = reg.upgrade_copilot_model_rules(cp_top)
+    ok &= _check("copilot top-up is idempotent — a second run adds nothing", not cp_added2)
+    _, cp_default_added = reg.upgrade_copilot_model_rules(reg.DEFAULT_MODEL_RULES)
+    ok &= _check("DEFAULT_MODEL_RULES already ships the copilot ladder — top-up is a no-op",
+                not cp_default_added)
+    cp_own = [{"id": "my-copilot-opus", "provider": "copilot", "match": "*opus*",
+               "cost_tier": "cheap", "max_complexity": "small", "enabled": True}]
+    _, cp_own_added = reg.upgrade_copilot_model_rules(cp_own)
+    ok &= _check("copilot top-up never overrides an operator's own (provider, match) rule",
+                "copilot-opus" not in cp_own_added)
 
     # --- OpenRouter Free Models Router rule + upgrade_openrouter_free_router_rule ---
 

--- a/workers.py
+++ b/workers.py
@@ -22,6 +22,7 @@ import json
 import os
 import py_compile
 import requests
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -263,6 +264,31 @@ def _check_entries_online(config):
                     "base_url": base_url, "online": bool(online),
                     "used": bool(runs > 0 or is_active), "runs": runs})
     return out
+
+
+def refresh_llm_endpoints_async():
+    """Re-probe endpoints and refresh ``state["llm_endpoints_online"]`` now.
+
+    connectivity_worker only rebuilds that list every 15 minutes, so a newly
+    added LLM entry stayed absent from the header Providers chip until the next
+    tick — indistinguishable, to the user, from the new provider never having
+    registered at all. Called after any llm_entries create/update/delete so the
+    header reflects the change immediately.
+
+    Runs on a daemon thread: probing every endpoint is network I/O and must
+    never block the save request. Best-effort — a probe failure must not turn a
+    successful save into an error.
+    """
+    def _run():
+        try:
+            config = load_config()
+            endpoints = _check_entries_online(config)
+            state["llm_endpoints_online"] = endpoints
+            state["any_llm_online"] = any(e["online"] for e in endpoints)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"refresh_llm_endpoints_async failed: {e}")
+
+    threading.Thread(target=_run, daemon=True).start()
 
 
 def connectivity_worker():


### PR DESCRIPTION
Two independent fixes to how AppBuilder surfaces and prices LLM endpoints.

## 1. Newly added LLMs never appeared in the header "Providers" chip

Three compounding causes:

1. **The filter.** `templates/index.html` rendered `state.llm_endpoints_online | selectattr('used')`. `used` is computed in `workers._check_entries_online()` as `runs > 0 or is_active` — so a **just-added endpoint has zero runs and isn't currently serving, and was filtered out**. It looked identical to an endpoint that had never registered. This is the direct cause of the reported symptom.
2. **Staleness.** `state["llm_endpoints_online"]` is written *only* by `connectivity_worker`, which probes then `sleep(900)`. Nothing re-ran it on config change, so even after fixing (1) a new endpoint could take up to 15 minutes to show.
3. **Fallback slots.** The pre-first-probe fallback loop was hardcoded to slots `[1,2,3,4]` while `_ALL_SLOTS` covers 1–8, hiding log (5,6) and review (7,8) slot endpoints until the first tick.

**Fixes:** the chip now renders *every* configured endpoint (used-first, remainder labelled `idle`); `workers.refresh_llm_endpoints_async()` is called from the create/update/delete LLM entry routes so a save is reflected immediately; the fallback loop covers 1–8. The refresh is best-effort and lazily imported (`workers` imports `main`, so a module-level import would close an import cycle) and can never fail the save that triggered it.

## 2. Copilot Opus was priced "cheap"; it is the most expensive model in the roster

The registry had a **single** Copilot rule (`match: "*"`) tagging every Copilot model `cost_tier: cheap`. Copilot is not free — every call spends a premium request, and the multiplier is per-model: **Claude Opus 27x** vs **gpt-4o / gpt-5-mini 0.33x**. Collapsing that ~80x spread into one tier broke the picker in *both* directions, because the two orderings read `cost_tier` in opposite directions:

| ordering | frontier position | effect of tagging Opus `cheap` |
|---|---|---|
| `model_registry.COST_TIER_RANK` (default, cost-first) | **last** — frontier is reserved | Opus became eligible for trivial work: the priciest call, picked first |
| `model_selection._CAPABILITY_TIER_ORDER` (`prefer_capable=True`) | **first** | Opus ranked *below* real frontier models and was skipped for the hard jobs it exists for |

**Fix:** a per-model Copilot ladder mirroring the existing `claude_cli` and `anthropic` ladders — opus / sonnet / gemini-pro / gpt-5 are `frontier`+`large`; haiku / gpt-4\* / gpt-5-mini are `cheap`+`medium`. Copilot Opus now resolves to the **same `frontier`+`large` as `anthropic` and `claude_cli` Opus**. The generic `*` rule remains the fallback and stays `cheap` — **never `free`** — so an unrecognised Copilot model is still costed.

Precedence is by match specificity (non-wildcard character count), so `gpt-5*mini*` (9) beats `gpt-5*` (5) and gpt-5-mini correctly stays cheap.

### Migration
New defaults alone would **not** reach an existing install, whose rules are frozen into `config["model_registry"]`. `upgrade_copilot_model_rules()` is wired into the same three call sites as the `claude_cli` equivalent (`llm_migrate`, settings page render, settings save). Append-only, idempotent, and skips any rule the operator already curated for that `(provider, match)`. Shared append logic factored out of `upgrade_claude_cli_model_rules` into `_append_missing_default_rules`.

## Verification
- Providers chip reproduced and fixed under a Jinja render harness: old logic rendered `4/4` listing only the original four; new logic renders `5/6` listing all six, new ones marked `idle`.
- `test_model_registry.py`: **ALL CASES PASSED**, including 9 new cases covering the tier ladder, cross-provider Opus parity, the `gpt-5-mini` specificity conflict, "copilot is never free", and the frozen-registry migration (upgrade + idempotence + operator-override).
- Full `ab` self-test suite: 45 pass / 8 fail — the 8 failures verified pre-existing on `origin/main` (confirmed by stash).

## Deliberate non-changes
- **`supports_tools` left `False` for Copilot** even though `llm_client._request_copilot` fully implements tool calling (sets `payload["tools"]`, parses `tool_calls`). Flipping it would let the picker route tool work to Copilot, but the tool-calling-400 retry-without-tools fallback exists only on the legacy slot-based path, not the requirements path — so a failure there has no safety net. Worth a follow-up.
- **`context_window` kept at 64000** for Copilot Claude models (vs 200k direct): overstating a context window causes hard request failures, understating only wastes capacity.