### PR TITLE
feat(llm-proxy): require an API token and expose the key in Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,13 @@ export ANTHROPIC_API_KEY="<your-proxy-key>"   # matches AB_PROXY_KEY / llm_proxy
 claude
 ```
 
-**Auth:** the `/v1/*` endpoints are exempt from the WebUI login and do their own
-API-key check. Set a key via the `AB_PROXY_KEY` env var or the
-`llm_proxy_api_key` config value; clients send it as `x-api-key` or
-`Authorization: Bearer`. If no key is configured the endpoint is **open** (a warning
-is logged per request) — fine on a trusted LAN, but set a key for anything exposed.
+**Auth: a token is required.** The `/v1/*` endpoints are exempt from the WebUI
+login and do their own API-key check, and they **fail closed** — with no key
+configured every request is refused with `401`. Set a key in
+**Settings → Automation → LLM Router API Key** (there is a *Generate* button; the
+value is stored redacted and never re-displayed), or via the `AB_PROXY_KEY` env
+var / `llm_proxy_api_key` config value. `AB_PROXY_KEY` wins if both are set.
+Clients send it as `x-api-key` or `Authorization: Bearer`.
 
 Endpoints: `POST /v1/messages`, `POST /v1/messages/count_tokens`, `GET /v1/models`.
 

--- a/docs/ab.md
+++ b/docs/ab.md
@@ -46,6 +46,8 @@ FastAPI dashboard on **8000** (HTTP). No WS listener — it is a WS **client** t
   - Endpoints: `GET /auth/oidc/enabled` (login page probe), `GET /auth/oidc/login` (→ Entra), `GET /auth/oidc/callback` (verifies id-token signature/issuer/audience/nonce, provisions the user, issues a session). The id-token is verified against the Entra JWKS; MFA is enforced by Entra Conditional Access, not in-token.
   - Entra users are provisioned into `users.json` as passwordless `auth_type:"entra"` accounts (keyed by email/UPN, else `oid`), so they can only ever SSO in and can never password-log-in. A local password account is never silently converted.
   - Redirect URI to register in Entra: `https://<host>/auth/oidc/callback`.
+- **LLM router API key** (`llm_proxy.py`) — the `/v1/*` endpoints are exempt from the session middleware (`main._AUTH_EXEMPT_PREFIX`) and do their own key check, so they are the one surface the WebUI login does **not** protect. They **fail closed**: with no key configured every request is refused with `401`. Set it in **Settings → Automation → LLM Router API Key** (a *Generate* button mints a 32-byte base64url key client-side), or via `AB_PROXY_KEY` / `llm_proxy_api_key`; the env var wins. Clients send `x-api-key` or `Authorization: Bearer`.
+  - The stored key is redacted out of the template context in `settings_page` (the whole config is otherwise merged in via `{**settings, **config}`), so it is never embedded in the served HTML. The input therefore renders blank, and because Settings is ONE form that submits every field from any tab, a blank value means **keep the stored key** — clearing is explicit, via the `__CLEAR__` sentinel the *Clear* button sets.
 
 ## Notable behaviors & gotchas
 

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -12,10 +12,14 @@ JSON, or a synthetic SSE stream when the client asks for ``stream: true``).
 
 Auth: the WebUI's session middleware is bypassed for ``/v1/*`` (see main's
 ``_AUTH_EXEMPT_PREFIX``); this router does its own API-key check instead. Set a
-key via the ``AB_PROXY_KEY`` env var or the ``llm_proxy_api_key`` config
-value and clients must send it as ``x-api-key`` or ``Authorization: Bearer``.
-With no key configured the endpoint is open (a warning is logged) — fine for a
-trusted LAN, but set a key for anything exposed.
+key in Settings > Automation ("LLM Router API Key"), or via the ``AB_PROXY_KEY``
+env var / ``llm_proxy_api_key`` config value, and clients must send it as
+``x-api-key`` or ``Authorization: Bearer``.
+
+A token is REQUIRED. This endpoint FAILS CLOSED: with no key configured every
+request is refused (401). It previously defaulted to open-with-a-log-warning,
+which on a ``0.0.0.0`` bind meant anyone who could reach the host could drive
+the router — and, with the agentic toggles on, the fix pipeline behind it.
 
 Tool use round-trips: Anthropic ``tools`` / ``tool_use`` / ``tool_result``
 blocks map onto the internal OpenAI-style ``tools`` param and tool-call return
@@ -23,6 +27,7 @@ shape (``{"text", "tool_calls"}``), so an agentic client's tool loop works
 through the proxy.
 """
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -84,7 +89,8 @@ def _proxy_fix_proposal(descriptor: Dict[str, Any], text: str,
     process_single_issue pipeline (full autonomy) — which clones, fixes, runs
     tests, and gates the merge through the review panel, with core-systems
     diffs forced to a human-reviewed PR (never direct-push). Defaults OFF so an
-    open/keyless proxy never mutates without an explicit operator opt-in."""
+    proxy never mutates without an explicit operator opt-in (defence in depth:
+    the key check already refuses unauthenticated callers)."""
     repo = descriptor.get("repo")
     number = descriptor.get("number")
     pref = descriptor.get("llm_preference")
@@ -253,13 +259,27 @@ def _presented_key(request: Request) -> str:
 
 
 def _authorized(request: Request) -> bool:
+    """True only when the caller presented the configured key.
+
+    FAILS CLOSED. This used to return True when no key was configured, which
+    left /v1/* -- an endpoint that is exempt from the WebUI session middleware
+    (see main._AUTH_EXEMPT_PREFIX) and bound on 0.0.0.0 -- reachable by anyone
+    who could route to the host, with only a log warning. That is an LLM router
+    that can also drive the agentic fix pipeline, so "open by default" was the
+    wrong default. With no key configured every request is now REFUSED and the
+    operator is told to set one in Settings."""
     want = _configured_key()
     if not want:
-        logger.warning("LLM proxy request served with NO api key configured — "
-                       "endpoint is open. Set AB_PROXY_KEY or "
-                       "llm_proxy_api_key to require authentication.")
-        return True
-    return _presented_key(request) == want
+        logger.warning("LLM proxy request REFUSED: no api key configured. Set "
+                       "one in Settings > Automation (LLM Router API), or via "
+                       "the AB_PROXY_KEY env var / llm_proxy_api_key config.")
+        return False
+    presented = _presented_key(request)
+    if not presented:
+        return False
+    # Constant-time: the key is a bearer credential, so avoid leaking a prefix
+    # match through comparison timing.
+    return hmac.compare_digest(presented, want)
 
 
 # ── Request translation (Anthropic -> internal) ─────────────────────────────

--- a/routes.py
+++ b/routes.py
@@ -2135,7 +2135,12 @@ async def settings_page(request: Request):
     return templates.TemplateResponse(request=request, name="index.html", context={
         "view": "settings",
         "settings": {**settings, **config, "repo_tests_str": repo_tests_str, "monitored_labels_str": settings["monitored_labels_str"],
-                     "llm_credentials": _safe_llm_credentials, "llm_entries": _safe_llm_entries},
+                     "llm_credentials": _safe_llm_credentials, "llm_entries": _safe_llm_entries,
+                     # SECURITY: same rule as llm_credentials above -- the raw
+                     # proxy key must never be embedded in the served HTML, so
+                     # the field renders from a presence flag only.
+                     "llm_proxy_api_key": "",
+                     "llm_proxy_api_key_configured": bool(config.get("llm_proxy_api_key"))},
         "registry_rules_json": _registry_rules_json,
         "registry_preview": _registry_preview,
         "registry_unclassified": _registry_unclassified,
@@ -2329,10 +2334,26 @@ async def save_settings(request: Request):
     config_data["direct_push_enabled"] = data.get("direct_push_enabled") == "on"
     # Agentic LLM router (/v1/messages) toggles. agentic_default (OFF): route
     # every proxy request through AppBuilder's agent loop, not just model=
-    # ab-agent. autofix_enabled (OFF, safe for an open/keyless proxy):
+    # ab-agent. autofix_enabled (OFF, a second gate behind the required key):
     # let the agentic router trigger real fixes — still panel + boundary gated.
     config_data["llm_proxy_agentic_default"] = data.get("llm_proxy_agentic_default") == "on"
     config_data["llm_proxy_autofix_enabled"] = data.get("llm_proxy_autofix_enabled") == "on"
+    # LLM router API key. /v1/* bypasses the WebUI session middleware and does
+    # its own key check, and llm_proxy._authorized now FAILS CLOSED, so this is
+    # the only thing standing between the router (and the agentic fix pipeline
+    # behind it) and anyone who can reach the host.
+    #
+    # Same secret discipline as the OIDC client_secret and the llm_credentials
+    # api_keys: the field is never rendered with its real value, so a blank
+    # submit means "operator did not retype it" and must KEEP the stored key
+    # rather than wipe it -- otherwise saving any other Automation setting
+    # would silently disable authentication. Clearing is explicit.
+    if "llm_proxy_api_key" in data:
+        _pk = str(data.get("llm_proxy_api_key") or "")
+        if _pk.strip() == "__CLEAR__":
+            config_data["llm_proxy_api_key"] = ""
+        elif _pk.strip():
+            config_data["llm_proxy_api_key"] = _pk.strip()
     # PR pre-review toggle (default OFF): comment parity/drift findings on open PRs.
     config_data["pr_review_enabled"] = data.get("pr_review_enabled") == "on"
     # Advisory skeptical-panel sub-option (unifies PR review with the AI-fix reviewer).

--- a/templates/index.html
+++ b/templates/index.html
@@ -1646,6 +1646,42 @@
                                     Direct Push for Trusted Repos
                                 </label>
                             </div>
+                            <!-- LLM Router API key. /v1/* is exempt from the WebUI session
+                                 middleware (main._AUTH_EXEMPT_PREFIX) and does its own key
+                                 check, so this field is the ONLY authentication on the
+                                 router and the agentic fix pipeline behind it. The real
+                                 value is never rendered (see settings_page's redaction) --
+                                 the input round-trips blank, which save_settings treats as
+                                 "keep the stored key". -->
+                            <div class="p-4 bg-slate-50 rounded-lg border border-slate-200 space-y-2">
+                                <div class="flex items-center justify-between gap-3">
+                                    <label for="llm_proxy_api_key" class="text-xs font-bold text-slate-700 uppercase tracking-wider">
+                                        LLM Router API Key (<code>/v1/messages</code>)
+                                    </label>
+                                    {% if settings.llm_proxy_api_key_configured %}
+                                    <span class="text-[11px] font-bold text-[#01A982]"><i class="fas fa-lock mr-1"></i>Key configured — API requires a token</span>
+                                    {% else %}
+                                    <span class="text-[11px] font-bold text-red-600"><i class="fas fa-triangle-exclamation mr-1"></i>No key — the API is refusing all requests</span>
+                                    {% endif %}
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <input type="password" name="llm_proxy_api_key" id="llm_proxy_api_key" value="" autocomplete="new-password"
+                                           placeholder="{% if settings.llm_proxy_api_key_configured %}•••••••••• already set — leave blank to keep it{% else %}Required — set a key to enable the API{% endif %}"
+                                           class="flex-1 p-2 text-sm rounded-lg outline-none focus:ring-2 focus:ring-[#01A982]">
+                                    <button type="button" onclick="abProxyKeyGenerate()" title="Generate a random 32-byte key in your browser and put it in the field. Copy it before saving — it is never shown again."
+                                            class="px-3 py-2 text-xs font-bold rounded-md border border-slate-300 hover:bg-slate-100 whitespace-nowrap">Generate</button>
+                                    <button type="button" onclick="abProxyKeyClear()" title="Explicitly remove the stored key. The API then refuses every request until a new key is set."
+                                            class="px-3 py-2 text-xs font-bold rounded-md border border-red-300 text-red-600 hover:bg-red-50 whitespace-nowrap">Clear</button>
+                                </div>
+                                <p class="text-[11px] text-slate-500 leading-relaxed">
+                                    Clients send it as <code>x-api-key</code> or <code>Authorization: Bearer</code>
+                                    (Claude Code: <code>ANTHROPIC_API_KEY</code>, with
+                                    <code>ANTHROPIC_BASE_URL</code> pointed at this server).
+                                    Applies to <code>/v1/messages</code>, <code>/v1/messages/count_tokens</code>
+                                    and <code>/v1/models</code>. The <code>AB_PROXY_KEY</code> environment
+                                    variable, when set, overrides this value.
+                                </p>
+                            </div>
                             <div class="flex items-center gap-3 p-4 bg-slate-50 rounded-lg border border-slate-200">
                                 <input type="checkbox" name="llm_proxy_agentic_default" id="llm_proxy_agentic_default" {{ 'checked' if settings.llm_proxy_agentic_default else '' }} class="w-4 h-4 text-[#01A982] focus:ring-[#01A982]">
                                 <label for="llm_proxy_agentic_default" class="text-xs font-medium text-slate-700" title="Off by default: only requests with model=ab-agent run the agentic loop. On: every /v1/messages (LLM router / Claude CLI) request runs AppBuilder's agent loop with repo tools.">
@@ -1654,7 +1690,7 @@
                             </div>
                             <div class="flex items-center gap-3 p-4 bg-slate-50 rounded-lg border border-slate-200">
                                 <input type="checkbox" name="llm_proxy_autofix_enabled" id="llm_proxy_autofix_enabled" {{ 'checked' if settings.llm_proxy_autofix_enabled else '' }} class="w-4 h-4 text-[#01A982] focus:ring-[#01A982]">
-                                <label for="llm_proxy_autofix_enabled" class="text-xs font-medium text-slate-700" title="Off by default (safe for an open/keyless proxy): the agentic router proposes fixes but does not run them. On: the router may trigger the real fix pipeline — still gated by the review panel, with core-systems diffs forced to a human-reviewed PR.">
+                                <label for="llm_proxy_autofix_enabled" class="text-xs font-medium text-slate-700" title="Off by default: the agentic router proposes fixes but does not run them. On: the router may trigger the real fix pipeline — still gated by the review panel, with core-systems diffs forced to a human-reviewed PR.">
                                     Allow Agentic Router to trigger fixes (full autonomy, panel + boundary gated)
                                 </label>
                             </div>
@@ -2600,6 +2636,31 @@
             const first = document.querySelector('[data-tab]');
             if (first) settingsTab(first.getAttribute('data-tab'));
         })();
+
+        // ---- LLM Router API key helpers ----
+        // The field renders blank on purpose (the stored key is never sent to the
+        // browser), and a Save from ANY settings tab submits the whole form, so a
+        // blank value must mean "keep the existing key" -- see save_settings.
+        // Clearing therefore has to be explicit, which is what the sentinel is for.
+        window.abProxyKeyGenerate = function () {
+            const el = document.getElementById('llm_proxy_api_key');
+            if (!el) return;
+            const bytes = new Uint8Array(32);
+            (window.crypto || window.msCrypto).getRandomValues(bytes);
+            // base64url — safe in an HTTP header, no padding to mangle.
+            let b64 = btoa(String.fromCharCode.apply(null, Array.from(bytes)));
+            el.value = b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+            el.type = 'text';  // show it once: after Save it is never displayed again
+            if (window.showToast) showToast('Key generated — copy it now, then Save. It is never shown again.', 'info');
+        };
+        window.abProxyKeyClear = function () {
+            const el = document.getElementById('llm_proxy_api_key');
+            if (!el) return;
+            if (!confirm('Remove the LLM Router API key?\n\nThe /v1 API will refuse every request until a new key is set.')) return;
+            el.value = '__CLEAR__';
+            el.type = 'text';
+            if (window.showToast) showToast('Key will be removed when you Save.', 'error');
+        };
 
         // ---- Settings Save: AJAX POST, toast on success/error, no full reload ----
         // The single <form> wraps every section; a Save from any tab submits the

--- a/test_llm_proxy_api_key.py
+++ b/test_llm_proxy_api_key.py
@@ -1,0 +1,205 @@
+"""The LLM router (/v1/*) must require a token, and the token must be settable
+from the WebUI without ever being disclosed to the browser.
+
+Why this file exists
+--------------------
+``/v1/*`` is exempt from the WebUI session middleware (``main._AUTH_EXEMPT_PREFIX``)
+and does its own key check, and AppBuilder binds ``0.0.0.0``. ``_authorized`` used
+to return **True when no key was configured**, so a default install exposed an LLM
+router -- and, with the agentic toggles on, the real fix pipeline -- to anyone who
+could route to the host, with only a log line to say so. These tests pin the
+fail-closed behaviour so that default can never come back silently.
+
+They also pin the two halves of the Settings plumbing that are easy to get wrong:
+
+* the stored key must never be rendered into the served HTML, and
+* because Settings is ONE form and a Save from ANY tab submits every field, a
+  blank key input must mean "keep the stored key" -- otherwise saving an
+  unrelated setting would silently turn authentication off.
+
+These are written as real ``def test_*`` functions on purpose: this repo's older
+``test_*.py`` self-tests are ``__main__`` scripts that ``pytest`` does not collect,
+so they never run in CI.
+
+``llm_proxy.py`` and ``routes.py`` cannot be imported directly (they transitively
+pull in main.py's circular import chain), so -- per this repo's convention (see
+test_llm_proxy_agentic.py / test_feature_settings_roundtrip.py) -- the functions
+under test are extracted with ``ast`` and exec'd against stubs.
+"""
+import ast
+import os
+import re
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+# ── llm_proxy._authorized ───────────────────────────────────────────────────
+
+def _load_auth_ns(configured_key: str):
+    """Exec llm_proxy's key-check helpers with a stubbed config + env."""
+    src = open(os.path.join(HERE, "llm_proxy.py")).read()
+    tree = ast.parse(src)
+    wanted = {"_configured_key", "_presented_key", "_authorized"}
+    segs = [ast.get_source_segment(src, n) for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name in wanted]
+    assert len(segs) == 3, f"expected 3 helpers, found {len(segs)}"
+
+    class _NoLog:
+        def __getattr__(self, _):
+            return lambda *a, **k: None
+
+    import hmac as _hmac
+
+    class _Env(dict):
+        def get(self, k, d=None):
+            return dict.get(self, k, d)
+
+    ns = {
+        "logger": _NoLog(),
+        "hmac": _hmac,
+        "os": type("os", (), {"environ": _Env()})(),
+        "load_config": lambda: {"llm_proxy_api_key": configured_key},
+        "Request": object,
+    }
+    for seg in segs:
+        exec(seg, ns)
+    return ns
+
+
+class _Req:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+def test_no_configured_key_refuses_every_request():
+    """THE regression this file exists for: keyless must mean CLOSED, not open."""
+    auth = _load_auth_ns("")["_authorized"]
+    assert auth(_Req()) is False, "a keyless proxy must refuse an anonymous request"
+    assert auth(_Req({"x-api-key": "anything"})) is False
+    assert auth(_Req({"authorization": "Bearer anything"})) is False
+
+
+def test_configured_key_accepts_only_the_exact_key():
+    auth = _load_auth_ns("s3cret-key")["_authorized"]
+    assert auth(_Req({"x-api-key": "s3cret-key"})) is True
+    assert auth(_Req({"authorization": "Bearer s3cret-key"})) is True
+    assert auth(_Req({"x-api-key": "wrong"})) is False
+    assert auth(_Req()) is False, "no header must not pass once a key is set"
+
+
+def test_partial_key_is_rejected():
+    """Guards against a prefix/truncation comparison creeping in."""
+    auth = _load_auth_ns("s3cret-key")["_authorized"]
+    assert auth(_Req({"x-api-key": "s3cret"})) is False
+    assert auth(_Req({"x-api-key": "s3cret-key-extra"})) is False
+    assert auth(_Req({"x-api-key": ""})) is False
+
+
+def test_env_var_overrides_stored_config():
+    ns = _load_auth_ns("from-config")
+    ns["os"].environ["AB_PROXY_KEY"] = "from-env"
+    auth = ns["_authorized"]
+    assert auth(_Req({"x-api-key": "from-env"})) is True
+    assert auth(_Req({"x-api-key": "from-config"})) is False
+
+
+# ── save_settings: the key must survive a save from another tab ─────────────
+
+def _save_settings_ns():
+    from test_feature_settings_roundtrip import _load_ns
+    cwd = os.getcwd()
+    os.chdir(HERE)
+    try:
+        return _load_ns()
+    finally:
+        os.chdir(cwd)
+
+
+def _run_save(ns, pairs):
+    import asyncio
+    from test_feature_settings_roundtrip import _FakeRequest
+    asyncio.run(ns["save_settings"](_FakeRequest(pairs)))
+    return ns["_config_holder"]["config"]
+
+
+BASE = [("label_mode", "ANY")]
+
+
+def test_blank_key_field_keeps_the_stored_key():
+    """Settings is one form: a Save from ANY tab submits llm_proxy_api_key blank.
+    Treating that as "clear" would silently disable API authentication."""
+    ns = _save_settings_ns()
+    _run_save(ns, BASE + [("llm_proxy_api_key", "initial-key")])
+    assert ns["_config_holder"]["config"]["llm_proxy_api_key"] == "initial-key"
+    cfg = _run_save(ns, BASE + [("llm_proxy_api_key", "")])
+    assert cfg["llm_proxy_api_key"] == "initial-key", "blank submit wiped the key"
+
+
+def test_absent_key_field_keeps_the_stored_key():
+    ns = _save_settings_ns()
+    _run_save(ns, BASE + [("llm_proxy_api_key", "initial-key")])
+    cfg = _run_save(ns, BASE)
+    assert cfg["llm_proxy_api_key"] == "initial-key"
+
+
+def test_new_value_replaces_the_key():
+    ns = _save_settings_ns()
+    _run_save(ns, BASE + [("llm_proxy_api_key", "initial-key")])
+    cfg = _run_save(ns, BASE + [("llm_proxy_api_key", "rotated-key")])
+    assert cfg["llm_proxy_api_key"] == "rotated-key"
+
+
+def test_sentinel_clears_the_key_explicitly():
+    ns = _save_settings_ns()
+    _run_save(ns, BASE + [("llm_proxy_api_key", "initial-key")])
+    cfg = _run_save(ns, BASE + [("llm_proxy_api_key", "__CLEAR__")])
+    assert cfg["llm_proxy_api_key"] == ""
+
+
+def test_whitespace_is_stripped_not_stored():
+    ns = _save_settings_ns()
+    cfg = _run_save(ns, BASE + [("llm_proxy_api_key", "  padded-key  ")])
+    assert cfg["llm_proxy_api_key"] == "padded-key"
+
+
+# ── the WebUI control must not disclose the key ─────────────────────────────
+
+def _key_block():
+    src = open(os.path.join(HERE, "templates", "index.html")).read()
+    m = re.search(r'(<!-- LLM Router API key\..*?</div>\s*\n)'
+                  r'(?=\s*<div class="flex items-center gap-3)', src, re.S)
+    assert m, "LLM Router API key block not found in index.html"
+    return m.group(1)
+
+
+@pytest.mark.parametrize("configured", [True, False])
+def test_stored_key_is_never_rendered_into_the_html(configured):
+    from jinja2 import Environment
+    out = Environment().from_string(_key_block()).render(
+        settings={"llm_proxy_api_key_configured": configured,
+                  "llm_proxy_api_key": "SUPER-SECRET-VALUE"})
+    assert "SUPER-SECRET-VALUE" not in out, "the proxy key leaked into the HTML"
+    assert re.search(r'name="llm_proxy_api_key"[^>]*value=""', out), \
+        "the key input must render empty so a blank save means 'keep'"
+
+
+def test_status_line_tells_the_operator_the_api_is_unprotected():
+    from jinja2 import Environment
+    env = Environment()
+    unset = env.from_string(_key_block()).render(
+        settings={"llm_proxy_api_key_configured": False})
+    assert "No key" in unset and "refusing all requests" in unset
+    setted = env.from_string(_key_block()).render(
+        settings={"llm_proxy_api_key_configured": True})
+    assert "Key configured" in setted
+
+
+def test_settings_page_redacts_the_key_into_a_presence_flag():
+    """The whole config is merged into the template context via {**settings,
+    **config}, so the key must be explicitly overridden after that merge."""
+    src = open(os.path.join(HERE, "routes.py")).read()
+    ctx = src[src.index('"llm_credentials": _safe_llm_credentials'):][:600]
+    assert '"llm_proxy_api_key": ""' in ctx
+    assert '"llm_proxy_api_key_configured": bool(config.get("llm_proxy_api_key"))' in ctx


### PR DESCRIPTION
The LLM router `/v1/*` was **open by default** — it bypasses the WebUI session middleware and AB binds `0.0.0.0`, so anyone who could reach the host could drive it (and the agentic fix pipeline behind it). There was also no UI to set the key, so in practice it stayed unset.

- `_authorized()` now **fails closed**; comparison uses `hmac.compare_digest`
- **Settings → Automation → LLM Router API Key**: status line, Generate, Clear
- Key is redacted out of the template context — never embedded in the served HTML
- Blank input = keep stored key (Settings is one form submitted from any tab); `__CLEAR__` clears

Verified by executing the save→authorize round trip and the Generate helper under a real JS engine. 13 new pytest tests (the older `__main__` self-tests aren't collected by pytest, so these are real `test_*` functions); the keyless-refused test fails against the previous code.