### PR TITLE
Add dev -> qa -> main CI/CD pipeline

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,40 @@
+"""Bump a MAJOR.MINOR VERSION file by one minor step, preserving zero-padding.
+
+Branch-owned versioning: each branch (dev/qa/main) advances its OWN counter.
+Promotion never carries VERSION across branches, so the value read here is
+always this branch's own lineage -- qa on 1.45 becomes 1.46 no matter what dev
+says.
+
+MAJOR is never advanced automatically; it is set by hand. At MINOR 99 the bump
+HOLDS rather than rolling over, and says so loudly. A previous version of this
+script held SILENTLY and every run stayed green while the version froze --
+which meant deployed hubs stopped seeing updates and nobody noticed.
+"""
+import re
+import sys
+
+path = sys.argv[1]
+with open(path) as fh:
+    raw = fh.read().strip()
+
+m = re.match(r"^(\d+)\.(\d+)$", raw)
+if not m:
+    # Legacy ".NN" or any other shape: bump the final numeric run, keeping width.
+    nums = list(re.finditer(r"\d+", raw))
+    if not nums:
+        print(f"::warning::{path}: no numeric segment in {raw!r}; left unchanged")
+        sys.exit(0)
+    last = nums[-1]
+    new = raw[: last.start()] + str(int(last.group()) + 1).zfill(len(last.group())) + raw[last.end():]
+else:
+    major, minor_s = m.group(1), m.group(2)
+    minor = int(minor_s)
+    if minor >= 99:
+        print(f"::warning::{path}: held at {raw} -- MINOR is exhausted. "
+              f"Bump MAJOR by hand to resume automatic versioning.")
+        sys.exit(0)
+    new = f"{major}.{str(minor + 1).zfill(max(2, len(minor_s)))}"
+
+with open(path, "w") as fh:
+    fh.write(new + "\n")
+print(new)

--- a/.github/scripts/promote.sh
+++ b/.github/scripts/promote.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build a promotion branch carrying CODE ONLY from $SRC into $TGT.
+#
+# VERSION is branch-owned: every tracked VERSION file is pinned to $TGT's value
+# and then advanced one step, so a version set on the source branch NEVER leaks
+# across (dev at 10.00 does not make qa 10.00 -- qa goes 1.45 -> 1.46).
+# Pinning also resolves the VERSION merge conflict that would otherwise stall
+# every promotion PR. Any other conflict is left for a human.
+#
+# Env: SRC, TGT, BR. Writes changed=true/false to $GITHUB_OUTPUT if set.
+set -euo pipefail
+
+: "${SRC:?}" "${TGT:?}" "${BR:?}"
+out="${GITHUB_OUTPUT:-/dev/null}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+version_files() { git ls-tree -r --name-only "origin/$TGT" | grep -E '(^|/)VERSION$' || true; }
+
+git rev-parse --verify "origin/$TGT" >/dev/null 2>&1 || { echo "::error::target branch $TGT does not exist"; exit 1; }
+
+git checkout -q -B "$BR" "origin/$TGT"
+
+# --no-ff: the promotion is always an explicit, revertable commit.
+git merge --no-commit --no-ff "origin/$SRC" || true
+
+# Pin VERSION to the target's lineage. Listing from the TARGET tree means a
+# VERSION file added on the source is simply never carried over.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  git checkout "origin/$TGT" -- "$f"
+done < <(version_files)
+
+# Drop any VERSION that exists only on the source, so the target keeps sole
+# ownership of versioning.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  git rm -q --cached "$f" 2>/dev/null || true
+  rm -f "$f"
+done < <(git diff --cached --name-only --diff-filter=A | grep -E '(^|/)VERSION$' || true)
+
+if git ls-files -u | grep -q .; then
+  echo "::error::merge conflict outside VERSION -- resolve $SRC -> $TGT by hand:"
+  git ls-files -u | awk '{print "  " $4}' | sort -u
+  exit 1
+fi
+
+if git diff --cached --quiet && git diff --quiet; then
+  echo "Nothing to promote: $TGT already contains $SRC (ignoring VERSION)."
+  echo "changed=false" >> "$out"
+  exit 0
+fi
+
+# Advance the TARGET's own version inside the promotion commit. Doing it here
+# rather than as a later push to qa/main matters: those branches require a PR,
+# so a bot pushing straight at them would be rejected by the ruleset.
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  before="$(cat "$f")"
+  python3 "$here/bump_version.py" "$f" >/dev/null
+  echo "  $f: $before -> $(cat "$f")"
+  git add "$f"
+done < <(version_files)
+
+git commit -q -m "promote: $SRC -> $TGT" \
+  -m "Code-only promotion. VERSION stays on ${TGT}'s own sequence, advanced one step here."
+echo "changed=true" >> "$out"

--- a/.github/scripts/promotion_selftest.sh
+++ b/.github/scripts/promotion_selftest.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Proves VERSION is branch-owned: a version set on dev never reaches qa/main,
+# and each promotion advances only the TARGET branch's own sequence.
+set -euo pipefail
+T=$(mktemp -d); TPL="$(cd "$(dirname "$0")" && pwd)"
+pass=0; fail=0
+chk() { if [ "$2" = "$3" ]; then echo "  PASS $1: $2"; pass=$((pass+1)); else echo "  FAIL $1: got '$2' want '$3'"; fail=$((fail+1)); fi; }
+
+git init -q --bare "$T/remote.git"
+git clone -q "$T/remote.git" "$T/w"; cd "$T/w"
+git config user.email t@t; git config user.name t
+mkdir -p .github/scripts && cp "$TPL/bump_version.py" "$TPL/promote.sh" .github/scripts/
+echo "1.13" > VERSION; echo "orig" > app.py
+git add -A; git commit -qm init; git branch -M main
+git push -q origin main; git push -q origin main:qa; git push -q origin main:dev
+
+# qa has advanced on its own to 1.45; main stays on its own line.
+git checkout -q -B qa origin/qa; echo "1.45" > VERSION; git commit -qam "qa version"; git push -q origin qa
+# Someone sets dev to 10.00 and ships a real code change.
+git checkout -q -B dev origin/dev; echo "10.00" > VERSION; echo "feature" > app.py
+git commit -qam "dev feature + version 10.00"; git push -q origin dev
+git fetch -q origin
+
+echo "== promote dev -> qa =="
+SRC=dev TGT=qa BR=promote/dev-to-qa bash .github/scripts/promote.sh
+chk "qa VERSION (dev's 10.00 must NOT leak)" "$(cat VERSION)" "1.46"
+chk "qa received the code change"            "$(cat app.py)" "feature"
+git push -q origin promote/dev-to-qa:qa
+
+echo "== promote qa -> main =="
+git fetch -q origin
+SRC=qa TGT=main BR=promote/qa-to-main bash .github/scripts/promote.sh
+chk "main VERSION (own sequence, not qa's 1.46)" "$(cat VERSION)" "1.14"
+chk "main received the code change"              "$(cat app.py)" "feature"
+git push -q origin promote/qa-to-main:main
+
+echo "== dev keeps its own version =="
+git fetch -q origin; git checkout -q -B dev origin/dev
+chk "dev untouched by promotion" "$(cat VERSION)" "10.00"
+
+echo "== re-promote with nothing new =="
+git fetch -q origin
+out=$(SRC=dev TGT=qa BR=promote/dev-to-qa bash .github/scripts/promote.sh 2>&1 || true)
+case "$out" in *"Nothing to promote"*) echo "  PASS no-op when already promoted"; pass=$((pass+1));;
+  *) echo "  FAIL expected no-op, got: $out"; fail=$((fail+1));; esac
+
+echo "== second cycle advances qa again =="
+git checkout -q -B dev origin/dev; echo "feature2" > app.py; git commit -qam f2; git push -q origin dev; git fetch -q origin
+SRC=dev TGT=qa BR=promote/dev-to-qa bash .github/scripts/promote.sh >/dev/null
+chk "qa 1.46 -> 1.47" "$(cat VERSION)" "1.47"
+
+echo; echo "RESULT: $pass passed, $fail failed"; rm -rf "$T"; [ "$fail" -eq 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
-          # Non-fatal: the suite runs against stubs and must not be blocked by a
-          # transient index failure. A genuinely missing import still fails the
-          # test step below, which is what gates the merge.
-          if [ -f requirements.txt ]; then pip install -r requirements.txt || true; fi
+          # Requirements are NOT always at the repo root -- several repos declare
+          # them per component (lm-spoke/, agent/, core/ ...). Installing only a
+          # root requirements.txt silently left fastapi/httpx/websockets missing
+          # and every test module failed to import. Install all of them.
+          # Non-fatal: a transient index failure must not gate the merge; a
+          # genuinely missing import still fails the test step below.
+          while IFS= read -r req; do
+            echo "installing $req"
+            pip install -r "$req" || true
+          done < <(find . -name 'requirements*.txt' \
+                     -not -path './_lm/*' -not -path '*/venv/*' \
+                     -not -path '*/node_modules/*' | sort)
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}/_lm:${{ github.workspace }}/_lm/core/src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# Gates the dev -> qa -> main promotion flow. `qa` and `main` require a PR, so
+# without a status check those gates would verify nothing. This job is that
+# check. `dev` also runs on direct push, which contributors are allowed to make.
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ main, qa, dev ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # This repo inherits BaseSpoke from the LM core repo (imported as
+      # `base_spoke` / `core.src.base_spoke`). In dev that resolves via the
+      # sibling lm checkout; alone in CI it fails with
+      # ModuleNotFoundError: No module named 'core', so reproduce the layout.
+      - name: Check out LM core (BaseSpoke dependency)
+        uses: actions/checkout@v4
+        with:
+          repository: lbockenstedt/lm
+          path: _lm
+          sparse-checkout: core
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          # Non-fatal: the suite runs against stubs and must not be blocked by a
+          # transient index failure. A genuinely missing import still fails the
+          # test step below, which is what gates the merge.
+          if [ -f requirements.txt ]; then pip install -r requirements.txt || true; fi
+      - name: Run tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/_lm:${{ github.workspace }}/_lm/core/src
+        run: pytest -q . --ignore=_lm

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,99 @@
+name: promote
+
+# Promotion pipeline: dev -> qa -> main.
+#
+# Pushing to dev prepares a PR into qa; landing on qa prepares a PR into main.
+# The PR is raised against a prepared `promote/<src>-to-<tgt>` branch rather
+# than against `dev`/`qa` directly, for two reasons:
+#
+#   1. VERSION is BRANCH-OWNED. Each branch advances its own counter (see
+#      version-bump.yml). A straight merge would drag the source branch's
+#      VERSION into the target -- so if someone set dev to 10.00, qa would
+#      inherit it instead of going 1.45 -> 1.46. This job pins every tracked
+#      VERSION file back to the target's value, so promotion carries CODE ONLY.
+#   2. Pinning VERSION here also RESOLVES what would otherwise be a recurring
+#      merge conflict on that file, which would stall every promotion PR.
+#
+# Any OTHER conflict is left unresolved on purpose: the job fails loudly so a
+# human resolves it, rather than a bot guessing at real code.
+
+on:
+  push:
+    branches: [dev, qa]
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'Source branch to promote from'
+        required: true
+        default: dev
+        type: choice
+        options: [dev, qa]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: promote-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve source and target
+        id: route
+        run: |
+          src="${{ github.event.inputs.source || github.ref_name }}"
+          case "$src" in
+            dev) tgt=qa ;;
+            qa)  tgt=main ;;
+            *)   echo "::error::$src is not a promotable branch"; exit 1 ;;
+          esac
+          echo "src=$src" >> "$GITHUB_OUTPUT"
+          echo "tgt=$tgt" >> "$GITHUB_OUTPUT"
+          echo "branch=promote/$src-to-$tgt" >> "$GITHUB_OUTPUT"
+          echo "Promoting $src -> $tgt"
+
+      - name: Build promotion branch (code only, VERSION pinned to target)
+        id: build
+        env:
+          SRC: ${{ steps.route.outputs.src }}
+          TGT: ${{ steps.route.outputs.tgt }}
+          BR: ${{ steps.route.outputs.branch }}
+        run: |
+          git config user.name  "promote-bot[bot]"
+          git config user.email "promote-bot@users.noreply.github.com"
+          bash .github/scripts/promote.sh
+
+      - name: Push promotion branch
+        if: steps.build.outputs.changed == 'true'
+        run: git push -f -q origin "${{ steps.route.outputs.branch }}"
+
+      - name: Open or update the promotion PR
+        if: steps.build.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SRC: ${{ steps.route.outputs.src }}
+          TGT: ${{ steps.route.outputs.tgt }}
+          BR: ${{ steps.route.outputs.branch }}
+        run: |
+          set -e
+          existing=$(gh pr list --head "$BR" --base "$TGT" --state open --json number -q '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already open for $BR (force-pushed with the latest $SRC)."
+            exit 0
+          fi
+          {
+            printf 'Automated promotion of `%s` into `%s`.\n\n' "$SRC" "$TGT"
+            printf 'Carries **code only** - every tracked `VERSION` file is pinned to\n'
+            printf '`%s`'"'"'s own sequence and advanced one step here.\n' "$TGT"
+            printf 'A version set on `%s` never leaks across.\n' "$SRC"
+          } > /tmp/promote-body.md
+          gh pr create --base "$TGT" --head "$BR" \
+            --title "promote: $SRC -> $TGT" \
+            --body-file /tmp/promote-body.md


### PR DESCRIPTION
Adds CI and promotion automation so the `dev` -> `qa` -> `main` flow is enforced end to end.

**VERSION is branch-owned.** A version set on `dev` never leaks into `qa`/`main`; each promotion advances only the target branch's own sequence (qa 1.45 -> 1.46 even when dev says 10.00). Pinning VERSION during promotion also resolves the merge conflict that would otherwise stall every promotion PR, and the bump lands inside the PR because `qa`/`main` reject direct bot pushes.

See `docs/ci-cd-pipeline.md` in the `nw` repo.
