### PR TITLE
Rank Opus above Sonnet with a within-tier capability axis

### DIFF
--- a/model_registry.py
+++ b/model_registry.py
@@ -61,8 +61,35 @@ COST_TIER_RANK = {"free": 0, "cheap": 1, "frontier": 2, "unknown": 3}
 _CAP_FIELDS = (
     "cost_tier", "max_complexity", "context_window", "supports_tools",
     "native_agentic_tools", "supports_mutating_agent", "supports_structured_output",
-    "supports_batch", "supports_streaming",
+    "supports_batch", "supports_streaming", "capability_rank",
 )
+
+#: Fallback `capability_rank` derived from max_complexity, for any rule that
+#: predates the field (operator-authored rules, auto-discovery stubs). Keeps an
+#: un-ranked registry behaving exactly as it did before the field existed.
+_CAPABILITY_RANK_BY_COMPLEXITY = {"trivial": 10, "small": 30, "medium": 50, "large": 70}
+
+#: Neither cost_tier nor max_complexity can express "Opus is stronger than
+#: Sonnet": both are `frontier`/`large`, and eight default rules collapse onto
+#: that same pair. Tier decides WHICH BUDGET to spend and max_complexity is a
+#: HARD filter (raise it and a model is excluded from work it could do), so
+#: neither can carry a within-tier ordering. `capability_rank` is that missing
+#: axis: 0-100, higher = smarter, compared ONLY between models already in the
+#: same tier. It is a pure ranking hint — it never filters, so a wrong value
+#: costs ordering, never availability.
+#:
+#: Deliberately NOT the premium-request multiplier: that would rank GPT-5.5
+#: (57x) above Opus (27x), which is a price signal, not a capability one.
+def capability_rank(caps):
+    """The 0-100 within-tier capability score for a resolved capability dict.
+
+    Falls back to a max_complexity-derived default when the rule carries no
+    explicit rank, so a registry written before this field existed keeps its
+    previous relative ordering instead of collapsing to zero."""
+    raw = (caps or {}).get("capability_rank")
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return _CAPABILITY_RANK_BY_COMPLEXITY.get((caps or {}).get("max_complexity"), 0)
+    return max(0, min(100, int(raw)))
 
 # A model that matches no curated rule at all — sorts LAST on cost (after
 # frontier) so it's genuinely last-resort, but starts at max_complexity=
@@ -100,7 +127,7 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "enabled": True,
+     "capability_rank": 70, "enabled": True,
      "notes": "session auth (no API key), but every call bills the operator's Anthropic "
               "account — cost_tier=frontier so the picker RESERVES it (free/GPU wins first, "
               "claude_cli is used only when a call needs its native_agentic_tools/"
@@ -116,19 +143,19 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "small", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "enabled": True,
+     "capability_rank": 55, "enabled": True,
      "notes": "fastest/cheapest Claude — capped at small so it handles light agentic/tool "
               "work; medium escalates to Sonnet and large/feature_build to Opus"},
     {"id": "claude-cli-sonnet", "provider": "claude_cli", "match": "*sonnet*", "label": "Claude Sonnet (via CLI)",
      "cost_tier": "frontier", "max_complexity": "medium", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "enabled": True, "notes": "balanced Claude — medium agentic/mutating work; large escalates to Opus"},
+     "capability_rank": 78, "enabled": True, "notes": "balanced Claude — medium agentic/mutating work; large escalates to Opus"},
     {"id": "claude-cli-opus", "provider": "claude_cli", "match": "*opus*", "label": "Claude Opus (via CLI)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "enabled": True,
+     "capability_rank": 95, "enabled": True,
      "notes": "most capable Claude — the ONLY claude_cli model at large complexity, so it is "
               "the default for feature_build and the hardest large agentic/mutating work"},
     {"id": "ollama-cloud", "provider": "ollama_cloud", "match": "*", "label": "Ollama Cloud",
@@ -192,7 +219,7 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True,
+     "capability_rank": 95, "enabled": True,
      "notes": "27x premium-request multiplier — the most expensive model Copilot serves. "
               "frontier/large matches anthropic-opus and claude-cli-opus so the picker "
               "RESERVES it for the hardest work instead of spending it on triage."},
@@ -200,49 +227,49 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "9x multiplier; frontier/large mirrors anthropic-sonnet"},
+     "capability_rank": 78, "enabled": True, "notes": "9x multiplier; frontier/large mirrors anthropic-sonnet"},
     {"id": "copilot-haiku", "provider": "copilot", "match": "*haiku*", "label": "Claude Haiku (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "0.33x multiplier; cheap/medium mirrors anthropic-haiku"},
+     "capability_rank": 55, "enabled": True, "notes": "0.33x multiplier; cheap/medium mirrors anthropic-haiku"},
     {"id": "copilot-gemini-pro", "provider": "copilot", "match": "*gemini*pro*", "label": "Gemini Pro (via Copilot)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "6x multiplier; frontier/large mirrors google-pro"},
+     "capability_rank": 80, "enabled": True, "notes": "6x multiplier; frontier/large mirrors google-pro"},
     # `gpt-5*mini*` is deliberately MORE specific than `gpt-5*` so gpt-5-mini
     # (0.33x) stays cheap instead of inheriting the gpt-5 frontier tier.
     {"id": "copilot-gpt5-mini", "provider": "copilot", "match": "gpt-5*mini*", "label": "GPT-5 mini (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "0.33x multiplier — the cheapest GPT-5 variant"},
+     "capability_rank": 50, "enabled": True, "notes": "0.33x multiplier — the cheapest GPT-5 variant"},
     {"id": "copilot-gpt5", "provider": "copilot", "match": "gpt-5*", "label": "GPT-5 class (via Copilot)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "6x base / 57x for GPT-5.5 — priced as frontier so it is reserved"},
+     "capability_rank": 85, "enabled": True, "notes": "6x base / 57x for GPT-5.5 — priced as frontier so it is reserved"},
     {"id": "copilot-gpt4", "provider": "copilot", "match": "gpt-4*", "label": "GPT-4 class (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "0.33x multiplier (gpt-4o / gpt-4o-mini)"},
+     "capability_rank": 45, "enabled": True, "notes": "0.33x multiplier (gpt-4o / gpt-4o-mini)"},
     {"id": "anthropic-haiku", "provider": "anthropic", "match": "*haiku*", "label": "Claude Haiku class",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 200000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "capability_rank": 55, "enabled": True, "notes": ""},
     {"id": "anthropic-sonnet", "provider": "anthropic", "match": "*sonnet*", "label": "Claude Sonnet class",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "capability_rank": 78, "enabled": True, "notes": ""},
     {"id": "anthropic-opus", "provider": "anthropic", "match": "*opus*", "label": "Claude Opus class",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "capability_rank": 95, "enabled": True, "notes": ""},
     {"id": "google-flash", "provider": "google", "match": "*flash*", "label": "Gemini Flash class",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 1000000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
@@ -252,7 +279,7 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 2000000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": False,
-     "enabled": True, "notes": "supports_streaming=False -- _request_google hardcodes stream=False"},
+     "capability_rank": 80, "enabled": True, "notes": "supports_streaming=False -- _request_google hardcodes stream=False"},
     {"id": "openai-mini", "provider": "openai", "match": "*mini*", "label": "OpenAI mini class",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 128000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
@@ -262,7 +289,7 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 128000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "capability_rank": 85, "enabled": True, "notes": ""},
 
     # --- Capable self-hosted models -------------------------------------
     # The generic `ollama`/`ollama2` defaults are deliberately conservative

--- a/model_selection.py
+++ b/model_selection.py
@@ -177,7 +177,20 @@ def _rank_tier(tier_candidates, perf, reqs, min_samples):
             if registry.is_nokey_provider(s["c"].get("provider")):
                 s["score"] -= _LOCAL_OFFLOAD_PENALTY
 
-    stats.sort(key=lambda s: s["score"], reverse=True)
+    # Capability ordering. Perf scores are min-max normalised WITHIN the tier,
+    # so between two candidates the faster one takes 1.0 and the slower 0.0 —
+    # a full-range gap that no additive bonus could ever overcome. Copilot Opus
+    # and Sonnet are both frontier/large, so before this the tier was ordered on
+    # speed alone and Sonnet (much faster) always beat Opus for exactly the hard
+    # work Opus is reserved for. When the caller explicitly asked for the
+    # smartest option, capability is therefore the PRIMARY key and perf only
+    # breaks ties within an equal rank. Left off the default path on purpose:
+    # ordinary work should still take the fastest model in the chosen tier.
+    if reqs.prefer_capable:
+        stats.sort(key=lambda s: (registry.capability_rank(s["c"].get("caps") or {}), s["score"]),
+                   reverse=True)
+    else:
+        stats.sort(key=lambda s: s["score"], reverse=True)
     return stats
 
 

--- a/test_model_registry.py
+++ b/test_model_registry.py
@@ -9,6 +9,7 @@ Standalone: imports only model_registry (no app/main init).
 import sys
 
 import model_registry as reg
+import model_selection as sel
 
 
 def _check(label, cond):
@@ -464,6 +465,57 @@ def main():
     ok &= _check("post-top-up, openrouter/free resolves free (offload prefers it over the GPU)",
                 reg.resolve("openrouter", "openrouter/free", {"model_registry": routed})["cost_tier"]
                     == "free")
+
+    # ---------------------------------------------------------- capability_rank
+    # cost_tier and max_complexity cannot express "Opus beats Sonnet": both are
+    # frontier/large. capability_rank is the within-tier ordering axis.
+    _cfg = {}
+    _rank = lambda p, m: reg.capability_rank(reg.resolve(p, m, _cfg))
+    for _p in ("copilot", "anthropic", "claude_cli"):
+        ok &= _check(f"{_p}: Opus outranks Sonnet on capability_rank",
+                    _rank(_p, "claude-opus-5") > _rank(_p, "claude-sonnet-5"))
+    ok &= _check("Opus carries the SAME capability_rank whichever provider serves it",
+                len({_rank(p, "claude-opus-5")
+                     for p in ("copilot", "anthropic", "claude_cli")}) == 1)
+    ok &= _check("Opus is the ceiling — no default rule outranks it",
+                max(reg.capability_rank(r) for r in reg.DEFAULT_MODEL_RULES)
+                    == _rank("copilot", "claude-opus-5"))
+    ok &= _check("capability_rank never exceeds a cheaper tier's job: it is compared "
+                "only within a tier, so Opus stays frontier (reserved), not promoted",
+                reg.resolve("copilot", "claude-opus-5", _cfg)["cost_tier"] == "frontier")
+    # Backward compatibility: a rule written before the field existed must keep
+    # its previous relative order rather than collapsing to zero.
+    ok &= _check("a rule with no capability_rank falls back to a max_complexity default",
+                reg.capability_rank({"max_complexity": "large"}) >
+                reg.capability_rank({"max_complexity": "medium"}) >
+                reg.capability_rank({"max_complexity": "trivial"}))
+    ok &= _check("a non-numeric/bool capability_rank falls back rather than crashing",
+                reg.capability_rank({"max_complexity": "large", "capability_rank": True})
+                    == reg.capability_rank({"max_complexity": "large"})
+                and reg.capability_rank({"max_complexity": "large",
+                                         "capability_rank": "high"})
+                    == reg.capability_rank({"max_complexity": "large"}))
+    ok &= _check("capability_rank is clamped to 0..100",
+                reg.capability_rank({"capability_rank": 999}) == 100
+                and reg.capability_rank({"capability_rank": -5}) == 0)
+
+    # The behaviour the axis exists for. Perf scores are min-max normalised
+    # within a tier, so the faster model takes the full 1.0 and the slower 0.0:
+    # before capability became the primary key, Sonnet's speed always beat Opus
+    # for precisely the hard work Opus is reserved for.
+    _cands = [{"key": f"copilot|x|{m}", "provider": "copilot", "model": m,
+               "caps": reg.resolve("copilot", m, _cfg), "available": True}
+              for m in ("claude-sonnet-5", "claude-opus-5")]
+    _perf = {"copilot|x|claude-sonnet-5": {"n": 50, "tps": 80.0, "latency_ms": 4411},
+             "copilot|x|claude-opus-5":   {"n": 50, "tps": 20.0, "latency_ms": 7414}}
+    def _pick(pc):
+        got = sel.select_model(
+            sel.LlmRequirements(complexity="large", prefer_capable=pc), _cands, _perf)
+        return getattr(got, "model", None)
+    ok &= _check("prefer_capable picks Opus over a MUCH faster Sonnet in the same tier",
+                _pick(True) == "claude-opus-5")
+    ok &= _check("without prefer_capable the tier is still ordered on speed (Sonnet wins)",
+                _pick(False) == "claude-sonnet-5")
 
     print()
     if ok:


### PR DESCRIPTION
You were right that Opus and Sonnet shared a categorization — both resolve to `frontier`/`large`. Eight of the default rules collapse onto that same pair.

### It wasn't just a cosmetic tie

Within a tier, `_rank_tier` scores **purely on throughput and latency**, and those scores are min-max normalised across the tier's candidates — so between two models the faster one takes `1.0` and the slower `0.0`. Sonnet is ~2x faster than Opus, so it won the **full range** every time and was picked for exactly the hard work Opus is reserved for. No additive bonus could fix that; a full-range gap always dominates.

### Why a new axis was needed

- `cost_tier` decides *which budget to spend* — both are `frontier`.
- `max_complexity` is a **hard filter** (`have >= need`), so ranking Opus above Sonnet there would **exclude** Sonnet from work it can do. `claude_cli`'s ladder already leans on this (`sonnet=medium`), which is why claude_cli Sonnet silently fails any `complexity="large"` request.

So: `capability_rank`, 0–100, compared **only within a tier**. A pure ranking hint that never filters — a wrong value costs ordering, never availability.

| model | rank |
|---|---|
| **Opus** (copilot / anthropic / claude_cli) | **95** |
| GPT-5 class | 85 |
| Gemini Pro | 80 |
| Sonnet | 78 |

Identical across providers, so one model ranks the same whoever serves it. Deliberately **not** the premium-request multiplier — that ranks GPT-5.5 (57x) above Opus (27x), a price signal rather than a capability one.

### Picker

Capability is the primary sort key **only** under `prefer_capable` (the planner turn asking for the smartest option); perf breaks ties at equal rank. Ordinary work is untouched and still takes the fastest model in its tier. `_apply_exhaustion` still runs after, so a pathologically slow Opus is dropped and falls through as before.

Rules predating the field fall back to a `max_complexity`-derived rank, so operator-authored and auto-discovered registries keep their previous order.

### Verified

```
prefer_capable=True  -> claude-opus-5     (despite 7414ms vs 4411ms)
prefer_capable=False -> claude-sonnet-5   (fast path preserved)
```

12 new cases. Full suite **53 pass / 0 fail**.