### PR TITLE
Run model-registry top-ups on every boot; correct Ollama Cloud capabilities

### DIFF
--- a/llm_migrate.py
+++ b/llm_migrate.py
@@ -123,6 +123,77 @@ def _seed_registry_stubs(config):
     return len(seen), classified, len(seen) - classified
 
 
+def upgrade_registry(config):
+    """Apply every idempotent, append-only model_registry top-up to *config*.
+
+    Returns (config, changed). Split out of migrate() and called
+    UNCONDITIONALLY at startup, because migrate() short-circuits on
+    ``llm_config_version == CONFIG_VERSION`` — so on any already-migrated
+    install (i.e. every install after its first boot) these top-ups never ran.
+    That is why a registry frozen before a ladder existed kept resolving with
+    the stale tiers no matter how many times AppBuilder restarted.
+
+    Every helper here is append-only, idempotent, and skips rules the operator
+    curated themselves, so running this on every boot is safe.
+    """
+    if not isinstance(config, dict) or not isinstance(config.get("model_registry"), list):
+        return config, False
+    changed = False
+    # Local/free registry top-up: a config["model_registry"] frozen before a
+    # local/free provider gained its DEFAULT rule (the `ollama2` GPU-endpoint
+    # gap) would classify that endpoint as `unknown` instead of `free`.
+    # Idempotent + append-only; see model_registry.upgrade_local_free_rules.
+    _topped, _added = model_registry.upgrade_local_free_rules(config["model_registry"])
+    if _added:
+        config["model_registry"] = _topped
+        changed = True
+        logger.info("LLM registry: added missing local/free rules %s.", _added)
+    _topped, _added_cap = model_registry.upgrade_capable_local_rules(config["model_registry"])
+    if _added_cap:
+        config["model_registry"] = _topped
+        changed = True
+        logger.info("LLM registry: added capable self-hosted model rules %s.", _added_cap)
+    _repaired, _reclassified = model_registry.reclassify_claude_cli_paid(config["model_registry"])
+    if _reclassified:
+        config["model_registry"] = _repaired
+        changed = True
+        logger.info("LLM registry: reclassified claude_cli free -> frontier (bills the "
+                    "operator's Anthropic account).")
+    _topped, _added_cc = model_registry.upgrade_claude_cli_model_rules(config["model_registry"])
+    if _added_cc:
+        config["model_registry"] = _topped
+        changed = True
+        logger.info("LLM registry: added per-model claude_cli capability rules %s "
+                    "(Haiku=medium, Sonnet/Opus=large).", _added_cc)
+    _topped, _added_copilot = model_registry.upgrade_copilot_model_rules(config["model_registry"])
+    if _added_copilot:
+        config["model_registry"] = _topped
+        changed = True
+        logger.info("LLM registry: added per-model copilot capability rules %s "
+                    "(Opus/Sonnet/GPT-5=frontier, Haiku/GPT-4/mini=cheap).",
+                    _added_copilot)
+    _topped, _added_router = model_registry.upgrade_openrouter_free_router_rule(config["model_registry"])
+    if _added_router:
+        config["model_registry"] = _topped
+        changed = True
+        logger.info("LLM registry: added the OpenRouter Free Models Router rule "
+                    "(openrouter/free -> free tier).")
+
+    _topped, _added_oc = model_registry.upgrade_ollama_cloud_model_rules(config["model_registry"])
+    if _added_oc:
+        config["model_registry"] = _topped
+        changed = True
+        logger.info("LLM registry: added per-model ollama_cloud capability rules %s "
+                    "(nano/flash/20b=medium, ultra=large).", _added_oc)
+    _repaired, _oc_tools = model_registry.enable_ollama_cloud_tools(config["model_registry"])
+    if _oc_tools:
+        config["model_registry"] = _repaired
+        changed = True
+        logger.info("LLM registry: enabled supports_tools on the ollama_cloud rule "
+                    "(the client has always sent tools; the flag was wrong).")
+    return config, changed
+
+
 def migrate(config):
     """Upgrade *config* in place to schema version 2. Returns (config, changed)."""
     if not isinstance(config, dict):
@@ -149,40 +220,7 @@ def migrate(config):
     # llm_slots is fully consumed now.
     config.pop("llm_slots", None)
 
-    # Local/free registry top-up: a config["model_registry"] frozen before a
-    # local/free provider gained its DEFAULT rule (the `ollama2` GPU-endpoint
-    # gap) would classify that endpoint as `unknown` instead of `free`.
-    # Idempotent + append-only; see model_registry.upgrade_local_free_rules.
-    if isinstance(config.get("model_registry"), list):
-        _topped, _added = model_registry.upgrade_local_free_rules(config["model_registry"])
-        if _added:
-            config["model_registry"] = _topped
-            logger.info("LLM registry: added missing local/free rules %s during migration.", _added)
-        _topped, _added_cap = model_registry.upgrade_capable_local_rules(config["model_registry"])
-        if _added_cap:
-            config["model_registry"] = _topped
-            logger.info("LLM registry: added capable self-hosted model rules %s during migration.", _added_cap)
-        _repaired, _reclassified = model_registry.reclassify_claude_cli_paid(config["model_registry"])
-        if _reclassified:
-            config["model_registry"] = _repaired
-            logger.info("LLM registry: reclassified claude_cli free -> frontier (bills the "
-                        "operator's Anthropic account) during migration.")
-        _topped, _added_cc = model_registry.upgrade_claude_cli_model_rules(config["model_registry"])
-        if _added_cc:
-            config["model_registry"] = _topped
-            logger.info("LLM registry: added per-model claude_cli capability rules %s "
-                        "(Haiku=medium, Sonnet/Opus=large) during migration.", _added_cc)
-        _topped, _added_copilot = model_registry.upgrade_copilot_model_rules(config["model_registry"])
-        if _added_copilot:
-            config["model_registry"] = _topped
-            logger.info("LLM registry: added per-model copilot capability rules %s "
-                        "(Opus/Sonnet/GPT-5=frontier, Haiku/GPT-4/mini=cheap) during migration.",
-                        _added_copilot)
-        _topped, _added_router = model_registry.upgrade_openrouter_free_router_rule(config["model_registry"])
-        if _added_router:
-            config["model_registry"] = _topped
-            logger.info("LLM registry: added the OpenRouter Free Models Router rule "
-                        "(openrouter/free -> free tier) during migration.")
+    config, _ = upgrade_registry(config)
 
     # 6: capability seeding + one summary line.
     try:

--- a/main.py
+++ b/main.py
@@ -391,6 +391,17 @@ try:
     if _migrated:
         save_config(_cfg)
         logger.info("LLM config migrated to schema v2 and persisted.")
+    # Registry top-ups run UNCONDITIONALLY, outside migrate()'s version gate:
+    # migrate() short-circuits once llm_config_version == CONFIG_VERSION, so on
+    # every already-migrated install (i.e. every boot after the first) the
+    # top-ups nested inside it never executed. A registry frozen before a
+    # capability ladder shipped therefore kept resolving stale tiers — e.g.
+    # Copilot Opus staying "cheap" — no matter how often AppBuilder restarted.
+    # Each helper is append-only, idempotent, and skips operator-curated rules.
+    _cfg2, _upgraded = llm_migrate.upgrade_registry(_cfg)
+    if _upgraded:
+        save_config(_cfg2)
+        logger.info("LLM model registry topped up with new default rules and persisted.")
 except Exception as me:
     logger.warning(f"LLM config migration skipped (non-fatal): {me}")
 

--- a/model_registry.py
+++ b/model_registry.py
@@ -133,9 +133,19 @@ DEFAULT_MODEL_RULES = [
               "the default for feature_build and the hardest large agentic/mutating work"},
     {"id": "ollama-cloud", "provider": "ollama_cloud", "match": "*", "label": "Ollama Cloud",
      "cost_tier": "cheap", "max_complexity": "large", "context_window": 32768,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "the one ollama* provider that takes a key"},
+     "enabled": True,
+     "notes": "the one ollama* provider that takes a key. supports_tools=True: "
+              "_request_ollama sets payload['tools'] and parses tool_calls for cloud "
+              "exactly as for local (identical wire protocol), and every model in the "
+              "current cloud library is tool-native. context_window is deliberately "
+              "ollama_num_ctx (default 32768), NOT the model's advertised window: "
+              "_request_ollama sends options.num_ctx, so that is the real usable "
+              "window regardless of model capability. Raising this without raising "
+              "ollama_num_ctx would let the picker select this endpoint for a job "
+              "whose prompt then gets silently truncated -- context_window is a HARD "
+              "selection filter (see model_selection), not a prompt budget."},
     {"id": "openrouter-free", "provider": "openrouter", "match": "*:free", "label": "OpenRouter free models",
      "cost_tier": "free", "max_complexity": "medium", "context_window": 32768,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
@@ -299,6 +309,45 @@ DEFAULT_MODEL_RULES = [
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": True,
      "enabled": True, "notes": "capable reasoning + JSON; tools left off (Gemma native tool-calling is unreliable)"},
+    # --- Ollama Cloud per-model ladder ------------------------------------
+    # The generic ollama-cloud `*` rule gives EVERY cloud model max_complexity
+    # "large". That is right for the frontier-class cloud models (nemotron-3-
+    # ultra, the kimi-k2/k3 and deepseek-v4-pro class, mistral-large-3,
+    # qwen3.5) but wrong for the small/fast end of the library, which the `*`
+    # rule would otherwise let the picker choose for the hardest jobs. These
+    # rules only DOWNGRADE that end; the flagship models keep the `*` default.
+    # context_window stays at the generic ollama_num_ctx value on purpose --
+    # see the ollama-cloud rule's notes.
+    {"id": "ollama-cloud-nano", "provider": "ollama_cloud", "match": "*nano*",
+     "label": "Ollama Cloud (nano class)",
+     "cost_tier": "cheap", "max_complexity": "medium", "context_window": 32768,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "smallest cloud tier (e.g. nemotron-3-nano:30b) -- fast/cheap, not a large-job model"},
+    {"id": "ollama-cloud-flash", "provider": "ollama_cloud", "match": "*flash*",
+     "label": "Ollama Cloud (flash class)",
+     "cost_tier": "cheap", "max_complexity": "medium", "context_window": 32768,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "latency-optimised cloud variants (e.g. deepseek-v4-flash, glm-5.3-flash)"},
+    {"id": "ollama-cloud-20b", "provider": "ollama_cloud", "match": "*:20b*",
+     "label": "Ollama Cloud (20B class)",
+     "cost_tier": "cheap", "max_complexity": "medium", "context_window": 32768,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True, "notes": "e.g. gpt-oss:20b -- the small open-weight cloud tier"},
+    {"id": "ollama-cloud-ultra", "provider": "ollama_cloud", "match": "*ultra*",
+     "label": "Ollama Cloud (ultra class)",
+     "cost_tier": "cheap", "max_complexity": "large", "context_window": 32768,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
+     "enabled": True,
+     "notes": "nemotron-3-ultra: 550B total / 55B active MoE, explicitly built for "
+              "long-running agents across hundreds of tool calls. Stated as an explicit "
+              "rule (rather than inheriting `*`) so the flagship is not silently "
+              "downgraded if the generic cloud default is ever retuned. Cheap+large is "
+              "intentional: cost_tier tracks PRICE, not capability, so the cost-first "
+              "picker reaches this frontier-grade model early -- which is the point."},
 ]
 
 
@@ -508,6 +557,54 @@ def upgrade_copilot_model_rules(rules):
     upgrade — an operator's own copilot rule for the same match is left
     untouched."""
     return _append_missing_default_rules(rules, _COPILOT_MODEL_RULE_IDS)
+
+
+#: Per-model ollama_cloud capability rules (see DEFAULT_MODEL_RULES). Appended
+#: to an already-persisted registry so the small end of the cloud library
+#: (nano / flash / 20b) stops inheriting the generic `*` rule's "large"
+#: ceiling, and so the nemotron-3-ultra flagship is pinned explicitly.
+_OLLAMA_CLOUD_MODEL_RULE_IDS = frozenset({
+    "ollama-cloud-nano", "ollama-cloud-flash", "ollama-cloud-20b",
+    "ollama-cloud-ultra",
+})
+
+
+def upgrade_ollama_cloud_model_rules(rules):
+    """Return (new_rules, added_ids): a COPY of `rules` with any missing
+    per-model ollama_cloud rules (_OLLAMA_CLOUD_MODEL_RULE_IDS) appended.
+
+    Append-only and idempotent, exactly like the claude_cli and copilot
+    upgrades; an operator's own rule for the same (provider, match) wins."""
+    return _append_missing_default_rules(rules, _OLLAMA_CLOUD_MODEL_RULE_IDS)
+
+
+def enable_ollama_cloud_tools(rules):
+    """Return (new_rules, changed): a COPY of `rules` with the shipped
+    ollama_cloud rule's supports_tools flipped False -> True.
+
+    An append-only top-up cannot fix this: the stale flag lives ON the existing
+    "ollama-cloud" rule, so a frozen registry keeps claiming Ollama Cloud has
+    no tool support. That is factually wrong -- _request_ollama sets
+    payload["tools"] and parses tool_calls for the cloud endpoint over the same
+    wire protocol as the local one, and the current cloud library is tool-native
+    (nemotron-3-ultra is marketed for "hundreds of tool calls"). Left uncorrected
+    it makes model_selection filter Ollama Cloud out of every tool-requiring job.
+
+    Scoped deliberately narrowly: only the rule whose id is exactly
+    "ollama-cloud" (the one AppBuilder ships) AND whose supports_tools is still
+    False. An operator who added their own ollama_cloud rule, or who
+    deliberately turned tools off on some other rule, is left alone. Idempotent;
+    never reorders, adds, or removes rules."""
+    rules = list(rules or [])
+    changed = False
+    out = []
+    for r in rules:
+        if (isinstance(r, dict) and r.get("id") == "ollama-cloud"
+                and r.get("supports_tools") is False):
+            r = {**r, "supports_tools": True}
+            changed = True
+        out.append(r)
+    return out, changed
 
 
 def upgrade_openrouter_free_router_rule(rules):

--- a/routes.py
+++ b/routes.py
@@ -2092,6 +2092,8 @@ async def settings_page(request: Request):
     _curated, _mr_claude_paid = _registry.reclassify_claude_cli_paid(_curated)
     _curated, _mr_claude_models = _registry.upgrade_claude_cli_model_rules(_curated)
     _curated, _mr_copilot_models = _registry.upgrade_copilot_model_rules(_curated)
+    _curated, _mr_oc_models = _registry.upgrade_ollama_cloud_model_rules(_curated)
+    _curated, _mr_oc_tools = _registry.enable_ollama_cloud_tools(_curated)
     _curated, _mr_or_router = _registry.upgrade_openrouter_free_router_rule(_curated)
     _registry_rules_json = json.dumps(_curated, indent=2)
     _auto = config.get("model_registry_auto") or []
@@ -2500,6 +2502,10 @@ async def save_settings(request: Request):
             config_data["model_registry"], _ = _registry_save.upgrade_claude_cli_model_rules(
                 config_data["model_registry"])
             config_data["model_registry"], _ = _registry_save.upgrade_copilot_model_rules(
+                config_data["model_registry"])
+            config_data["model_registry"], _ = _registry_save.upgrade_ollama_cloud_model_rules(
+                config_data["model_registry"])
+            config_data["model_registry"], _ = _registry_save.enable_ollama_cloud_tools(
                 config_data["model_registry"])
             config_data["model_registry"], _ = _registry_save.upgrade_openrouter_free_router_rule(
                 config_data["model_registry"])

--- a/test_model_registry.py
+++ b/test_model_registry.py
@@ -388,6 +388,48 @@ def main():
     ok &= _check("copilot top-up never overrides an operator's own (provider, match) rule",
                 "copilot-opus" not in cp_own_added)
 
+    # --- ollama_cloud: tools flag + per-model ladder ------------------------
+
+    ok &= _check("ollama_cloud advertises tool support (the client has always sent tools)",
+                reg.resolve("ollama_cloud", "nemotron-3-ultra", {})["supports_tools"] is True)
+    ok &= _check("ollama_cloud small tiers are capped at medium; ultra stays large",
+                reg.resolve("ollama_cloud", "nemotron-3-nano:30b", {})["max_complexity"] == "medium"
+                and reg.resolve("ollama_cloud", "gpt-oss:20b", {})["max_complexity"] == "medium"
+                and reg.resolve("ollama_cloud", "glm-5.3-flash", {})["max_complexity"] == "medium"
+                and reg.resolve("ollama_cloud", "nemotron-3-ultra", {})["max_complexity"] == "large")
+    ok &= _check("ollama_cloud frontier-class models still inherit the generic large default",
+                reg.resolve("ollama_cloud", "kimi-k3", {})["max_complexity"] == "large"
+                and reg.resolve("ollama_cloud", "mistral-large-3:675b", {})["max_complexity"] == "large")
+    ok &= _check("ollama_cloud context_window stays pinned to ollama_num_ctx (32768), not the "
+                 "model's advertised window — it is a hard selection filter, not a prompt budget",
+                reg.resolve("ollama_cloud", "nemotron-3-ultra", {})["context_window"] == 32768)
+
+    frozen_oc = [{"id": "ollama-cloud", "provider": "ollama_cloud", "match": "*",
+                  "cost_tier": "cheap", "max_complexity": "large", "context_window": 32768,
+                  "supports_tools": False, "enabled": True}]
+    ok &= _check("a frozen ollama-cloud rule wrongly reports no tool support (the bug)",
+                reg.resolve("ollama_cloud", "nemotron-3-ultra",
+                            {"model_registry": frozen_oc})["supports_tools"] is False)
+    oc_fixed, oc_changed = reg.enable_ollama_cloud_tools(frozen_oc)
+    ok &= _check("enable_ollama_cloud_tools repairs the frozen rule in place",
+                oc_changed is True
+                and reg.resolve("ollama_cloud", "nemotron-3-ultra",
+                                {"model_registry": oc_fixed})["supports_tools"] is True)
+    _, oc_changed2 = reg.enable_ollama_cloud_tools(oc_fixed)
+    ok &= _check("enable_ollama_cloud_tools is idempotent", oc_changed2 is False)
+    oc_own = [{"id": "my-cloud", "provider": "ollama_cloud", "match": "*",
+               "supports_tools": False, "enabled": True}]
+    _, oc_own_changed = reg.enable_ollama_cloud_tools(oc_own)
+    ok &= _check("enable_ollama_cloud_tools leaves an operator's own ollama_cloud rule alone",
+                oc_own_changed is False)
+    oc_top, oc_added = reg.upgrade_ollama_cloud_model_rules(frozen_oc)
+    ok &= _check("ollama_cloud per-model top-up injects the ladder into a frozen registry",
+                "ollama-cloud-nano" in oc_added
+                and reg.resolve("ollama_cloud", "nemotron-3-nano:30b",
+                                {"model_registry": oc_top})["max_complexity"] == "medium")
+    _, oc_added2 = reg.upgrade_ollama_cloud_model_rules(oc_top)
+    ok &= _check("ollama_cloud per-model top-up is idempotent", not oc_added2)
+
     # --- OpenRouter Free Models Router rule + upgrade_openrouter_free_router_rule ---
 
     # Injected into a frozen config that predates the rule (append-only).


### PR DESCRIPTION
Follow-up to #19. Reported symptom: after adding new LLMs, the performance table still showed `copilot · claude-opus-5` and `claude-sonnet-5` as **cheap** despite the Copilot ladder having already merged.

## Root cause: the registry top-ups were dead code on every existing install

`llm_migrate.migrate()` early-returns when `llm_config_version == CONFIG_VERSION`, and **all six** `model_registry` top-ups lived *inside* it, after that gate. They therefore only ever ran during the one-time v1→v2 schema migration. On any install past its first boot the gate short-circuits and none of them execute — no matter how many restarts.

So a registry frozen before a ladder shipped keeps resolving stale tiers forever. The Copilot fix in #19 was correct but **unreachable**. The pre-existing `claude_cli`, capable-local and OpenRouter top-ups have been unreachable for the same reason.

Reproduced directly:

```
migrate changed = False          # version gate short-circuits
copilot rules after startup: ['copilot']
copilot/claude-opus-5 -> cheap
```

**Fix:** extracted the block into `llm_migrate.upgrade_registry(config) -> (config, changed)`, called from `main.py` **unconditionally**, outside the version gate, persisting when it reports a change. Every helper is append-only, idempotent and skips operator-curated rules, so per-boot execution is safe and a second run is a no-op (asserted).

## Ollama Cloud was described inaccurately

`supports_tools: False` — but `_request_ollama` sets `payload["tools"]` and parses `tool_calls` for the cloud endpoint over the *same wire protocol* as local. The client has always sent tools. The flag made `model_selection` filter Ollama Cloud out of **every** tool-requiring job — a real loss, since the current cloud library is tool-native and `nemotron-3-ultra` (550B total / 55B active MoE, per Ollama's model card) is explicitly built for long-running agents across *hundreds of tool calls*. That endpoint has the highest run count in the reported table.

Corrected to `True`, plus `enable_ollama_cloud_tools()` to repair already-frozen registries — an append-only top-up **cannot** fix a stale flag on an existing rule. Scoped narrowly to the shipped `ollama-cloud` rule with `supports_tools` still `False`, so operator rules are untouched.

The single `*` rule also gave *every* cloud model `max_complexity: large`. Added a per-model ladder capping nano / flash / `:20b` at `medium` while frontier-class models keep the large default, and pinned `nemotron-3-ultra` explicitly. Patterns were checked against the live `https://ollama.com/api/tags` lineup (18 models).

### `context_window` deliberately left at 32768
`_request_ollama` sends `options.num_ctx` (config `ollama_num_ctx`, default 32768), so that is the **real** usable window regardless of what the model advertises. `context_window` is a **hard selection filter** (`>= min_context_tokens * 1.25`), not a prompt budget — raising it alone would let the picker choose this endpoint for a job whose prompt is then silently truncated. Now documented in the rule so the two sides cannot be desynced by a well-meaning edit. See "Follow-ups" below.

## Verified against the reported table

| endpoint | before | after |
|---|---|---|
| `claude_cli · claude-opus-5` | frontier/large | unchanged ✅ |
| `google · gemini-3.5-flash-lite` | cheap/medium/tools | unchanged ✅ (1M ctx confirmed) |
| `ollama_cloud · nemotron-3-ultra` | cheap/large/**tools=False** | cheap/large/**tools=True** |
| `openrouter · openrouter/free` | free/medium | unchanged ✅ |
| `copilot · claude-haiku-4.5` | cheap/**large** | cheap/**medium** |
| `copilot · claude-sonnet-5` | **cheap**/large | **frontier**/large |
| `copilot · claude-opus-5` | **cheap**/large | **frontier**/large |
| `copilot · gpt-4o-2024-08-06` | cheap/**large** | cheap/**medium** |

- `test_model_registry.py`: **ALL CASES PASSED**, +12 new cases covering the tools repair (incl. idempotence and operator-override safety), the complexity ladder, and the pinned context window.
- Full `ab` suite: 45 pass / 8 fail — the same 8 failures verified pre-existing on `origin/main`.

## Follow-ups (not changed here)
- **Ollama Cloud context is capped at 3% of `nemotron-3-ultra`'s capability.** Its card advertises a 1M-token window; we request 32K. Unlocking it means raising `ollama_num_ctx` *and* the registry value together — ideally a cloud-specific default, since the local Ollama box shares this setting and 32K there is a deliberate memory choice. Worth doing, but it changes live inference parameters, so flagging rather than assuming.
- **Copilot `supports_tools` remains `False`** (unchanged from #19): `_request_copilot` implements tools, but the tool-calling-400 retry-without-tools fallback exists only on the legacy slot path (`_try_provider`), not the requirements path (`_try_candidate`) — confirmed again here.
- **`claude_cli` Opus 5 context is set to 200K** while the model supports 1M; the CLI session governs the real limit, and overstating a hard filter causes truncation, so it was left conservative.