### PR TITLE
Re-implement the tool-calling-400 retry-without-tools fallback

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -2313,22 +2313,42 @@ def _configured_entries(config):
     ]
 
 
+#: Substrings that mark a 400 as "this endpoint won't accept the tools payload"
+#: rather than a genuine bad request. Kept deliberately narrow: a 400 we cannot
+#: attribute to tool calling must still fail loudly instead of silently
+#: downgrading a tool run into a plain completion.
+_TOOL_400_MARKERS = (
+    "tool", "function call", "function_call", "functions are not",
+    "does not support tools", "unsupported_parameter",
+)
+
+
+def _is_tool_unsupported_400(err_str):
+    """True when `err_str` looks like a 400 caused by the tools payload.
+
+    _llm_retry_post folds the response body into the message, so the provider's
+    own explanation ("model does not support tools", "unsupported_parameter:
+    tools", ...) is available here."""
+    if "400" not in err_str:
+        return False
+    low = err_str.lower()
+    return any(m in low for m in _TOOL_400_MARKERS)
+
+
 def _try_candidate(candidate, messages, tools, effective_stream, task_id, config, **kwargs):
     """The requirements= path's per-candidate attempt. Covers credit
-    exhaustion and rate-limit cooldown (incl. claude_cli session limits), so
-    nothing here can leave a dead endpoint retried forever.
+    exhaustion, rate-limit cooldown (incl. claude_cli session limits) and the
+    tool-calling-400 retry-without-tools fallback, so nothing here can leave a
+    dead endpoint retried forever or fail a whole run because one endpoint
+    rejects a tools payload it advertised support for.
 
-    NOTE: this used to describe itself as a conservative subset of
-    _try_provider, with the provider-specific message-rewriting branches
-    (ollama 404/403 detail, tool-calling-400 retry-without-tools, routed-model
-    retry) "staying on the slot-based path for now". That path no longer
-    exists -- it was retired once the last call site moved here, and those
-    branches went with it rather than being ported. They are therefore absent
-    for EVERY provider, not parked somewhere else; treat their loss as a known
-    gap to re-implement here, not as a reason to under-declare a provider's
-    capabilities in model_registry (doing exactly that kept Copilot's
-    supports_tools False long after the fallback it was hedging against had
-    been deleted)."""
+    The retry-without-tools branch was lost when the slot-based path
+    (_try_provider) was retired and its provider-specific error handling was
+    deleted rather than ported -- leaving it absent for EVERY provider. It is
+    re-implemented here because a registry flag can only ever say whether an
+    endpoint *should* accept tools; this is the runtime net for when it does
+    not. Still missing from the old path and worth porting later: the ollama
+    404/403 message detail and the routed-model retry."""
     provider, model, base_url, api_key = (candidate["provider"], candidate["model"],
                                           candidate["base_url"], candidate["api_key"])
     mk = candidate["key"]
@@ -2354,6 +2374,26 @@ def _try_candidate(candidate, messages, tools, effective_stream, task_id, config
                 _cb_trip(_MODEL_RATE_CB, mk, f"Rate-limited: {err_str[:120]}",
                          _RATELIMIT_COOLDOWN_SECONDS, "rate_limit", provider)
                 return None, "rate_limited"
+            if tools and _is_tool_unsupported_400(err_str):
+                # One retry without the tools payload. Better a usable plain
+                # answer than failing the run: callers that asked for tools
+                # (fix_engine's review loop) already scrape tool calls out of
+                # the TEXT when the structured field is absent, so the degraded
+                # result can still drive their loop.
+                logger.warning("%s/%s rejected the tools payload (400); retrying without tools. %s",
+                               provider, model, err_str[:200])
+                try:
+                    degraded = _call_provider_timed(provider, model, api_key, base_url, messages, None,
+                                                    effective_stream, task_id, config, **kwargs)
+                except Exception as e2:  # noqa: BLE001 — the retry is best-effort
+                    return None, e2
+                # Preserve the tools-call CONTRACT: with tools= set, providers
+                # return {"text", "tool_calls"}; without it they return a bare
+                # string. Handing that string back would change the return type
+                # under the caller purely because of a transport failure.
+                if not isinstance(degraded, dict):
+                    degraded = {"text": str(degraded or ""), "tool_calls": None}
+                return degraded, None
             return None, e
 
 

--- a/test_llm_client_requirements_path.py
+++ b/test_llm_client_requirements_path.py
@@ -27,13 +27,13 @@ def _load_ns():
     want_funcs = {
         "_endpoint_key", "_cb_trip", "_cb_remaining", "_model_lock",
         "_iter_configured_endpoints", "_enumerate_candidates", "_configured_entries",
-        "_try_candidate", "_call_llm_with_requirements",
+        "_try_candidate", "_call_llm_with_requirements", "_is_tool_unsupported_400",
         "_model_key", "get_llm_perf_snapshot", "_get_llm_perf_store",
         "_provider_configured", "_provider_is_nokey", "_is_ollama", "_is_ollama_cloud", "_is_lmstudio",
         "_routed_model_dead", "_get_category_semaphore",
     }
     want_assign = {
-        "_ALL_SLOTS", "_CODE_SLOTS", "_LOG_SLOTS", "_REVIEW_SLOTS",
+        "_ALL_SLOTS", "_CODE_SLOTS", "_LOG_SLOTS", "_REVIEW_SLOTS", "_TOOL_400_MARKERS",
         "_ENDPOINT_CB_LOCK", "_ENDPOINT_CREDIT_CB", "_MODEL_RATE_CB",
         "_MODEL_LOCKS_LOCK", "_MODEL_LOCKS",
         "_LLM_PERF_STORE", "_LLM_PERF_LOCK",
@@ -196,6 +196,60 @@ def main():
     ok &= _check("a 429 trips the per-MODEL rate CB (not the endpoint credit CB)",
                 ns["_cb_remaining"](ns["_MODEL_RATE_CB"], candidate["key"]) > 0
                 and ns["_cb_remaining"](ns["_ENDPOINT_CREDIT_CB"], ns["_endpoint_key"]("anthropic", "")) == 0)
+
+    # --- _try_candidate: tool-calling 400 retries once WITHOUT tools -----------
+    # This net was deleted with the old slot path, leaving every provider
+    # exposed; it matters more now that Copilot advertises tool support.
+    ns["_ENDPOINT_CREDIT_CB"].clear()
+    ns["_MODEL_RATE_CB"].clear()
+    _tools = [{"type": "function", "function": {"name": "read_file"}}]
+
+    ok &= _check("a tools-shaped 400 is recognised",
+                ns["_is_tool_unsupported_400"](
+                    "400 Client Error: Bad Request for url: x - model does not support tools")
+                is True)
+    ok &= _check("an unrelated 400 is NOT treated as a tools problem "
+                "(must fail loudly, not silently downgrade)",
+                ns["_is_tool_unsupported_400"](
+                    "400 Client Error: Bad Request - context length exceeded") is False)
+    ok &= _check("a non-400 tools error is not swallowed by the tools branch",
+                ns["_is_tool_unsupported_400"]("500 tool explosion") is False)
+
+    _seen = {"n": 0}
+    def _fail_first_with_tools(p, m):
+        _seen["n"] += 1
+        return Exception("400 Bad Request - unsupported_parameter: tools") if _seen["n"] == 1 else None
+    ns["_test_calls"]["raise_exc"] = _fail_first_with_tools
+    ns["_test_calls"]["provider_calls"].clear()
+    result, err = ns["_try_candidate"](candidate, [], _tools, True, None, {})
+    ok &= _check("a tool-calling 400 retries the SAME endpoint instead of failing",
+                err is None and len(ns["_test_calls"]["provider_calls"]) == 2)
+    ok &= _check("the degraded retry preserves the tools-call return CONTRACT "
+                "({text, tool_calls}), not a bare string",
+                isinstance(result, dict) and result.get("tool_calls") is None
+                and "ok from" in result.get("text", ""))
+    ok &= _check("a tool-calling 400 does NOT trip a circuit breaker "
+                "(the endpoint is healthy, it just refused the payload)",
+                ns["_cb_remaining"](ns["_MODEL_RATE_CB"], candidate["key"]) == 0
+                and ns["_cb_remaining"](ns["_ENDPOINT_CREDIT_CB"],
+                                        ns["_endpoint_key"]("anthropic", "")) == 0)
+
+    # No tools sent -> nothing to drop, so the 400 must propagate as a failure.
+    _seen["n"] = 0
+    ns["_test_calls"]["provider_calls"].clear()
+    result, err = ns["_try_candidate"](candidate, [], None, True, None, {})
+    ok &= _check("without tools, a 400 is NOT retried and is reported as an error",
+                result is None and err is not None
+                and len(ns["_test_calls"]["provider_calls"]) == 1)
+
+    # If the retry ALSO fails, surface that error rather than looping.
+    ns["_test_calls"]["raise_exc"] = lambda p, m: Exception(
+        "400 Bad Request - unsupported_parameter: tools")
+    ns["_test_calls"]["provider_calls"].clear()
+    result, err = ns["_try_candidate"](candidate, [], _tools, True, None, {})
+    ok &= _check("a retry that also fails is reported, and is attempted only once",
+                result is None and err is not None
+                and len(ns["_test_calls"]["provider_calls"]) == 2)
 
     # --- _call_llm_with_requirements: end-to-end selection + success -----------
 


### PR DESCRIPTION
Follow-up to #29. That PR enabled Copilot's `supports_tools` after finding the fallback which had justified keeping it `False` **no longer existed** — it was deleted with the slot path (`_try_provider`) rather than ported, so *no* provider had it. Advertising tool support for another provider while that net stays missing widens the exposure, so this closes it.

`_try_candidate` now retries once without the tools payload when a 400 looks attributable to tool calling, keyed off a deliberately narrow marker list. **A 400 we can't attribute to tools still fails loudly** — silently downgrading a tool run into a plain completion on, say, a context-length 400 would hide a real bug.

Two details that matter:

- **The retry preserves the return contract.** With `tools=` set, providers return `{text, tool_calls}`; without it they return a bare string. Handing that back would change the return type under the caller purely because of a transport failure, so the degraded result is normalised to the dict shape. `fix_engine`'s review loop then still recovers tool calls from the text via `_parse_review_text_tool_calls`, so the loop keeps working.
- **It trips no circuit breaker.** The endpoint is healthy — it just refused one payload shape. Cooling it down would be wrong.

Also registers the new helpers in `test_llm_client_requirements_path.py`'s AST-extraction namespace; extracted functions only see collaborators listed there.

8 new cases. Full suite **53 pass / 0 fail**.