### PR TITLE
Route the hub's Ask-AI turns by role instead of sending them all identically

### DIFF
--- a/hub_agent.py
+++ b/hub_agent.py
@@ -1244,8 +1244,51 @@ class HubAgentClient:
                 # tool set (if any) is caller-supplied by the hub itself, not fixed
                 # ahead of time -- so needs_tools mirrors whether the hub actually
                 # sent any this turn.
-                _help_ask_reqs = LlmRequirements(
-                    complexity="medium", needs_tools=bool(tools), latency_sensitive=True)
+                #
+                # ROLE-BASED ROUTING. Every turn used to be routed identically:
+                # cost-first + latency_sensitive, which resolves to the FREE tier --
+                # so the free model both picked the tools AND wrote the final prose.
+                # That is the wrong split. Choosing a tool and a query string is an
+                # easy, latency-critical job; turning the gathered docs/code into a
+                # correct answer is the hard one, and it happens ONCE per question.
+                #
+                # The hub tags each turn (it owns the loop, so only it knows which
+                # turn this is) and we map that to requirements:
+                #
+                #   tool       fastest capable model -- many of these per question
+                #   tool_hard  the loop is struggling: same tier, strongest model
+                #   final      the single synthesis turn: smartest available
+                #
+                # Not latency-free by accident: on the measured endpoints the free
+                # model is SLOWER than both Sonnet and Opus, so this is faster as
+                # well as better.
+                #
+                # Unknown/absent role falls back to the previous behaviour, so an
+                # older hub that doesn't send one keeps working unchanged.
+                _role = str(data.get("role") or "").strip().lower()
+                if _role == "final":
+                    # No tools on this turn by construction, and it is the answer the
+                    # user actually reads -- buy the best model available.
+                    _help_ask_reqs = LlmRequirements(
+                        complexity="large", needs_tools=bool(tools),
+                        prefer_capable=True)
+                elif _role == "tool_hard":
+                    # Escalated tool turn: the hub told us its searches aren't
+                    # landing. Raise complexity to "large" as well as asking for the
+                    # strongest model in tier -- the flag ALONE is not enough, because
+                    # max_complexity is a hard FILTER while capability_rank only
+                    # orders. With the free tier holding a single endpoint,
+                    # "best within tier" is a no-op there and the weak model would be
+                    # re-picked forever; raising complexity is what actually filters
+                    # it out and promotes a stronger one. Still not prefer_capable:
+                    # that jumps to the frontier tier, and several tool turns may
+                    # remain.
+                    _help_ask_reqs = LlmRequirements(
+                        complexity="large", needs_tools=bool(tools),
+                        prefer_capable_within_tier=True)
+                else:
+                    _help_ask_reqs = LlmRequirements(
+                        complexity="medium", needs_tools=bool(tools), latency_sensitive=True)
                 # call_llm does NOT return a (value, error) tuple — it returns the
                 # result directly (a {"text", "tool_calls"} dict when `tools` is
                 # passed, per _request_ollama et al.; a bare string otherwise) and

--- a/test_model_registry.py
+++ b/test_model_registry.py
@@ -754,6 +754,55 @@ def main():
     ok &= _check("speed backfill never overwrites a value the operator retuned",
                 _sp_tc is False and _sp_tuned[0]["speed_tier"] == "fast")
 
+    # ── Help-assistant role ladder ───────────────────────────────────────────
+    # The hub's Ask-AI loop tags each turn with a `role` and hub_agent.py maps it
+    # to requirements. Before this, EVERY turn routed identically (cost-first +
+    # latency_sensitive), so the free model both picked the tools and wrote the
+    # user-visible answer. These pin the three rungs against the real measured
+    # endpoint mix, because the mapping is only correct relative to a registry:
+    # the escalated rung in particular is a silent no-op unless complexity rises.
+    _ha = [("claude_cli", "claude-opus-5", 70.1, 110263, 19),
+           ("google", "gemini-3.5-flash-lite", 41.3, 233189, 2),
+           ("ollama_cloud", "nemotron-3-ultra", 16.1, 59989, 49),
+           ("openrouter", "openrouter/free", None, 9533, 50),
+           ("copilot", "claude-haiku-4.5", None, 9923, 5),
+           ("copilot", "claude-sonnet-5", None, 4411, 4),
+           ("copilot", "claude-opus-5", None, 7414, 4),
+           ("copilot", "gpt-4o-2024-08-06", None, 4453, 2)]
+    _hac = [{"key": f"{p}|x|{m}", "provider": p, "model": m,
+             "caps": reg.resolve(p, m, _cfg), "available": True}
+            for p, m, _t, _l, _n in _ha]
+    _hap = {f"{p}|x|{m}": {"n": n, "tps": t, "latency_ms": l}
+            for p, m, t, l, n in _ha}
+    _hapick = lambda **kw: getattr(
+        sel.select_model(sel.LlmRequirements(**kw), _hac, _hap), "model", None)
+    _r_tool = _hapick(complexity="medium", needs_tools=True, latency_sensitive=True)
+    _r_hard = _hapick(complexity="large", needs_tools=True,
+                      prefer_capable_within_tier=True)
+    _r_final = _hapick(complexity="large", needs_tools=False, prefer_capable=True)
+    ok &= _check("help role=tool stays on the cheap/fast model",
+                _r_tool == "openrouter/free")
+    ok &= _check("help role=final buys the strongest model",
+                _r_final == "claude-opus-5")
+    ok &= _check("help role=tool_hard escalates off the fast model",
+                _r_hard != _r_tool)
+    # The escalation is driven by max_complexity, which is a hard FILTER, not by
+    # capability_rank, which only orders (and is unset on several shipped rules).
+    # Asserting the ceiling is therefore asserting the actual mechanism: the
+    # escalated turn lands on a model that can take work the fast one cannot.
+    _hacap = lambda model: next(
+        reg.resolve(p, m, _cfg).get("max_complexity")
+        for p, m, _t, _l, _n in _ha if m == model)
+    ok &= _check("help role=tool_hard escalates past the fast model's ceiling",
+                _hacap(_r_tool) == "medium" and _hacap(_r_hard) == "large")
+    ok &= _check("help role=tool_hard stops SHORT of the frontier answer model",
+                _r_hard != _r_final)
+    # Regression: prefer_capable_within_tier ALONE cannot escalate a tier that
+    # holds a single endpoint — this is why the mapping raises complexity too.
+    ok &= _check("within-tier preference alone is a no-op in a one-model tier",
+                _hapick(complexity="medium", needs_tools=True,
+                        prefer_capable_within_tier=True) == _r_tool)
+
     print()
     if ok:
         print("ALL CASES PASSED")


### PR DESCRIPTION
Every `HELP_ASK` turn arrived with the same requirements (`complexity=medium`, `latency_sensitive`), which resolves to the cheapest endpoint. So the free model both picked the tools **and** wrote the user-visible answer — the reason simple questions came back with poor results.

The hub now tags each turn (it owns the loop, so it's the only side that knows which turn is which). The mapping:

| role | requirements | why |
|---|---|---|
| `final` | `complexity=large` + `prefer_capable` | the answer the user reads, bought once per question |
| `tool_hard` | `complexity=large` + `prefer_capable_within_tier` | an escalated gathering turn |
| `tool` | unchanged fast path | many per question, latency-critical |

Against the current measured endpoints this yields a real three-step ladder:

```
tool      -> openrouter/free
tool_hard -> ollama_cloud/nemotron-3-ultra
final     -> copilot/claude-opus-5
```

`tool_hard` raises complexity as well as setting the within-tier preference. The flag **alone is not enough**: `max_complexity` is a hard *filter* while `capability_rank` only *orders*, so with a single endpoint in the free tier "strongest in tier" is a no-op and the weak model would be re-picked forever. Raising complexity is what actually promotes it. It deliberately stops short of `prefer_capable`, which inverts to the frontier tier — several tool turns may still remain.

This is not a speed/quality trade: on the measured endpoints the free model is *slower* than both Sonnet and Opus, so the answer turn gets faster as well as better.

An absent or unknown `role` keeps the previous behaviour, so a hub that predates this change is unaffected.

## Testing
Six new cases in `test_model_registry.py` pin all three rungs against the real measured endpoint mix, including a regression for the within-tier no-op — the mapping is only correct relative to a registry. Full file passes (168 cases). The other pre-existing test-file failures are unchanged (verified by stashing).