### PR TITLE
Advertise tool support for Copilot; the blocking fallback no longer exists

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -2314,15 +2314,21 @@ def _configured_entries(config):
 
 
 def _try_candidate(candidate, messages, tools, effective_stream, task_id, config, **kwargs):
-    """The requirements= path's per-candidate attempt — the identity-keyed
-    counterpart to _try_provider below. Deliberately a conservative subset
-    of _try_provider's error handling for this first phase: credit
-    exhaustion, rate-limit cooldown (incl. claude_cli session limits) are
-    covered (nothing here can leave a dead endpoint retried forever); the
-    provider-specific message-rewriting branches (ollama 404/403 detail,
-    tool-calling-400 retry-without-tools, routed-model retry) stay on the
-    slot-based path for now and can be ported here as a later phase converts
-    call sites that actually need them."""
+    """The requirements= path's per-candidate attempt. Covers credit
+    exhaustion and rate-limit cooldown (incl. claude_cli session limits), so
+    nothing here can leave a dead endpoint retried forever.
+
+    NOTE: this used to describe itself as a conservative subset of
+    _try_provider, with the provider-specific message-rewriting branches
+    (ollama 404/403 detail, tool-calling-400 retry-without-tools, routed-model
+    retry) "staying on the slot-based path for now". That path no longer
+    exists -- it was retired once the last call site moved here, and those
+    branches went with it rather than being ported. They are therefore absent
+    for EVERY provider, not parked somewhere else; treat their loss as a known
+    gap to re-implement here, not as a reason to under-declare a provider's
+    capabilities in model_registry (doing exactly that kept Copilot's
+    supports_tools False long after the fallback it was hedging against had
+    been deleted)."""
     provider, model, base_url, api_key = (candidate["provider"], candidate["model"],
                                           candidate["base_url"], candidate["api_key"])
     mk = candidate["key"]

--- a/llm_migrate.py
+++ b/llm_migrate.py
@@ -191,6 +191,13 @@ def upgrade_registry(config):
         changed = True
         logger.info("LLM registry: enabled supports_tools on the ollama_cloud rule "
                     "(the client has always sent tools; the flag was wrong).")
+    _cp_tools, _cp_changed = model_registry.enable_copilot_tools(config["model_registry"])
+    if _cp_changed:
+        config["model_registry"] = _cp_tools
+        changed = True
+        logger.info("LLM registry: enabled supports_tools on the copilot rules "
+                    "(_request_copilot has always sent tools; the flag was wrong, and it "
+                    "hard-excluded every Copilot endpoint from tool-requiring jobs).")
     _ranked, _ranks = model_registry.backfill_capability_ranks(config["model_registry"])
     if _ranks:
         config["model_registry"] = _ranked

--- a/model_registry.py
+++ b/model_registry.py
@@ -206,7 +206,7 @@ DEFAULT_MODEL_RULES = [
      "enabled": True, "notes": ""},
     {"id": "copilot", "provider": "copilot", "match": "*", "label": "GitHub Copilot",
      "cost_tier": "cheap", "max_complexity": "large", "context_window": 64000,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
      "enabled": True,
      "notes": "generic fallback for Copilot models with no class rule below. Copilot is NOT "
@@ -223,7 +223,7 @@ DEFAULT_MODEL_RULES = [
     # whichever provider serves it. More-specific match beats the generic `*`.
     {"id": "copilot-opus", "provider": "copilot", "match": "*opus*", "label": "Claude Opus (via Copilot)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
      "capability_rank": 95, "enabled": True,
      "notes": "27x premium-request multiplier — the most expensive model Copilot serves. "
@@ -231,34 +231,34 @@ DEFAULT_MODEL_RULES = [
               "RESERVES it for the hardest work instead of spending it on triage."},
     {"id": "copilot-sonnet", "provider": "copilot", "match": "*sonnet*", "label": "Claude Sonnet (via Copilot)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
      "capability_rank": 78, "enabled": True, "notes": "9x multiplier; frontier/large mirrors anthropic-sonnet"},
     {"id": "copilot-haiku", "provider": "copilot", "match": "*haiku*", "label": "Claude Haiku (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
      "capability_rank": 55, "enabled": True, "notes": "0.33x multiplier; cheap/medium mirrors anthropic-haiku"},
     {"id": "copilot-gemini-pro", "provider": "copilot", "match": "*gemini*pro*", "label": "Gemini Pro (via Copilot)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
      "capability_rank": 80, "enabled": True, "notes": "6x multiplier; frontier/large mirrors google-pro"},
     # `gpt-5*mini*` is deliberately MORE specific than `gpt-5*` so gpt-5-mini
     # (0.33x) stays cheap instead of inheriting the gpt-5 frontier tier.
     {"id": "copilot-gpt5-mini", "provider": "copilot", "match": "gpt-5*mini*", "label": "GPT-5 mini (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
      "capability_rank": 50, "enabled": True, "notes": "0.33x multiplier — the cheapest GPT-5 variant"},
     {"id": "copilot-gpt5", "provider": "copilot", "match": "gpt-5*", "label": "GPT-5 class (via Copilot)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
      "capability_rank": 85, "enabled": True, "notes": "6x base / 57x for GPT-5.5 — priced as frontier so it is reserved"},
     {"id": "copilot-gpt4", "provider": "copilot", "match": "gpt-4*", "label": "GPT-4 class (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
-     "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
+     "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
      "capability_rank": 45, "enabled": True, "notes": "0.33x multiplier (gpt-4o / gpt-4o-mini)"},
     {"id": "anthropic-haiku", "provider": "anthropic", "match": "*haiku*", "label": "Claude Haiku class",
@@ -637,6 +637,51 @@ def enable_ollama_cloud_tools(rules):
     for r in rules:
         if (isinstance(r, dict) and r.get("id") == "ollama-cloud"
                 and r.get("supports_tools") is False):
+            r = {**r, "supports_tools": True}
+            changed = True
+        out.append(r)
+    return out, changed
+
+
+def enable_copilot_tools(rules):
+    """Return (new_rules, changed): a COPY of `rules` with supports_tools
+    flipped False -> True on the copilot rules AppBuilder ships.
+
+    Same shape of bug as enable_ollama_cloud_tools, and the flag is equally
+    wrong: _request_copilot has always set payload["tools"] via
+    _tools_to_openai and parsed message.tool_calls back out, and the Copilot
+    chat/completions surface is OpenAI-compatible function calling. Copilot was
+    the ONLY provider whose client implements tools while the registry claimed
+    it could not, so model_selection's needs_tools HARD filter dropped every
+    Copilot endpoint from every tool-requiring job.
+
+    The flag was originally left False on the theory that the
+    tool-calling-400 retry-without-tools fallback existed only on the
+    slot-based path (_try_provider) and so Copilot would have no safety net.
+    That path no longer exists -- it was retired once the last call site moved
+    to the requirements path, and the fallback went with it. _try_candidate's
+    docstring still promises those branches "stay on the slot-based path for
+    now", which outlived the path itself. So no provider has that net today:
+    anthropic, google, groq, lmstudio, openai, openrouter and ollama_cloud all
+    advertise tools without it, and Copilot was being singled out for a
+    protection that is not there for anyone.
+
+    Deliberately does NOT touch native_agentic_tools or supports_mutating_agent.
+    Those mean "the provider runs its own agent loop with built-in
+    Read/Grep/Glob", which is true of claude_cli (a CLI harness) but not of
+    this provider: ab drives the Copilot chat-completions API and runs the tool
+    loop itself. Copilot CLI being agentic as a product says nothing about the
+    API surface ab actually calls.
+
+    Scoped narrowly like the ollama_cloud repair: only ids AppBuilder ships,
+    only where the flag is still False. Idempotent; never reorders or adds."""
+    shipped = {"copilot", "copilot-opus", "copilot-sonnet", "copilot-haiku",
+               "copilot-gemini-pro", "copilot-gpt5-mini", "copilot-gpt5", "copilot-gpt4"}
+    out = []
+    changed = False
+    for r in rules or []:
+        if (isinstance(r, dict) and r.get("id") in shipped
+                and r.get("provider") == "copilot" and r.get("supports_tools") is False):
             r = {**r, "supports_tools": True}
             changed = True
         out.append(r)

--- a/routes.py
+++ b/routes.py
@@ -2095,6 +2095,7 @@ async def settings_page(request: Request):
     _curated, _mr_oc_models = _registry.upgrade_ollama_cloud_model_rules(_curated)
     _curated, _mr_oc_tools = _registry.enable_ollama_cloud_tools(_curated)
     _curated, _mr_or_router = _registry.upgrade_openrouter_free_router_rule(_curated)
+    _curated, _mr_cp_tools = _registry.enable_copilot_tools(_curated)
     _curated, _mr_ranks = _registry.backfill_capability_ranks(_curated)
     _registry_rules_json = json.dumps(_curated, indent=2)
     _auto = config.get("model_registry_auto") or []
@@ -2509,6 +2510,8 @@ async def save_settings(request: Request):
             config_data["model_registry"], _ = _registry_save.enable_ollama_cloud_tools(
                 config_data["model_registry"])
             config_data["model_registry"], _ = _registry_save.upgrade_openrouter_free_router_rule(
+                config_data["model_registry"])
+            config_data["model_registry"], _ = _registry_save.enable_copilot_tools(
                 config_data["model_registry"])
             config_data["model_registry"], _ = _registry_save.backfill_capability_ranks(
                 config_data["model_registry"])

--- a/test_model_registry.py
+++ b/test_model_registry.py
@@ -584,6 +584,54 @@ def main():
     ok &= _check("backfill leaves an operator's own retuned rule alone",
                 _op_changed is False)
 
+    # ------------------------------------------------------ copilot tool support
+    # _request_copilot has always sent payload["tools"] and parsed tool_calls;
+    # the registry claiming otherwise made needs_tools (a HARD filter) drop
+    # every Copilot endpoint from every tool job.
+    ok &= _check("every shipped copilot rule advertises supports_tools",
+                all(r.get("supports_tools") is True
+                    for r in reg.DEFAULT_MODEL_RULES if r.get("provider") == "copilot"))
+    ok &= _check("copilot is selectable for a needs_tools job",
+                getattr(sel.select_model(
+                    sel.LlmRequirements(complexity="large", needs_tools=True),
+                    [{"key": "copilot|x|claude-opus-5", "provider": "copilot",
+                      "model": "claude-opus-5",
+                      "caps": reg.resolve("copilot", "claude-opus-5", _cfg),
+                      "available": True}], {}), "model", None) == "claude-opus-5")
+    # native_agentic_tools means "the provider runs its own agent loop with
+    # built-in Read/Grep/Glob" — true of the claude_cli harness, NOT of the
+    # Copilot chat-completions API that ab actually drives. Copilot CLI being
+    # agentic as a product says nothing about that surface.
+    _cp = reg.resolve("copilot", "claude-opus-5", _cfg)
+    _cli = reg.resolve("claude_cli", "claude-opus-5", _cfg)
+    ok &= _check("copilot does OpenAI-style tools but is NOT native-agentic",
+                _cp["supports_tools"] is True
+                and _cp["native_agentic_tools"] is False
+                and _cp["supports_mutating_agent"] is False)
+    ok &= _check("claude_cli is the inverse — native-agentic, no OpenAI tool schema",
+                _cli["supports_tools"] is False
+                and _cli["native_agentic_tools"] is True
+                and _cli["supports_mutating_agent"] is True)
+    _frozen_cp = [dict(r) for r in reg.DEFAULT_MODEL_RULES]
+    for _r in _frozen_cp:
+        if _r.get("provider") == "copilot":
+            _r["supports_tools"] = False
+    _cpf, _cpc = reg.enable_copilot_tools(_frozen_cp)
+    _, _cpc2 = reg.enable_copilot_tools(_cpf)
+    ok &= _check("copilot tools repair fixes a frozen registry and is idempotent",
+                _cpc is True and _cpc2 is False
+                and all(r["supports_tools"] for r in _cpf if r.get("provider") == "copilot"))
+    ok &= _check("copilot tools repair never adds, drops or reorders rules",
+                [r["id"] for r in _cpf] == [r["id"] for r in _frozen_cp])
+    _, _cp_default = reg.enable_copilot_tools(reg.DEFAULT_MODEL_RULES)
+    ok &= _check("DEFAULT_MODEL_RULES already ship copilot tools — repair is a no-op",
+                _cp_default is False)
+    _, _cp_op = reg.enable_copilot_tools(
+        [{"id": "my-copilot", "provider": "copilot", "match": "*",
+          "supports_tools": False, "enabled": True}])
+    ok &= _check("copilot tools repair leaves an operator's own rule alone",
+                _cp_op is False)
+
     print()
     if ok:
         print("ALL CASES PASSED")


### PR DESCRIPTION
You asked why Copilot isn't considered tool-capable when it's running the same model as claude_cli. It's a bug — and the reason I'd previously deferred it turned out to be false.

### The bug

`_request_copilot` has **always** built `payload["tools"]` and parsed `message.tool_calls` back out, and Copilot's chat/completions surface is OpenAI-compatible function calling. But the registry declared `supports_tools=False` on all 8 copilot rules, and `needs_tools` is a **hard filter** — so every Copilot endpoint was dropped from every tool-requiring job.

Copilot was the **only** provider whose client implements tools while the registry denied it.

### Why it was left False, and why that was wrong

The stated reason was that the tool-calling-400 retry-without-tools fallback lived only on the slot-based path (`_try_provider`), leaving Copilot without a safety net.

**`_try_provider` does not exist.** It was retired once the last call site moved to the requirements path (Phase 5, #15), and the fallback was deleted with it rather than ported. The net is absent for *every* provider — anthropic, google, groq, lmstudio, openai, openrouter and ollama_cloud all advertise tools without it. Copilot was singled out for a protection that isn't there for anyone.

The real root cause is `_try_candidate`'s docstring, which still promised those branches *"stay on the slot-based path for now"* — it outlived the code it described, and that stale claim is what justified under-declaring the capability. Rewritten to say they're gone for everyone and are a gap to re-implement, **not** a reason to misdeclare a provider.

### What I deliberately did *not* change

`native_agentic_tools` and `supports_mutating_agent` stay `False` for copilot. Those mean *"the provider runs its own agent loop with built-in Read/Grep/Glob"* — true of the claude_cli harness, but not of the chat-completions API `ab` drives, where ab runs the tool loop itself. **Copilot CLI being agentic as a product says nothing about that API surface.** The two are exact inverses, and both are now correct:

| provider | tools | agentic | mutating |
|---|---|---|---|
| `copilot` | **True** | False | False |
| `claude_cli` | False | True | True |

### Migration + verification

`enable_copilot_tools()` repairs installs that already persisted the false flag — scoped like `enable_ollama_cloud_tools` (only shipped ids, only where still `False`), idempotent, order-preserving, operator rules untouched. Wired into the boot upgrade and both settings paths.

```
copilot-only candidates, needs_tools=True
  before -> None (all excluded)
  after  -> claude-opus-5
```

Registry suite **all pass**; full suite **53 pass / 0 fail**.