### PR TITLE
Self-update from the deployed branch, not hardcoded main

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,11 +86,16 @@ fi
 git config --system --add safe.directory "$INSTALL_DIR" 2>/dev/null || true
 if [ ! -d "$INSTALL_DIR/.git" ]; then
     echo ">> Cloning AppBuilder to $INSTALL_DIR..."
-    git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
+    # AB_BRANCH lets a dev/qa host be provisioned straight onto its branch.
+    git clone --depth 1 --branch "${AB_BRANCH:-main}" "$REPO_URL" "$INSTALL_DIR"
 else
     echo ">> Updating existing install in $INSTALL_DIR..."
-    git -C "$INSTALL_DIR" fetch origin
-    git -C "$INSTALL_DIR" reset --hard origin/main
+    # Follow the branch the install is on so re-running the installer on a
+    # dev/qa host does not silently move it back to main.
+    BR=$(git -C "$INSTALL_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    case "$BR" in ""|HEAD) BR=main ;; esac
+    git -C "$INSTALL_DIR" fetch origin "$BR"
+    git -C "$INSTALL_DIR" reset --hard "origin/$BR"
 fi
 # svc_bg owns the whole tree (git clone/pull/push, the venv, claude creds in
 # ~svc_bg). Migrates an existing root-owned install on re-run.

--- a/update.sh
+++ b/update.sh
@@ -7,17 +7,22 @@ echo "🔄 Updating AppBuilder from GitHub..."
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$DIR"
 
-# 1. Fetch + hard-reset to origin/main. /opt/ab is a deployment mirror, so a
+# 1. Fetch + hard-reset to the deployed branch. /opt/ab is a deployment mirror, so a
 # plain `git pull` aborts on "local changes would be overwritten" if any tracked
 # file was dirtied at runtime. Reset is robust to that (matches the in-process
 # self-update). Any local changes are intentionally discarded.
 if [ -d ".git" ]; then
-    git fetch origin main
+    # Track the branch this deployment is checked out on rather than a hardcoded
+    # "main", so a dev/qa instance is not reset back onto main. Detached HEAD
+    # (or any failure) falls back to main.
+    BR=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    case "$BR" in ""|HEAD) BR=main ;; esac
+    git fetch origin "$BR"
     if ! git diff --quiet HEAD; then
         echo "⚠️  Local changes present — discarding (deployment mirror):"
         git status --porcelain
     fi
-    git reset --hard origin/main
+    git reset --hard "origin/$BR"
 else
     echo "❌ Error: This directory is not a git repository. Please run setup.sh first."
     exit 1


### PR DESCRIPTION
Required for running dev/QA instances: this module hard-reset its checkout to `origin/main` on every update, so a dev or qa host was silently moved back onto main. It now follows the branch the checkout is on, falling back to main on a detached HEAD.