### PR TITLE
Stop max_complexity caps hard-excluding claude_cli Sonnet and Haiku

### DIFF
--- a/llm_migrate.py
+++ b/llm_migrate.py
@@ -191,6 +191,13 @@ def upgrade_registry(config):
         changed = True
         logger.info("LLM registry: enabled supports_tools on the ollama_cloud rule "
                     "(the client has always sent tools; the flag was wrong).")
+    _ranked, _ranks = model_registry.backfill_capability_ranks(config["model_registry"])
+    if _ranks:
+        config["model_registry"] = _ranked
+        changed = True
+        logger.info("LLM registry: backfilled capability_rank and lifted the claude_cli "
+                    "sonnet/haiku max_complexity caps (Opus now outranks Sonnet within "
+                    "the frontier tier instead of losing to it on raw speed).")
     return config, changed
 
 

--- a/model_registry.py
+++ b/model_registry.py
@@ -140,17 +140,23 @@ DEFAULT_MODEL_RULES = [
     # for feature_build and any large agentic/mutating task). More-specific
     # match beats the generic `*` above.
     {"id": "claude-cli-haiku", "provider": "claude_cli", "match": "*haiku*", "label": "Claude Haiku (via CLI)",
-     "cost_tier": "frontier", "max_complexity": "small", "context_window": 200000,
-     "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
-     "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "capability_rank": 55, "enabled": True,
-     "notes": "fastest/cheapest Claude — capped at small so it handles light agentic/tool "
-              "work; medium escalates to Sonnet and large/feature_build to Opus"},
-    {"id": "claude-cli-sonnet", "provider": "claude_cli", "match": "*sonnet*", "label": "Claude Sonnet (via CLI)",
      "cost_tier": "frontier", "max_complexity": "medium", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "capability_rank": 78, "enabled": True, "notes": "balanced Claude — medium agentic/mutating work; large escalates to Opus"},
+     "capability_rank": 55, "enabled": True,
+     "notes": "fastest Claude; medium mirrors anthropic-haiku. Preference for Sonnet/Opus "
+              "is carried by capability_rank (55 < 78 < 95) rather than a max_complexity "
+              "cap, which would hard-exclude it rather than rank it last"},
+    {"id": "claude-cli-sonnet", "provider": "claude_cli", "match": "*sonnet*", "label": "Claude Sonnet (via CLI)",
+     "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
+     "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
+     "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
+     "capability_rank": 78, "enabled": True,
+     "notes": "balanced Claude; large mirrors anthropic-sonnet. Escalation to Opus is "
+              "expressed by capability_rank (95 > 78), NOT by capping max_complexity — "
+              "that is a hard filter, so the cap EXCLUDED Sonnet from large work instead "
+              "of ranking it second, and a claude_cli-only install had nothing left to "
+              "escalate TO"},
     {"id": "claude-cli-opus", "provider": "claude_cli", "match": "*opus*", "label": "Claude Opus (via CLI)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
@@ -634,6 +640,54 @@ def enable_ollama_cloud_tools(rules):
             r = {**r, "supports_tools": True}
             changed = True
         out.append(r)
+    return out, changed
+
+
+def backfill_capability_ranks(rules):
+    """Return (new_rules, changed): a COPY of `rules` with `capability_rank`
+    backfilled onto the shipped default rules, and the two claude_cli
+    max_complexity caps corrected.
+
+    An append-only top-up cannot do either job -- both live ON rules an existing
+    install already persisted, so a frozen registry would keep ordering the
+    frontier tier on raw speed (Sonnet beating Opus for the hardest work, since
+    within-tier perf scores are min-max normalised and the faster model takes
+    the whole range).
+
+    The max_complexity repair matters more than the ordering. claude_cli Sonnet
+    shipped capped at "medium" and Haiku at "small" to express "escalate to
+    Opus", but max_complexity is a HARD filter -- so the cap did not rank them
+    lower, it removed them. On a claude_cli-only install (session auth, no API
+    keys) a complexity="large" request matched NOTHING and select_model returned
+    None: there was no Opus to escalate to. capability_rank now carries that
+    preference without costing availability.
+
+    Scoped narrowly, exactly like enable_ollama_cloud_tools: only rules whose id
+    is one AppBuilder ships, only where the value still matches the stale
+    default we are replacing. An operator's own rule, or one they have already
+    retuned, is left untouched. Idempotent; never reorders, adds or removes."""
+    shipped_ranks = {r.get("id"): r.get("capability_rank")
+                     for r in DEFAULT_MODEL_RULES if r.get("capability_rank") is not None}
+    # (rule id -> the stale value we replace) — only corrected if unchanged.
+    stale_complexity = {"claude-cli-sonnet": ("medium", "large"),
+                        "claude-cli-haiku": ("small", "medium")}
+    out = []
+    changed = False
+    for r in rules or []:
+        if not isinstance(r, dict):
+            out.append(r)
+            continue
+        rid = r.get("id")
+        new = r
+        if rid in shipped_ranks and new.get("capability_rank") is None:
+            new = {**new, "capability_rank": shipped_ranks[rid]}
+            changed = True
+        if rid in stale_complexity:
+            was, now = stale_complexity[rid]
+            if new.get("max_complexity") == was:
+                new = {**new, "max_complexity": now}
+                changed = True
+        out.append(new)
     return out, changed
 
 

--- a/model_selection.py
+++ b/model_selection.py
@@ -182,11 +182,19 @@ def _rank_tier(tier_candidates, perf, reqs, min_samples):
     # a full-range gap that no additive bonus could ever overcome. Copilot Opus
     # and Sonnet are both frontier/large, so before this the tier was ordered on
     # speed alone and Sonnet (much faster) always beat Opus for exactly the hard
-    # work Opus is reserved for. When the caller explicitly asked for the
-    # smartest option, capability is therefore the PRIMARY key and perf only
-    # breaks ties within an equal rank. Left off the default path on purpose:
-    # ordinary work should still take the fastest model in the chosen tier.
-    if reqs.prefer_capable:
+    # work Opus is reserved for.
+    #
+    # Capability therefore becomes the PRIMARY key for demanding work, with perf
+    # only breaking ties at equal rank. "Demanding" is either an explicit
+    # prefer_capable (the planner/router turn) or complexity="large" — the
+    # latter is what keeps feature_build landing on Opus now that the strength
+    # ladder is expressed as a rank instead of as a max_complexity cap that
+    # hard-excluded the smaller models.
+    #
+    # Everything below large still orders on speed, so light work keeps taking
+    # the fastest model in its tier rather than reaching for the smartest.
+    demanding = reqs.prefer_capable or reqs.complexity == "large"
+    if demanding:
         stats.sort(key=lambda s: (registry.capability_rank(s["c"].get("caps") or {}), s["score"]),
                    reverse=True)
     else:

--- a/routes.py
+++ b/routes.py
@@ -2095,6 +2095,7 @@ async def settings_page(request: Request):
     _curated, _mr_oc_models = _registry.upgrade_ollama_cloud_model_rules(_curated)
     _curated, _mr_oc_tools = _registry.enable_ollama_cloud_tools(_curated)
     _curated, _mr_or_router = _registry.upgrade_openrouter_free_router_rule(_curated)
+    _curated, _mr_ranks = _registry.backfill_capability_ranks(_curated)
     _registry_rules_json = json.dumps(_curated, indent=2)
     _auto = config.get("model_registry_auto") or []
     _registry_preview = (
@@ -2508,6 +2509,8 @@ async def save_settings(request: Request):
             config_data["model_registry"], _ = _registry_save.enable_ollama_cloud_tools(
                 config_data["model_registry"])
             config_data["model_registry"], _ = _registry_save.upgrade_openrouter_free_router_rule(
+                config_data["model_registry"])
+            config_data["model_registry"], _ = _registry_save.backfill_capability_ranks(
                 config_data["model_registry"])
 
     config_data["feature_build_timeout_s"] = int(data.get("feature_build_timeout_s")) \

--- a/test_model_registry.py
+++ b/test_model_registry.py
@@ -317,20 +317,32 @@ def main():
                 op_changed is False and op_out[0]["cost_tier"] == "cheap")
 
     # --- per-model claude_cli rules: a strength ladder (Haiku<Sonnet<Opus) ----
-    ok &= _check("claude_cli Haiku resolves to small (the light/cheap model)",
-                reg.resolve("claude_cli", "claude-haiku-4-5-20251001", {})["max_complexity"] == "small")
-    ok &= _check("claude_cli Sonnet resolves to medium (balanced)",
-                reg.resolve("claude_cli", "claude-sonnet-4-6", {})["max_complexity"] == "medium")
+    # The ladder is now carried by capability_rank, NOT by capping
+    # max_complexity. The cap was a hard filter, so it excluded Haiku/Sonnet
+    # from work they can do instead of ranking them below Opus — and on a
+    # claude_cli-only install that left complexity="large" with no candidate
+    # at all. Both now report their honest ceiling and mirror their anthropic
+    # twins; ordering is asserted via capability_rank below.
+    ok &= _check("claude_cli Haiku reports its honest ceiling (medium, mirrors anthropic-haiku)",
+                reg.resolve("claude_cli", "claude-haiku-4-5-20251001", {})["max_complexity"] == "medium")
+    ok &= _check("claude_cli Sonnet reports its honest ceiling (large, mirrors anthropic-sonnet)",
+                reg.resolve("claude_cli", "claude-sonnet-4-6", {})["max_complexity"] == "large")
+    ok &= _check("the Haiku<Sonnet<Opus ladder survives as capability_rank",
+                reg.capability_rank(reg.resolve("claude_cli", "claude-haiku-4-5-20251001", {}))
+                < reg.capability_rank(reg.resolve("claude_cli", "claude-sonnet-4-6", {}))
+                < reg.capability_rank(reg.resolve("claude_cli", "claude-opus-5", {})))
     ok &= _check("claude_cli Opus resolves to large (the hardest-work default)",
                 reg.resolve("claude_cli", "claude-opus-5", {})["max_complexity"] == "large")
     ok &= _check("an unrecognized claude_cli model falls back to the generic rule (large)",
                 reg.resolve("claude_cli", "claude-future-99", {})["max_complexity"] == "large")
     _h = reg.resolve("claude_cli", "claude-haiku-4-5-20251001", {})
-    ok &= _check("Haiku keeps the agentic caps (mutating agent) while capped at small",
+    ok &= _check("Haiku keeps the agentic caps (mutating agent)",
                 _h["supports_mutating_agent"] is True and _h["cost_tier"] == "frontier")
 
-    # feature_build (large + mutating) must escalate to Opus — Haiku (small) and
-    # Sonnet (medium) are both below the large ceiling, so only Opus qualifies.
+    # feature_build (large + mutating) must still escalate to Opus. This used to
+    # fall out of the hard complexity filter (only Opus was "large"); now all
+    # three qualify, and Opus wins because complexity="large" makes
+    # capability_rank the primary ordering key in _rank_tier.
     import model_selection as _sel
     def _cc_cand(m):
         return {"key": ("claude_cli", "", m), "provider": "claude_cli", "model": m,
@@ -353,9 +365,13 @@ def main():
     cc_top, cc_added = reg.upgrade_claude_cli_model_rules(frozen_generic)
     ok &= _check("claude_cli per-model top-up appends Haiku/Sonnet/Opus to a generic-only config",
                 set(cc_added) == {"claude-cli-haiku", "claude-cli-sonnet", "claude-cli-opus"})
-    ok &= _check("after top-up, Haiku resolves to small via the frozen config",
+    ok &= _check("after top-up, Haiku resolves via the frozen config and ranks below Opus",
                 reg.resolve("claude_cli", "claude-haiku-4-5-20251001",
-                            {"model_registry": cc_top})["max_complexity"] == "small")
+                            {"model_registry": cc_top})["max_complexity"] == "medium"
+                and reg.capability_rank(reg.resolve("claude_cli", "claude-haiku-4-5-20251001",
+                                                    {"model_registry": cc_top}))
+                    < reg.capability_rank(reg.resolve("claude_cli", "claude-opus-5",
+                                                      {"model_registry": cc_top})))
     _, cc_added2 = reg.upgrade_claude_cli_model_rules(cc_top)
     ok &= _check("claude_cli per-model top-up is idempotent — a second run adds nothing", cc_added2 == [])
     cc_own = [{"id": "my-haiku", "provider": "claude_cli", "match": "*haiku*", "cost_tier": "frontier",
@@ -508,14 +524,65 @@ def main():
               for m in ("claude-sonnet-5", "claude-opus-5")]
     _perf = {"copilot|x|claude-sonnet-5": {"n": 50, "tps": 80.0, "latency_ms": 4411},
              "copilot|x|claude-opus-5":   {"n": 50, "tps": 20.0, "latency_ms": 7414}}
-    def _pick(pc):
+    def _pick(complexity, pc):
         got = sel.select_model(
-            sel.LlmRequirements(complexity="large", prefer_capable=pc), _cands, _perf)
+            sel.LlmRequirements(complexity=complexity, prefer_capable=pc), _cands, _perf)
         return getattr(got, "model", None)
     ok &= _check("prefer_capable picks Opus over a MUCH faster Sonnet in the same tier",
-                _pick(True) == "claude-opus-5")
-    ok &= _check("without prefer_capable the tier is still ordered on speed (Sonnet wins)",
-                _pick(False) == "claude-sonnet-5")
+                _pick("medium", True) == "claude-opus-5")
+    ok &= _check("complexity=large alone also reaches for Opus (no prefer_capable needed)",
+                _pick("large", False) == "claude-opus-5")
+    # Below "large" and without prefer_capable, light work must still take the
+    # fastest model in the tier rather than reaching for the smartest.
+    ok &= _check("ordinary (non-large) work is still ordered on speed — Sonnet wins",
+                _pick("medium", False) == "claude-sonnet-5")
+
+    # capability_rank replaced max_complexity as the escalation mechanism. The
+    # cap was a HARD filter, so it EXCLUDED claude_cli Sonnet/Haiku from work
+    # they can do rather than ranking them second — and on a claude_cli-only
+    # install (session auth, no API keys) there was no Opus to escalate TO.
+    _cc = lambda m: {"key": f"claude_cli|x|{m}", "provider": "claude_cli", "model": m,
+                     "caps": reg.resolve("claude_cli", m, _cfg), "available": True}
+    ok &= _check("claude_cli Sonnet is no longer hard-excluded from complexity=large",
+                getattr(sel.select_model(sel.LlmRequirements(complexity="large"),
+                                         [_cc("claude-sonnet-5")], {}), "model", None)
+                    == "claude-sonnet-5")
+    ok &= _check("escalation still lands on Opus when it IS available",
+                getattr(sel.select_model(
+                    sel.LlmRequirements(complexity="large", prefer_capable=True),
+                    [_cc("claude-sonnet-5"), _cc("claude-haiku-4.5"), _cc("claude-opus-5")],
+                    {}), "model", None) == "claude-opus-5")
+
+    # Backfill migration: the ranks and the two lifted caps live ON rules an
+    # existing install already persisted, so an append-only top-up can't do it.
+    _frozen = [dict(r) for r in reg.DEFAULT_MODEL_RULES]
+    for _r in _frozen:
+        _r.pop("capability_rank", None)
+        if _r.get("id") == "claude-cli-sonnet":
+            _r["max_complexity"] = "medium"
+        if _r.get("id") == "claude-cli-haiku":
+            _r["max_complexity"] = "small"
+    _fixed, _bf = reg.backfill_capability_ranks(_frozen)
+    _, _bf2 = reg.backfill_capability_ranks(_fixed)
+    _byid = {r["id"]: r for r in _fixed}
+    ok &= _check("backfill repairs a frozen pre-capability_rank registry", _bf is True)
+    ok &= _check("backfill is idempotent — a second run changes nothing", _bf2 is False)
+    ok &= _check("backfill lifts the claude_cli sonnet/haiku max_complexity caps",
+                _byid["claude-cli-sonnet"]["max_complexity"] == "large"
+                and _byid["claude-cli-haiku"]["max_complexity"] == "medium")
+    ok &= _check("backfill restores Opus to the top rank on a frozen registry",
+                _byid["copilot-opus"]["capability_rank"] == 95)
+    ok &= _check("backfill never adds, drops or reorders rules",
+                [r["id"] for r in _fixed] == [r["id"] for r in _frozen])
+    _, _bf_default = reg.backfill_capability_ranks(reg.DEFAULT_MODEL_RULES)
+    ok &= _check("DEFAULT_MODEL_RULES already ship ranked — backfill is a no-op",
+                _bf_default is False)
+    _op = [{"id": "claude-cli-sonnet", "provider": "claude_cli", "match": "*sonnet*",
+            "cost_tier": "frontier", "max_complexity": "small",
+            "capability_rank": 10, "enabled": True}]
+    _, _op_changed = reg.backfill_capability_ranks(_op)
+    ok &= _check("backfill leaves an operator's own retuned rule alone",
+                _op_changed is False)
 
     print()
     if ok:


### PR DESCRIPTION
Follow-up to #24, which flagged this but left it in place.

### The bug

`claude_cli` Sonnet shipped capped at `max_complexity="medium"` and Haiku at `"small"` to express *"large escalates to Opus"*. But `max_complexity` is a **hard filter** (`have >= need`), not a preference — the cap didn't rank those models lower, it **removed** them.

On a claude_cli-only install (session auth, no API keys — a supported config), a `complexity="large"` request matched **nothing** and `select_model` returned `None`. There was no Opus to escalate *to*, so the escalation the caps encoded couldn't happen; the request just failed.

Verified before the fix:
```
claude_cli Sonnet, only candidate, complexity=large -> None
```
…despite Sonnet 5 being a frontier model fully capable of the work.

### The fix

Both now report their honest ceiling, mirroring their anthropic twins (`sonnet=large`, `haiku=medium`), and the Haiku<Sonnet<Opus ladder is carried by `capability_rank` (55 < 78 < 95) — which orders **without ever filtering**, so a preference can no longer cost availability.

To keep `feature_build` landing on Opus once the hard filter stops doing it, `capability_rank` becomes the primary ordering key for **demanding** work rather than only under an explicit `prefer_capable`:

```python
demanding = reqs.prefer_capable or reqs.complexity == "large"
```

Anything below `large` still orders on speed, so light work keeps taking the fastest model in its tier — a small mutating task still resolves to Haiku.

### Migration

`backfill_capability_ranks()` repairs installs that already persisted the old values; the ranks and caps live **on existing rules**, so the append-only top-ups can't reach them. Scoped like `enable_ollama_cloud_tools`: only ids AppBuilder ships, only where the value still matches the stale default — an operator's own or already-retuned rule is untouched. Idempotent, order-preserving. Wired into the unconditional boot upgrade plus both settings paths.

### Tests

Updates 4 pre-existing cases that asserted the capped design (behaviour deliberately changed), keeping the guarantees they protected by re-expressing them on the new mechanism: feature_build still → Opus, small mutating task still → Haiku, ladder now asserted as `capability_rank` ordering.

Registry suite **124 cases pass**. Full suite **53 pass / 0 fail**.