### PR TITLE
Add front-matter to docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+---
+summary: "Doc index for the ab repo: links to this module's feature reference and the shared LM architecture/topology page."
+keywords: [ab, documentation, index]
+---
+
 # ab — docs
 
 This repo carries a copy of its LM feature page plus the shared topology page:

--- a/docs/ab.md
+++ b/docs/ab.md
@@ -1,3 +1,8 @@
+---
+summary: "Autonomous bot, and an optional hub agent (not a spoke). Repo: ab. See architecture-topology.md."
+keywords: [ab, authentication, behaviors, commands, dashboard, get_logs, hub_agent, install_github, module_type, set_log_level]
+---
+
 # ab — Autonomous GitHub Issue Fixer
 
 Autonomous bot, and an optional hub **agent** (not a spoke). Repo: `ab`. See [architecture-topology.md](architecture-topology.md).

--- a/docs/architecture-topology.md
+++ b/docs/architecture-topology.md
@@ -1,3 +1,8 @@
+---
+summary: "This is the shared backbone page for the Lab Manager (LM) system."
+keywords: [architecture, cs, hub, install_agent, install_all, install_pxmx, lm, mesh, module_type, overview, pxmx, recovery, spoke, topology]
+---
+
 # Architecture & Topology
 
 This is the shared backbone page for the Lab Manager (LM) system. It describes the hub/spoke/agent mesh, the WebSocket + TLS scheme, discovery, message signing, onboarding, log relay, self-update, and state/tenancy. Every module page cross-references this one. The canonical copy lives in `lm/docs/`; each repo carries a verbatim copy in its own `docs/`.


### PR DESCRIPTION
Short `summary` + `keywords` block on each doc, matching the canonical set in `lm/docs`.

The hub help assistant scores these when choosing which docs to put in front of the model — keywords bridge the gap between the word a user types and the word the doc uses, which plain full-text matching cannot do. The block is stripped before rendering, so readers never see it.

Generated and verified alongside lbockenstedt/lm#457.