### PR TITLE
Add a speed axis to model selection, and make latency_sensitive real

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -966,10 +966,31 @@ def run_agent_loop(messages, config, gh, *, task_id, max_iter=6,
         stay cost-first (medium, latency-sensitive); the LLM router passes a
         stronger requirement (large + prefer_capable) so agentic diagnosis gets
         a smarter model. tool_requirements MUST keep needs_tools=True.
+
+        When neither is supplied, the loop self-escalates: it starts fastest-in-
+        tier and switches to most-capable-in-tier after
+        `chat_escalate_after_iters` (default 2) tool rounds, so a hard question
+        is not answered by the fast model forever. See the loop preamble.
     """
     from model_selection import LlmRequirements
+    import dataclasses as _dc
     _status = status_cb or (lambda *_a, **_k: None)
     _tool_reqs = tool_requirements or LlmRequirements(complexity="medium", needs_tools=True, latency_sensitive=True)
+    # In-loop escalation. The first turns are latency_sensitive so the dashboard
+    # feels instant, but a question that is still calling tools after several
+    # rounds is, empirically, one that needs more reasoning than the fastest
+    # model in the tier has. From that point on, order the SAME tier by
+    # capability instead of speed and stop optimising for latency.
+    #
+    # Deliberately prefer_capable_within_tier, not prefer_capable: this is the
+    # dashboard's cost-first chat, so escalating must not start spending on the
+    # frontier tier. (llm_proxy's agentic path is the one that does that, and it
+    # passes its own tool_requirements.) Skipped entirely when the caller steered
+    # selection itself or the operator pinned a model -- neither wants us
+    # second-guessing the pick.
+    _escalate_after = max(1, int((config or {}).get("chat_escalate_after_iters", 2) or 2))
+    _can_escalate = tool_requirements is None and not (config or {}).get("chat_pin")
+    _escalated = False
     # Azure fleet tools are advertised only when the operator has opted in, so a
     # model on a host without the login helper isn't tempted to call them.
     tools = CHAT_TOOLS + (AZURE_TOOLS if az_console.azure_enabled(config) else [])
@@ -977,6 +998,12 @@ def run_agent_loop(messages, config, gh, *, task_id, max_iter=6,
     final_text = None
     last_text = ""
     for iteration in range(max_iter):
+        if _can_escalate and not _escalated and iteration >= _escalate_after:
+            _tool_reqs = _dc.replace(_tool_reqs, latency_sensitive=False,
+                                     prefer_capable_within_tier=True)
+            _escalated = True
+            logger.info("Chat agent loop still working after %d tool rounds; escalating model "
+                        "selection from fastest-in-tier to most-capable-in-tier.", iteration)
         _status("Thinking…" if iteration == 0 else "Working…")
         try:
             result = call_llm("", messages=messages, task_id=task_id, tools=tools, stream=False, requirements=_tool_reqs)
@@ -1061,6 +1088,13 @@ def run_agent_loop(messages, config, gh, *, task_id, max_iter=6,
                 _status("Summarizing…")
                 messages.append({"role": "system", "content": "You have gathered enough information from the tools. Do NOT call any more tools. Write your final answer to the user now, in plain text."})
                 _final_reqs = final_requirements or LlmRequirements(complexity="medium", latency_sensitive=True)
+                # We only reach this branch by exhausting max_iter without a
+                # written answer, so the loop already proved it was hard. If the
+                # tool turns escalated, the synthesis that has to make sense of
+                # them should not drop back to the fastest weakest model.
+                if _escalated and final_requirements is None:
+                    _final_reqs = _dc.replace(_final_reqs, latency_sensitive=False,
+                                              prefer_capable_within_tier=True)
                 forced = call_llm("", messages=messages, task_id=task_id, requirements=_final_reqs)
                 if isinstance(forced, dict):
                     forced = forced.get("text") or ""

--- a/hub_agent.py
+++ b/hub_agent.py
@@ -482,6 +482,7 @@ class HubAgentClient:
             else:
                 reqs = LlmRequirements(complexity="small", latency_sensitive=False,
                                        deprioritize_local=True,
+                                       prefer_capable_within_tier=True,
                                        min_context_tokens=len(log_text) // 4)
                 raw = await _aio.get_event_loop().run_in_executor(
                     None, lambda: analyze_logs(log_text, title, requirements=reqs))

--- a/llm_migrate.py
+++ b/llm_migrate.py
@@ -205,6 +205,13 @@ def upgrade_registry(config):
         logger.info("LLM registry: backfilled capability_rank and lifted the claude_cli "
                     "sonnet/haiku max_complexity caps (Opus now outranks Sonnet within "
                     "the frontier tier instead of losing to it on raw speed).")
+    _sped, _speeds = model_registry.backfill_speed_tiers(config["model_registry"])
+    if _speeds:
+        config["model_registry"] = _sped
+        changed = True
+        logger.info("LLM registry: backfilled speed_tier (latency-sensitive work such as "
+                    "chat now orders its tier fastest-first on a declared speed class, so a "
+                    "new fast endpoint is not starved by having no samples yet).")
     return config, changed
 
 

--- a/log_scan.py
+++ b/log_scan.py
@@ -308,8 +308,10 @@ def analyze_logs_for_errors(logs):
     as a hint only and is not required.
 
     Routed via requirements=LlmRequirements(complexity="small",
-    needs_structured_output=True) (LLM Selection Redesign Phase 5, site #14)
-    rather than the old task_kind="log_review" pool pin.
+    needs_structured_output=True, prefer_capable_within_tier=True) (LLM
+    Selection Redesign Phase 5, site #14) rather than the old
+    task_kind="log_review" pool pin -- i.e. the most capable FREE model, since
+    this runs unattended and triage quality matters more than latency.
     """
     if not logs: return []
 
@@ -328,8 +330,14 @@ def analyze_logs_for_errors(logs):
     )
     try:
         from model_selection import LlmRequirements
+        # prefer_capable_within_tier, NOT prefer_capable: log analysis runs
+        # constantly and unattended, so it must stay in the cheapest tier that
+        # qualifies -- but within that tier it wants the STRONGEST model, not the
+        # fastest weakest one. Triage quality is the whole point of the call, and
+        # nobody is waiting on the latency.
         reqs = LlmRequirements(complexity="small", needs_structured_output=True,
                                deprioritize_local=True,
+                               prefer_capable_within_tier=True,
                                min_context_tokens=len(prompt) // 4)
         res = call_llm(prompt, system_prompt="You are a log analysis expert. Return only a JSON array.",
                        requirements=reqs)

--- a/model_registry.py
+++ b/model_registry.py
@@ -61,7 +61,7 @@ COST_TIER_RANK = {"free": 0, "cheap": 1, "frontier": 2, "unknown": 3}
 _CAP_FIELDS = (
     "cost_tier", "max_complexity", "context_window", "supports_tools",
     "native_agentic_tools", "supports_mutating_agent", "supports_structured_output",
-    "supports_batch", "supports_streaming", "capability_rank",
+    "supports_batch", "supports_streaming", "capability_rank", "speed_tier",
 )
 
 #: Fallback `capability_rank` derived from max_complexity, for any rule that
@@ -80,6 +80,39 @@ _CAPABILITY_RANK_BY_COMPLEXITY = {"trivial": 10, "small": 30, "medium": 50, "lar
 #:
 #: Deliberately NOT the premium-request multiplier: that would rank GPT-5.5
 #: (57x) above Opus (27x), which is a price signal, not a capability one.
+#: Declared speed class, the cold-start prior for "how fast is this model".
+#: Ranking still refines with MEASURED tok/s + latency (llm_perf); this exists
+#: because a brand-new endpoint has no samples yet, and because latency data
+#: alone cannot distinguish "big model, inherently slow" from "fast model
+#: having a bad minute".
+SPEED_RANK = {"fast": 0, "standard": 1, "slow": 2}
+
+#: Fallback speed derived from capability_rank for rules that predate the
+#: field: bigger/stronger models are, as a prior, slower.
+_SPEED_BY_CAPABILITY_RANK = ((85, "slow"), (60, "standard"))
+
+
+def speed_tier(caps):
+    """The declared speed class for a resolved capability dict.
+
+    Falls back to a capability_rank-derived prior when a rule carries no
+    explicit value, so an un-annotated registry still orders sensibly instead
+    of treating every model as equally fast."""
+    raw = (caps or {}).get("speed_tier")
+    if isinstance(raw, str) and raw.strip().lower() in SPEED_RANK:
+        return raw.strip().lower()
+    rank = capability_rank(caps)
+    for floor, tier in _SPEED_BY_CAPABILITY_RANK:
+        if rank >= floor:
+            return tier
+    return "fast"
+
+
+def speed_rank(caps):
+    """SPEED_RANK for a capability dict — lower is faster."""
+    return SPEED_RANK.get(speed_tier(caps), 1)
+
+
 def capability_rank(caps):
     """The 0-100 within-tier capability score for a resolved capability dict.
 
@@ -112,22 +145,22 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "free", "max_complexity": "medium", "context_window": 32768,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "max_complexity is refined per-model by parameter count in resolve()"},
+     "speed_tier": "fast", "enabled": True, "notes": "max_complexity is refined per-model by parameter count in resolve()"},
     {"id": "ollama2-local", "provider": "ollama2", "match": "*", "label": "Self-hosted Ollama (2nd endpoint / GPU)",
      "cost_tier": "free", "max_complexity": "medium", "context_window": 32768,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "second local Ollama endpoint (e.g. a GPU box); free, mirrors ollama-local"},
+     "speed_tier": "fast", "enabled": True, "notes": "second local Ollama endpoint (e.g. a GPU box); free, mirrors ollama-local"},
     {"id": "lmstudio-local", "provider": "lmstudio", "match": "*", "label": "Self-hosted LM Studio",
      "cost_tier": "free", "max_complexity": "medium", "context_window": 32768,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "speed_tier": "fast", "enabled": True, "notes": ""},
     {"id": "claude-cli", "provider": "claude_cli", "match": "*", "label": "Claude CLI (session auth)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "capability_rank": 70, "enabled": True,
+     "capability_rank": 70, "speed_tier": "slow", "enabled": True,
      "notes": "session auth (no API key), but every call bills the operator's Anthropic "
               "account — cost_tier=frontier so the picker RESERVES it (free/GPU wins first, "
               "claude_cli is used only when a call needs its native_agentic_tools/"
@@ -143,7 +176,7 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "medium", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "capability_rank": 55, "enabled": True,
+     "capability_rank": 55, "speed_tier": "fast", "enabled": True,
      "notes": "fastest Claude; medium mirrors anthropic-haiku. Preference for Sonnet/Opus "
               "is carried by capability_rank (55 < 78 < 95) rather than a max_complexity "
               "cap, which would hard-exclude it rather than rank it last"},
@@ -151,7 +184,7 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "capability_rank": 78, "enabled": True,
+     "capability_rank": 78, "speed_tier": "standard", "enabled": True,
      "notes": "balanced Claude; large mirrors anthropic-sonnet. Escalation to Opus is "
               "expressed by capability_rank (95 > 78), NOT by capping max_complexity — "
               "that is a hard filter, so the cap EXCLUDED Sonnet from large work instead "
@@ -161,14 +194,14 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": False, "native_agentic_tools": True, "supports_mutating_agent": True,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": False,
-     "capability_rank": 95, "enabled": True,
+     "capability_rank": 95, "speed_tier": "slow", "enabled": True,
      "notes": "most capable Claude — the ONLY claude_cli model at large complexity, so it is "
               "the default for feature_build and the hardest large agentic/mutating work"},
     {"id": "ollama-cloud", "provider": "ollama_cloud", "match": "*", "label": "Ollama Cloud",
      "cost_tier": "cheap", "max_complexity": "large", "context_window": 131072,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True,
+     "speed_tier": "standard", "enabled": True,
      "notes": "the one ollama* provider that takes a key. supports_tools=True: "
               "_request_ollama sets payload['tools'] and parses tool_calls for cloud "
               "exactly as for local (identical wire protocol), and every model in the "
@@ -182,13 +215,13 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "free", "max_complexity": "medium", "context_window": 32768,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "speed_tier": "fast", "enabled": True, "notes": ""},
     {"id": "openrouter-free-router", "provider": "openrouter", "match": "openrouter/free",
      "label": "OpenRouter Free Models Router",
      "cost_tier": "free", "max_complexity": "medium", "context_window": 32768,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True,
+     "speed_tier": "fast", "enabled": True,
      "notes": "the 'openrouter/free' Free Models Router auto-routes each call to whatever "
               ":free model is currently available/capable, transparently absorbing per-model "
               "rate-limits + outages. Its id has no ':free' suffix so it would otherwise fall "
@@ -198,17 +231,17 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "cheap", "max_complexity": "large", "context_window": 32768,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "less specific than openrouter-free's *:free pattern"},
+     "speed_tier": "standard", "enabled": True, "notes": "less specific than openrouter-free's *:free pattern"},
     {"id": "groq", "provider": "groq", "match": "*", "label": "Groq",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 32768,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "speed_tier": "fast", "enabled": True, "notes": ""},
     {"id": "copilot", "provider": "copilot", "match": "*", "label": "GitHub Copilot",
      "cost_tier": "cheap", "max_complexity": "large", "context_window": 64000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True,
+     "speed_tier": "standard", "enabled": True,
      "notes": "generic fallback for Copilot models with no class rule below. Copilot is NOT "
               "free — every call spends a premium request — so this stays 'cheap', never 'free'."},
     # Per-model capability tiers for the GitHub Copilot roster. Copilot bills a
@@ -225,7 +258,7 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "capability_rank": 95, "enabled": True,
+     "capability_rank": 95, "speed_tier": "slow", "enabled": True,
      "notes": "27x premium-request multiplier — the most expensive model Copilot serves. "
               "frontier/large matches anthropic-opus and claude-cli-opus so the picker "
               "RESERVES it for the hardest work instead of spending it on triage."},
@@ -233,69 +266,69 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "capability_rank": 78, "enabled": True, "notes": "9x multiplier; frontier/large mirrors anthropic-sonnet"},
+     "capability_rank": 78, "speed_tier": "standard", "enabled": True, "notes": "9x multiplier; frontier/large mirrors anthropic-sonnet"},
     {"id": "copilot-haiku", "provider": "copilot", "match": "*haiku*", "label": "Claude Haiku (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "capability_rank": 55, "enabled": True, "notes": "0.33x multiplier; cheap/medium mirrors anthropic-haiku"},
+     "capability_rank": 55, "speed_tier": "fast", "enabled": True, "notes": "0.33x multiplier; cheap/medium mirrors anthropic-haiku"},
     {"id": "copilot-gemini-pro", "provider": "copilot", "match": "*gemini*pro*", "label": "Gemini Pro (via Copilot)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "capability_rank": 80, "enabled": True, "notes": "6x multiplier; frontier/large mirrors google-pro"},
+     "capability_rank": 80, "speed_tier": "standard", "enabled": True, "notes": "6x multiplier; frontier/large mirrors google-pro"},
     # `gpt-5*mini*` is deliberately MORE specific than `gpt-5*` so gpt-5-mini
     # (0.33x) stays cheap instead of inheriting the gpt-5 frontier tier.
     {"id": "copilot-gpt5-mini", "provider": "copilot", "match": "gpt-5*mini*", "label": "GPT-5 mini (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "capability_rank": 50, "enabled": True, "notes": "0.33x multiplier — the cheapest GPT-5 variant"},
+     "capability_rank": 50, "speed_tier": "fast", "enabled": True, "notes": "0.33x multiplier — the cheapest GPT-5 variant"},
     {"id": "copilot-gpt5", "provider": "copilot", "match": "gpt-5*", "label": "GPT-5 class (via Copilot)",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 64000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "capability_rank": 85, "enabled": True, "notes": "6x base / 57x for GPT-5.5 — priced as frontier so it is reserved"},
+     "capability_rank": 85, "speed_tier": "slow", "enabled": True, "notes": "6x base / 57x for GPT-5.5 — priced as frontier so it is reserved"},
     {"id": "copilot-gpt4", "provider": "copilot", "match": "gpt-4*", "label": "GPT-4 class (via Copilot)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 64000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "capability_rank": 45, "enabled": True, "notes": "0.33x multiplier (gpt-4o / gpt-4o-mini)"},
+     "capability_rank": 45, "speed_tier": "fast", "enabled": True, "notes": "0.33x multiplier (gpt-4o / gpt-4o-mini)"},
     {"id": "anthropic-haiku", "provider": "anthropic", "match": "*haiku*", "label": "Claude Haiku class",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 200000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "capability_rank": 55, "enabled": True, "notes": ""},
+     "capability_rank": 55, "speed_tier": "fast", "enabled": True, "notes": ""},
     {"id": "anthropic-sonnet", "provider": "anthropic", "match": "*sonnet*", "label": "Claude Sonnet class",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "capability_rank": 78, "enabled": True, "notes": ""},
+     "capability_rank": 78, "speed_tier": "standard", "enabled": True, "notes": ""},
     {"id": "anthropic-opus", "provider": "anthropic", "match": "*opus*", "label": "Claude Opus class",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 200000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "capability_rank": 95, "enabled": True, "notes": ""},
+     "capability_rank": 95, "speed_tier": "slow", "enabled": True, "notes": ""},
     {"id": "google-flash", "provider": "google", "match": "*flash*", "label": "Gemini Flash class",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 1000000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": False,
-     "enabled": True, "notes": "supports_streaming=False -- _request_google hardcodes stream=False"},
+     "speed_tier": "fast", "enabled": True, "notes": "supports_streaming=False -- _request_google hardcodes stream=False"},
     {"id": "google-pro", "provider": "google", "match": "*pro*", "label": "Gemini Pro class",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 2000000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": False,
-     "capability_rank": 80, "enabled": True, "notes": "supports_streaming=False -- _request_google hardcodes stream=False"},
+     "capability_rank": 80, "speed_tier": "standard", "enabled": True, "notes": "supports_streaming=False -- _request_google hardcodes stream=False"},
     {"id": "openai-mini", "provider": "openai", "match": "*mini*", "label": "OpenAI mini class",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 128000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "enabled": True, "notes": ""},
+     "speed_tier": "fast", "enabled": True, "notes": ""},
     {"id": "openai-gpt", "provider": "openai", "match": "gpt-*", "label": "OpenAI GPT class",
      "cost_tier": "frontier", "max_complexity": "large", "context_window": 128000,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": True, "supports_streaming": True,
-     "capability_rank": 85, "enabled": True, "notes": ""},
+     "capability_rank": 85, "speed_tier": "slow", "enabled": True, "notes": ""},
 
     # --- Capable self-hosted models -------------------------------------
     # The generic `ollama`/`ollama2` defaults are deliberately conservative
@@ -315,32 +348,32 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "free", "max_complexity": "large", "context_window": 262144,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "strong local coder with native tool-calling + long context"},
+     "speed_tier": "standard", "enabled": True, "notes": "strong local coder with native tool-calling + long context"},
     {"id": "ollama2-qwen3-coder", "provider": "ollama2", "match": "qwen3-coder*", "label": "Qwen3-Coder (GPU)",
      "cost_tier": "free", "max_complexity": "large", "context_window": 262144,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "strong local coder with native tool-calling + long context"},
+     "speed_tier": "standard", "enabled": True, "notes": "strong local coder with native tool-calling + long context"},
     {"id": "ollama-llama33", "provider": "ollama", "match": "llama3.3*", "label": "Llama 3.3 (self-hosted)",
      "cost_tier": "free", "max_complexity": "large", "context_window": 131072,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "native tool-calling; capable general planner/coordinator"},
+     "speed_tier": "standard", "enabled": True, "notes": "native tool-calling; capable general planner/coordinator"},
     {"id": "ollama2-llama33", "provider": "ollama2", "match": "llama3.3*", "label": "Llama 3.3 (GPU)",
      "cost_tier": "free", "max_complexity": "large", "context_window": 131072,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "native tool-calling; capable general planner/coordinator"},
+     "speed_tier": "standard", "enabled": True, "notes": "native tool-calling; capable general planner/coordinator"},
     {"id": "ollama-gemma4", "provider": "ollama", "match": "gemma4*", "label": "Gemma 4 (self-hosted)",
      "cost_tier": "free", "max_complexity": "large", "context_window": 131072,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "capable reasoning + JSON; tools left off (Gemma native tool-calling is unreliable)"},
+     "speed_tier": "fast", "enabled": True, "notes": "capable reasoning + JSON; tools left off (Gemma native tool-calling is unreliable)"},
     {"id": "ollama2-gemma4", "provider": "ollama2", "match": "gemma4*", "label": "Gemma 4 (GPU)",
      "cost_tier": "free", "max_complexity": "large", "context_window": 131072,
      "supports_tools": False, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": True, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "capable reasoning + JSON; tools left off (Gemma native tool-calling is unreliable)"},
+     "speed_tier": "fast", "enabled": True, "notes": "capable reasoning + JSON; tools left off (Gemma native tool-calling is unreliable)"},
     # --- Ollama Cloud per-model ladder ------------------------------------
     # The generic ollama-cloud `*` rule gives EVERY cloud model max_complexity
     # "large". That is right for the frontier-class cloud models (nemotron-3-
@@ -356,25 +389,25 @@ DEFAULT_MODEL_RULES = [
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 131072,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "smallest cloud tier (e.g. nemotron-3-nano:30b) -- fast/cheap, not a large-job model"},
+     "speed_tier": "fast", "enabled": True, "notes": "smallest cloud tier (e.g. nemotron-3-nano:30b) -- fast/cheap, not a large-job model"},
     {"id": "ollama-cloud-flash", "provider": "ollama_cloud", "match": "*flash*",
      "label": "Ollama Cloud (flash class)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 131072,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "latency-optimised cloud variants (e.g. deepseek-v4-flash, glm-5.3-flash)"},
+     "speed_tier": "fast", "enabled": True, "notes": "latency-optimised cloud variants (e.g. deepseek-v4-flash, glm-5.3-flash)"},
     {"id": "ollama-cloud-20b", "provider": "ollama_cloud", "match": "*:20b*",
      "label": "Ollama Cloud (20B class)",
      "cost_tier": "cheap", "max_complexity": "medium", "context_window": 131072,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True, "notes": "e.g. gpt-oss:20b -- the small open-weight cloud tier"},
+     "speed_tier": "standard", "enabled": True, "notes": "e.g. gpt-oss:20b -- the small open-weight cloud tier"},
     {"id": "ollama-cloud-ultra", "provider": "ollama_cloud", "match": "*ultra*",
      "label": "Ollama Cloud (ultra class)",
      "cost_tier": "cheap", "max_complexity": "large", "context_window": 262144,
      "supports_tools": True, "native_agentic_tools": False, "supports_mutating_agent": False,
      "supports_structured_output": False, "supports_batch": False, "supports_streaming": True,
-     "enabled": True,
+     "speed_tier": "slow", "enabled": True,
      "notes": "nemotron-3-ultra: 550B total / 55B active MoE, explicitly built for "
               "long-running agents across hundreds of tool calls. Stated as an explicit "
               "rule (rather than inheriting `*`) so the flagship is not silently "
@@ -733,6 +766,40 @@ def backfill_capability_ranks(rules):
                 new = {**new, "max_complexity": now}
                 changed = True
         out.append(new)
+    return out, changed
+
+
+def backfill_speed_tiers(rules):
+    """Return (new_rules, changed): a COPY of `rules` with `speed_tier`
+    backfilled onto the shipped default rules.
+
+    speed_tier lives ON rules an existing install already persisted, so an
+    append-only top-up cannot deliver it -- a frozen registry would fall back to
+    the capability_rank-derived prior for every endpoint and lose the hand-set
+    distinctions inside a rank band (Haiku and gpt-4o share a band with models
+    that are not latency-oriented at all).
+
+    Without it, latency_sensitive work (chat's first turn) orders on measured
+    perf alone, which starves a brand-new fast endpoint: with no samples it sits
+    on the tier MEDIAN and loses to any already-measured slower peer.
+
+    Scoped exactly like backfill_capability_ranks: only rules whose id is one
+    AppBuilder ships, only where no explicit value is set. Operator rules and
+    retuned values are untouched. Idempotent; never reorders, adds or removes."""
+    shipped = {r.get("id"): r.get("speed_tier")
+               for r in DEFAULT_MODEL_RULES if r.get("speed_tier")}
+    out = []
+    changed = False
+    for r in rules or []:
+        if not isinstance(r, dict):
+            out.append(r)
+            continue
+        rid = r.get("id")
+        if rid in shipped and not r.get("speed_tier"):
+            out.append({**r, "speed_tier": shipped[rid]})
+            changed = True
+        else:
+            out.append(r)
     return out, changed
 
 

--- a/model_selection.py
+++ b/model_selection.py
@@ -41,7 +41,11 @@ class LlmRequirements:
     min_context_tokens: int = 0                # HARD filter: context_window >= this * 1.25
     batch_ok: bool = False                     # consumed by the caller (llm_client), not this module
     needs_streaming: bool = False              # SOFT preference
-    latency_sensitive: bool = False            # informational; ranking already favors low latency
+    latency_sensitive: bool = False            # SOFT: order the chosen tier FASTEST-first
+                                               # (declared speed_tier, then measured perf).
+                                               # For chat's first turn, which must feel instant
+                                               # and can escalate afterwards. Yields to a
+                                               # capability request — see _rank_tier.
     must_escalate_to_human: bool = False       # consumed by the caller when select_model returns None
     restrict: str | None = None                # "local"|"cloud"|"claude" — HARD filter
     pin_key: str | None = None                 # exact ModelKey "provider|base_url|model" — HARD pin (chat_pin)
@@ -49,6 +53,13 @@ class LlmRequirements:
     prefer_capable: bool = False               # invert tier preference: pick the SMARTEST tier
                                                # first (frontier>cheap>free) instead of cheapest —
                                                # for the planner/router turn ("fast AND smart")
+    prefer_capable_within_tier: bool = False   # SOFT: order by capability_rank INSIDE whichever
+                                               # tier the cost preference already chose, WITHOUT
+                                               # inverting that preference. This is the "free but
+                                               # capable" knob: prefer_capable would spend frontier
+                                               # money, plain cheapest-first would take the fastest
+                                               # weakest model in the free tier. Log analysis wants
+                                               # neither — it wants the best FREE model.
     deprioritize_local: bool = False           # SOFT within-tier bias: rank no-key/local endpoints
                                                # (self-hosted GPU, LM Studio, claude_cli session) LAST
                                                # so offloadable work (log review, batch) prefers a
@@ -191,11 +202,30 @@ def _rank_tier(tier_candidates, perf, reqs, min_samples):
     # ladder is expressed as a rank instead of as a max_complexity cap that
     # hard-excluded the smaller models.
     #
-    # Everything below large still orders on speed, so light work keeps taking
-    # the fastest model in its tier rather than reaching for the smartest.
-    demanding = reqs.prefer_capable or reqs.complexity == "large"
+    # prefer_capable_within_tier asks for the same capability-primary ordering
+    # WITHOUT prefer_capable's tier inversion, which is how "free but capable"
+    # work (log analysis) gets the strongest model in the free tier instead of
+    # the fastest weakest one.
+    #
+    # Everything below large orders on SPEED. latency_sensitive makes that
+    # explicit and adds the declared speed_tier as the primary key, ahead of the
+    # measured score: a brand-new fast endpoint has no samples yet and would
+    # otherwise sit on the tier median, and measured latency alone cannot tell
+    # "inherently big and slow" apart from "fast model having a bad minute".
+    # The measured score still breaks ties inside a speed class, so real data
+    # decides between two fast models.
+    #
+    # Precedence is deliberate: capability WINS over latency_sensitive. A caller
+    # that asks for speed and then escalates (chat) must actually get a stronger
+    # model on the escalated call, so the escalation ladder for chat, builds,
+    # feature requests and bugfixes cannot be flattened by a stale speed flag.
+    demanding = (reqs.prefer_capable or reqs.prefer_capable_within_tier
+                 or reqs.complexity == "large")
     if demanding:
         stats.sort(key=lambda s: (registry.capability_rank(s["c"].get("caps") or {}), s["score"]),
+                   reverse=True)
+    elif reqs.latency_sensitive:
+        stats.sort(key=lambda s: (-registry.speed_rank(s["c"].get("caps") or {}), s["score"]),
                    reverse=True)
     else:
         stats.sort(key=lambda s: s["score"], reverse=True)
@@ -272,6 +302,13 @@ def _select_pass(reqs, candidates, perf, slow_factor, min_samples, allow_unknown
         other_tiers = [c for name, group in tiers.items() if name != tier_name for c in group]
         alternatives = survivors[1:] + other_tiers
         reason = f"tier={tier_name}, complexity>={reqs.complexity}"
+        # Name the axis that actually ordered the tier, so an operator reading
+        # Diagnostics can tell "picked for speed" from "picked for strength".
+        _bcaps = best.get("caps") or {}
+        if reqs.prefer_capable or reqs.prefer_capable_within_tier or reqs.complexity == "large":
+            reason += f", ranked by capability (rank={registry.capability_rank(_bcaps)})"
+        elif reqs.latency_sensitive:
+            reason += f", ranked by speed (speed={registry.speed_tier(_bcaps)})"
         if allow_unknown:
             reason += " (permissive pass: unclassified models admitted)"
         return Selection(
@@ -355,7 +392,8 @@ def explain_selection(reqs, candidates, perf=None, tuning=None):
 
         {"selected": {key, provider, model, tier, reason}|None,
          "permissive": bool,        # True if the winner came from the unclassified-admitting pass
-         "rows": [{key, provider, model, tier, status, reason, n, tps, latency_ms}, ...]}
+         "rows": [{key, provider, model, tier, speed, capability_rank,
+                    status, reason, n, tps, latency_ms}, ...]}
 
     Rows are ordered selected → alternatives (rank order) → excluded."""
     perf = perf or {}
@@ -375,6 +413,8 @@ def explain_selection(reqs, candidates, perf=None, tuning=None):
         row = {
             "key": key, "provider": c.get("provider"), "model": c.get("model"),
             "tier": caps.get("cost_tier"),
+            "speed": registry.speed_tier(caps),
+            "capability_rank": registry.capability_rank(caps),
             "n": s.get("n", 0) or 0, "tps": s.get("tps"), "latency_ms": s.get("latency_ms"),
         }
         if key == winner_key:

--- a/routes.py
+++ b/routes.py
@@ -780,6 +780,7 @@ def _endpoint_perf_rows(config):
     raises — a stats field must never 500 the page."""
     try:
         import llm_client
+        import model_registry
         cands = llm_client._enumerate_candidates(config)
         perf = llm_client.get_llm_perf_snapshot()  # {(provider, base_url, model): {n, tps, latency_ms}}
     except Exception:
@@ -795,6 +796,8 @@ def _endpoint_perf_rows(config):
             "model": c.get("model"),
             "base_url": c.get("base_url"),
             "tier": (c.get("caps") or {}).get("cost_tier"),
+            "speed": model_registry.speed_tier(c.get("caps") or {}),
+            "capability_rank": model_registry.capability_rank(c.get("caps") or {}),
             "n": p.get("n") or 0,
             "tps": round(tps, 1) if tps is not None else None,
             "latency_ms": round(latency, 1) if latency is not None else None,
@@ -2097,12 +2100,15 @@ async def settings_page(request: Request):
     _curated, _mr_or_router = _registry.upgrade_openrouter_free_router_rule(_curated)
     _curated, _mr_cp_tools = _registry.enable_copilot_tools(_curated)
     _curated, _mr_ranks = _registry.backfill_capability_ranks(_curated)
+    _curated, _mr_speeds = _registry.backfill_speed_tiers(_curated)
     _registry_rules_json = json.dumps(_curated, indent=2)
     _auto = config.get("model_registry_auto") or []
     _registry_preview = (
         [{"provider": r.get("provider"), "match": r.get("match"),
           "cost_tier": r.get("cost_tier"), "max_complexity": r.get("max_complexity"),
           "context_window": r.get("context_window"),
+          "speed_tier": _registry.speed_tier(r),
+          "capability_rank": _registry.capability_rank(r),
           "supports_tools": r.get("supports_tools"),
           "native_agentic_tools": r.get("native_agentic_tools"),
           "supports_structured_output": r.get("supports_structured_output"),
@@ -2112,6 +2118,8 @@ async def settings_page(request: Request):
         [{"provider": r.get("provider"), "match": r.get("model"),
           "cost_tier": r.get("cost_tier"), "max_complexity": r.get("max_complexity"),
           "context_window": r.get("context_window"),
+          "speed_tier": _registry.speed_tier(r),
+          "capability_rank": _registry.capability_rank(r),
           "supports_tools": r.get("supports_tools"),
           "native_agentic_tools": r.get("native_agentic_tools"),
           "supports_structured_output": r.get("supports_structured_output"),
@@ -2514,6 +2522,8 @@ async def save_settings(request: Request):
             config_data["model_registry"], _ = _registry_save.enable_copilot_tools(
                 config_data["model_registry"])
             config_data["model_registry"], _ = _registry_save.backfill_capability_ranks(
+                config_data["model_registry"])
+            config_data["model_registry"], _ = _registry_save.backfill_speed_tiers(
                 config_data["model_registry"])
 
     config_data["feature_build_timeout_s"] = int(data.get("feature_build_timeout_s")) \

--- a/templates/index.html
+++ b/templates/index.html
@@ -1321,7 +1321,10 @@
                                     <thead class="bg-slate-50 text-slate-500 uppercase"><tr>
                                         <th class="px-2 py-1 text-left">Provider</th><th class="px-2 py-1 text-left">Match</th>
                                         <th class="px-2 py-1 text-left">Cost</th><th class="px-2 py-1 text-left">Max</th>
-                                        <th class="px-2 py-1 text-right">Context</th><th class="px-2 py-1 text-center">Tools</th>
+                                        <th class="px-2 py-1 text-right">Context</th>
+                                        <th class="px-2 py-1 text-left" title="Declared speed class — the cold-start prior for latency-sensitive routing (chat). Measured tok/s still breaks ties inside a class.">Speed</th>
+                                        <th class="px-2 py-1 text-right" title="Relative strength WITHIN a cost tier (0-100). Orders demanding work (complexity=large, prefer_capable) — never filters.">Rank</th>
+                                        <th class="px-2 py-1 text-center">Tools</th>
                                         <th class="px-2 py-1 text-center">Agentic</th><th class="px-2 py-1 text-center">Struct</th>
                                         <th class="px-2 py-1 text-center">Batch</th><th class="px-2 py-1 text-left">Source</th>
                                     </tr></thead>
@@ -1333,6 +1336,8 @@
                                             <td class="px-2 py-1">{{ r.cost_tier }}</td>
                                             <td class="px-2 py-1">{{ r.max_complexity }}</td>
                                             <td class="px-2 py-1 text-right">{{ r.context_window }}</td>
+                                            <td class="px-2 py-1">{{ r.speed_tier }}</td>
+                                            <td class="px-2 py-1 text-right tabular-nums">{{ r.capability_rank }}</td>
                                             <td class="px-2 py-1 text-center">{{ '✓' if r.supports_tools else '' }}</td>
                                             <td class="px-2 py-1 text-center">{{ '✓' if r.native_agentic_tools else '' }}</td>
                                             <td class="px-2 py-1 text-center">{{ '✓' if r.supports_structured_output else '' }}</td>
@@ -2387,7 +2392,7 @@
                 <div class="overflow-x-auto">
                     <table class="w-full text-sm">
                         <thead class="text-left text-xs text-slate-500 uppercase tracking-wider">
-                            <tr><th class="py-2 pr-3">Provider</th><th class="py-2 pr-3">Model</th><th class="py-2 pr-3" title="Cost tier resolved from the Model Registry">Tier</th><th class="py-2 pr-3" title="Measured generation speed for this endpoint — median over completed generations, so idle time is excluded">tok/s</th><th class="py-2 pr-3" title="Median successful-call wire latency">Latency</th><th class="py-2 pr-3" title="Available, or the reason it is currently skipped (credit/rate cooldown, dead model)">Status</th><th class="py-2 pr-3" title="Number of measured generations">Runs</th></tr>
+                            <tr><th class="py-2 pr-3">Provider</th><th class="py-2 pr-3">Model</th><th class="py-2 pr-3" title="Cost tier resolved from the Model Registry">Tier</th><th class="py-2 pr-3" title="Declared speed class from the Model Registry — routes latency-sensitive work (chat) fastest-first, with measured tok/s breaking ties inside a class">Speed</th><th class="py-2 pr-3" title="Measured generation speed for this endpoint — median over completed generations, so idle time is excluded">tok/s</th><th class="py-2 pr-3" title="Median successful-call wire latency">Latency</th><th class="py-2 pr-3" title="Available, or the reason it is currently skipped (credit/rate cooldown, dead model)">Status</th><th class="py-2 pr-3" title="Number of measured generations">Runs</th></tr>
                         </thead>
                         <tbody id="diag-providers-body"></tbody>
                     </table>
@@ -3446,6 +3451,7 @@
                         + '<td class="py-2 pr-3 text-slate-700">' + (p.provider || '—') + '</td>'
                         + '<td class="py-2 pr-3 font-mono text-xs text-slate-600">' + (p.model || '—') + '</td>'
                         + '<td class="py-2 pr-3 text-xs text-slate-500">' + (p.tier || '—') + '</td>'
+                        + '<td class="py-2 pr-3 text-xs ' + (p.speed === 'fast' ? 'text-emerald-600' : 'text-slate-500') + '">' + (p.speed || '—') + '</td>'
                         // Throughput for THIS endpoint, keyed by ModelKey — the
                         // same (provider, base_url, model) reachable two ways is
                         // one figure. '—' when never measured, never 0.
@@ -3811,7 +3817,9 @@
                 body.innerHTML =
                     '<div class="overflow-x-auto"><table class="w-full text-sm">' +
                     '<thead><tr class="text-left text-xs uppercase tracking-wider text-slate-400 border-b border-slate-200">' +
-                    '<th class="py-2 pr-3">Endpoint</th><th class="py-2 pr-3">Tier</th><th class="py-2 pr-3 text-right">tok/s</th>' +
+                    '<th class="py-2 pr-3">Endpoint</th><th class="py-2 pr-3">Tier</th>' +
+                    '<th class="py-2 pr-3" title="Declared speed class from the Model Registry. Latency-sensitive work (chat) is routed fastest-first on this, with measured tok/s breaking ties — so a brand-new fast endpoint is not penalised for having no samples yet.">Speed</th>' +
+                    '<th class="py-2 pr-3 text-right">tok/s</th>' +
                     '<th class="py-2 pr-3 text-right">Latency</th><th class="py-2 pr-3 text-right">Runs</th>' +
                     '<th class="py-2 pr-3">Status</th><th class="py-2 w-1/4">Relative</th></tr></thead><tbody>' +
                     rows.map(r => {
@@ -3825,6 +3833,7 @@
                           '<td class="py-2 pr-3 font-mono text-xs ' + (isActive ? 'font-bold text-[#01A982]' : 'text-slate-700') + '">' +
                             _bfEsc(r.provider || '') + ' · ' + _bfEsc(r.model) + (isActive ? ' <span class="text-[10px] uppercase">active</span>' : '') + '</td>' +
                           '<td class="py-2 pr-3 text-xs text-slate-500">' + _bfEsc(r.tier || '—') + '</td>' +
+                          '<td class="py-2 pr-3 text-xs ' + (r.speed === 'fast' ? 'text-emerald-600' : 'text-slate-500') + '">' + _bfEsc(r.speed || '—') + '</td>' +
                           '<td class="py-2 pr-3 text-right tabular-nums font-semibold text-slate-800">' + (r.tps != null ? r.tps : '—') + '</td>' +
                           '<td class="py-2 pr-3 text-right tabular-nums text-slate-500">' + lat + '</td>' +
                           '<td class="py-2 pr-3 text-right tabular-nums text-slate-500">' + r.n + '</td>' +

--- a/test_model_registry.py
+++ b/test_model_registry.py
@@ -632,6 +632,128 @@ def main():
     ok &= _check("copilot tools repair leaves an operator's own rule alone",
                 _cp_op is False)
 
+    # ── speed_tier: the declared speed class that routes latency-sensitive work ──
+    ok &= _check("every shipped rule declares a valid speed_tier",
+                all(r.get("speed_tier") in reg.SPEED_RANK for r in reg.DEFAULT_MODEL_RULES))
+    ok &= _check("speed_rank orders fast < standard < slow",
+                reg.speed_rank({"speed_tier": "fast"}) < reg.speed_rank({"speed_tier": "standard"})
+                < reg.speed_rank({"speed_tier": "slow"}))
+    # A rule with no explicit value must still order sensibly, or an operator's
+    # own rule would be treated as exactly as fast as everything else.
+    ok &= _check("speed_tier falls back to a capability_rank-derived prior",
+                reg.speed_tier({"capability_rank": 95}) == "slow"
+                and reg.speed_tier({"capability_rank": 70}) == "standard"
+                and reg.speed_tier({"capability_rank": 30}) == "fast")
+    ok &= _check("speed_tier ignores a garbage value rather than trusting it",
+                reg.speed_tier({"speed_tier": "quick", "capability_rank": 95}) == "slow")
+    ok &= _check("the big reasoning models are not classed fast",
+                all(reg.speed_tier(reg.resolve(p, m, _cfg)) != "fast"
+                    for p, m in (("copilot", "claude-opus-5"), ("claude_cli", "claude-opus-5"),
+                                 ("ollama_cloud", "nemotron-3-ultra"))))
+    ok &= _check("the small/cheap models are classed fast",
+                all(reg.speed_tier(reg.resolve(p, m, _cfg)) == "fast"
+                    for p, m in (("copilot", "claude-haiku-4.5"), ("copilot", "gpt-4o-2024-08-06"),
+                                 ("google", "gemini-3.5-flash-lite"), ("openrouter", "openrouter/free"))))
+    ok &= _check("speed_tier is resolved as a capability, not dropped by resolve()",
+                reg.resolve("copilot", "claude-haiku-4.5", _cfg).get("speed_tier") == "fast")
+
+    # Ranking. The slow-class model is given the BETTER measured latency, so a
+    # pure perf sort would take it — proving the declared class actually leads.
+    _sp = [{"key": f"copilot|x|{m}", "provider": "copilot", "model": m,
+            "caps": reg.resolve("copilot", m, _cfg), "available": True}
+           for m in ("claude-opus-5", "claude-sonnet-5")]
+    _spperf = {"copilot|x|claude-opus-5":   {"n": 20, "tps": 90.0, "latency_ms": 1000},
+               "copilot|x|claude-sonnet-5": {"n": 20, "tps": 40.0, "latency_ms": 2500}}
+    _sppick = lambda **kw: getattr(
+        sel.select_model(sel.LlmRequirements(**kw), _sp, _spperf), "model", None)
+    ok &= _check("without latency_sensitive, measured perf still decides",
+                _sppick(complexity="small") == "claude-opus-5")
+    ok &= _check("latency_sensitive picks the FAST class over a better-measured slow one",
+                _sppick(complexity="small", latency_sensitive=True) == "claude-sonnet-5")
+    # Precedence: a stale speed flag must never flatten the escalation ladder
+    # for chat, builds, feature requests or bugfixes.
+    ok &= _check("complexity=large beats latency_sensitive",
+                _sppick(complexity="large", latency_sensitive=True) == "claude-opus-5")
+    ok &= _check("prefer_capable beats latency_sensitive",
+                _sppick(complexity="small", latency_sensitive=True,
+                        prefer_capable=True) == "claude-opus-5")
+    ok &= _check("prefer_capable_within_tier beats latency_sensitive",
+                _sppick(complexity="small", latency_sensitive=True,
+                        prefer_capable_within_tier=True) == "claude-opus-5")
+    # Cold start: with no samples every candidate sits on the tier MEDIAN, so
+    # before speed_tier a brand-new fast endpoint could not win on merit.
+    ok &= _check("latency_sensitive still works with ZERO perf samples",
+                getattr(sel.select_model(
+                    sel.LlmRequirements(complexity="small", latency_sensitive=True),
+                    _sp, {}), "model", None) == "claude-sonnet-5")
+
+    # Measured perf must still decide INSIDE a speed class — the class is a
+    # prior, not a replacement for data.
+    _tf = [{"key": f"copilot|x|{m}", "provider": "copilot", "model": m,
+            "caps": reg.resolve("copilot", m, _cfg), "available": True}
+           for m in ("claude-haiku-4.5", "gpt-4o-2024-08-06")]
+    _tfperf = {"copilot|x|claude-haiku-4.5":  {"n": 20, "tps": 50.0, "latency_ms": 2500},
+               "copilot|x|gpt-4o-2024-08-06": {"n": 20, "tps": 90.0, "latency_ms": 1000}}
+    ok &= _check("between two fast models the measurably faster one wins",
+                getattr(sel.select_model(
+                    sel.LlmRequirements(complexity="small", latency_sensitive=True),
+                    _tf, _tfperf), "model", None) == "gpt-4o-2024-08-06")
+    ok &= _check("prefer_capable_within_tier takes the stronger of the two instead",
+                getattr(sel.select_model(
+                    sel.LlmRequirements(complexity="small", prefer_capable_within_tier=True),
+                    _tf, _tfperf), "model", None) == "claude-haiku-4.5")
+
+    # "Free but capable" (log analysis): capability ordering INSIDE the tier the
+    # cost preference already chose, WITHOUT prefer_capable's tier inversion.
+    _mix = [{"key": f"{p}|x|{m}", "provider": p, "model": m,
+             "caps": reg.resolve(p, m, _cfg), "available": True}
+            for p, m in (("copilot", "claude-opus-5"), ("openrouter", "openrouter/free"))]
+    _mixperf = {"copilot|x|claude-opus-5":       {"n": 20, "tps": 90.0, "latency_ms": 1000},
+                "openrouter|x|openrouter/free":  {"n": 20, "tps": 30.0, "latency_ms": 2500}}
+    ok &= _check("prefer_capable_within_tier does NOT buy a more expensive tier",
+                getattr(sel.select_model(
+                    sel.LlmRequirements(complexity="small", prefer_capable_within_tier=True),
+                    _mix, _mixperf), "model", None) == "openrouter/free")
+    ok &= _check("prefer_capable, by contrast, DOES invert to the frontier tier",
+                getattr(sel.select_model(
+                    sel.LlmRequirements(complexity="small", prefer_capable=True),
+                    _mix, _mixperf), "model", None) == "claude-opus-5")
+
+    # The picker must be able to explain which axis ordered the tier.
+    _ex = sel.explain_selection(
+        sel.LlmRequirements(complexity="small", latency_sensitive=True), _sp, _spperf)
+    ok &= _check("explain_selection exposes speed and capability_rank per row",
+                all("speed" in r and "capability_rank" in r for r in _ex["rows"]))
+    ok &= _check("the selection reason names the axis that ordered the tier",
+                "ranked by speed" in (_ex["selected"] or {}).get("reason", ""))
+    ok &= _check("a capability-ordered pick says so instead",
+                "ranked by capability" in (sel.explain_selection(
+                    sel.LlmRequirements(complexity="large"), _sp, _spperf
+                )["selected"] or {}).get("reason", ""))
+
+    # Backfill migration: speed_tier lives ON already-persisted rules.
+    _frozen_sp = [dict(r) for r in reg.DEFAULT_MODEL_RULES]
+    for _r in _frozen_sp:
+        _r.pop("speed_tier", None)
+    _spf, _spc = reg.backfill_speed_tiers(_frozen_sp)
+    _, _spc2 = reg.backfill_speed_tiers(_spf)
+    ok &= _check("speed backfill repairs a frozen registry and is idempotent",
+                _spc is True and _spc2 is False
+                and all(r.get("speed_tier") in reg.SPEED_RANK for r in _spf))
+    ok &= _check("speed backfill never adds, drops or reorders rules",
+                [r["id"] for r in _spf] == [r["id"] for r in _frozen_sp])
+    _, _sp_default = reg.backfill_speed_tiers(reg.DEFAULT_MODEL_RULES)
+    ok &= _check("DEFAULT_MODEL_RULES already ship speed_tier — backfill is a no-op",
+                _sp_default is False)
+    _, _sp_op = reg.backfill_speed_tiers(
+        [{"id": "my-rule", "provider": "copilot", "match": "*", "enabled": True}])
+    ok &= _check("speed backfill leaves an operator's own rule alone", _sp_op is False)
+    _sp_tuned, _sp_tc = reg.backfill_speed_tiers(
+        [{"id": "copilot-opus", "provider": "copilot", "match": "*opus*",
+          "speed_tier": "fast", "enabled": True}])
+    ok &= _check("speed backfill never overwrites a value the operator retuned",
+                _sp_tc is False and _sp_tuned[0]["speed_tier"] == "fast")
+
     print()
     if ok:
         print("ALL CASES PASSED")


### PR DESCRIPTION
`latency_sensitive` has been declared on `LlmRequirements` but **never read** — the comment said *"informational; ranking already favors low latency"*. `chat.py` sets it in five places expecting a fast model, so those calls were silently ordering on measured perf alone.

That is not the same thing. Perf scores are min-max normalised *within* a tier, and a candidate under `min_samples` gets the tier **median** — so a brand-new fast endpoint cannot win on merit, because it has no samples yet. Measured latency also cannot tell *"inherently big and slow"* apart from *"fast model having a bad minute"*.

`speed_tier` (fast/standard/slow) is therefore a **declared class used as the cold-start prior**, with the measured score still breaking ties *inside* a class — real data keeps deciding between two fast models. Rules with no explicit value fall back to a `capability_rank`-derived prior, so operator rules degrade sanely instead of all looking equally fast.

### Precedence is the part that matters

```python
demanding = prefer_capable or prefer_capable_within_tier or complexity == "large"
if demanding:            sort by (capability_rank, score)
elif latency_sensitive:  sort by (speed_rank, score)
else:                    sort by score
```

Capability deliberately **wins over** `latency_sensitive`. A caller that asks for speed and then escalates must actually get a stronger model on the escalated call, so a stale speed flag can never flatten the ladder for chat, builds, feature requests or bugfixes. Tests pin all three guarantees.

### Free *but capable*

`prefer_capable` conflated two things: inverting tier order to smartest-first, **and** making capability primary within the tier. Log analysis wants only the second — the best **free** model. `prefer_capable` would spend frontier money; plain cost-first would take the fastest *weakest* model in the free tier. New `prefer_capable_within_tier` separates them; `log_scan` and `hub_agent` set it.

### Chat now genuinely escalates

`run_agent_loop` starts fastest-in-tier and switches to most-capable-in-tier after `chat_escalate_after_iters` (default 2) tool rounds — a question still calling tools after several rounds needs more reasoning than the fastest model has. It escalates **within the tier, not to frontier**: this is the dashboard's cost-first chat, and `llm_proxy`'s agentic path is the one that buys frontier. Skipped when the caller passed its own `tool_requirements` or the operator pinned a model. The forced final-synthesis turn inherits the escalation, since we only reach it by exhausting `max_iter` without an answer.

### Delivery + UI

`speed_tier` lives ON already-persisted rules, so an append-only top-up cannot deliver it — `backfill_speed_tiers` follows the established in-place repair pattern, wired into all three sites. Surfaced as a **Speed** column in both endpoint tables and the effective-registry preview (which also gained **Rank**), and `explain_selection` now reports speed + capability_rank per row and **names the axis that ordered the tier**, so "picked for speed" is distinguishable from "picked for strength".

### Verified

feature_build and fix_engine large paths still reach Opus · small mutating work still lands on Haiku · `prefer_capable_within_tier` stays in the free tier while `prefer_capable` inverts to frontier · `latency_sensitive` works with **zero** perf samples.

28 new cases. Full suite **53 pass / 0 fail**.