### PR TITLE
SSO allowed group: pick from an Entra list instead of typing a GUID

### DIFF
--- a/oidc.py
+++ b/oidc.py
@@ -333,6 +333,76 @@ async def exchange_code(cfg: OidcConfig, discovery_doc: dict,
     return resp.json()
 
 
+# ── directory reads (app-only / client-credentials) ─────────────────────────
+
+async def fetch_app_token(cfg: OidcConfig, scope: str,
+                          http: httpx.AsyncClient | None = None) -> str:
+    """Mint an app-only (client-credentials) token for AppBuilder's own app
+    registration, for any resource the app holds a permission on.
+
+    Unlike the LM hub's equivalent this accepts EITHER credential type, because
+    AppBuilder supports a client secret as well as a cert ``client_assertion``
+    — refusing the secret here would make the group picker unavailable on a
+    secret-configured install that otherwise logs in fine."""
+    token_endpoint = (f"https://login.microsoftonline.com/{cfg.tenant_id}"
+                      "/oauth2/v2.0/token")
+    data = {
+        "grant_type": "client_credentials",
+        "client_id": cfg.client_id,
+        "scope": scope,
+    }
+    if cfg.client_secret:
+        data["client_secret"] = cfg.client_secret
+    else:
+        data["client_assertion_type"] = \
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        data["client_assertion"] = build_client_assertion(cfg, token_endpoint)
+    async with (http or httpx.AsyncClient(timeout=15.0)) as client:
+        resp = await client.post(token_endpoint, data=data)
+    if resp.status_code != 200:
+        raise OidcError(f"app-token failed ({scope}): HTTP {resp.status_code}"
+                        f"{_entra_error_detail(resp)}")
+    tok = resp.json().get("access_token")
+    if not tok:
+        raise OidcError("app-token response had no access_token")
+    return tok
+
+
+async def fetch_directory_groups(cfg: OidcConfig,
+                                 http: httpx.AsyncClient | None = None,
+                                 limit: int = 2000) -> list:
+    """List the tenant's Entra groups as ``[{id, displayName}]`` so the admin
+    can PICK the allowed group instead of pasting its object ID.
+
+    The object IDs returned here are exactly what ``allowed_group`` matches at
+    login, which is the point: a group *name* silently matches nothing, so the
+    picker is what stops an admin from locking everyone out. Needs the Graph
+    ``Group.Read.All`` **application** permission with admin consent. Pages
+    ``@odata.nextLink`` up to ``limit``."""
+    token = await fetch_app_token(cfg, "https://graph.microsoft.com/.default",
+                                  http=http)
+    out: list = []
+    url = ("https://graph.microsoft.com/v1.0/groups"
+           "?$select=id,displayName&$top=999")
+    async with (http or httpx.AsyncClient(timeout=20.0)) as client:
+        while url:
+            resp = await client.get(url,
+                                    headers={"Authorization": f"Bearer {token}"})
+            if resp.status_code != 200:
+                raise OidcError(f"Graph groups list failed: HTTP "
+                                f"{resp.status_code} — {resp.text[:200]}")
+            body = resp.json()
+            for v in body.get("value", []):
+                gid = v.get("id")
+                if gid:
+                    out.append({"id": gid,
+                                "displayName": v.get("displayName") or gid})
+                    if len(out) >= limit:
+                        return out
+            url = body.get("@odata.nextLink")
+    return out
+
+
 # ── id-token verification ───────────────────────────────────────────────────
 
 async def fetch_jwks(jwks_uri: str, http: httpx.AsyncClient | None = None) -> list:

--- a/routes.py
+++ b/routes.py
@@ -321,6 +321,51 @@ async def oidc_config_get():
     return out
 
 
+@router.get("/setup/oidc/groups")
+async def oidc_groups_list():
+    """List the tenant's Entra groups (id + displayName) for the allowed-group
+    picker, so an admin chooses a group by NAME instead of pasting a GUID.
+
+    ``allowed_group`` only ever matches group OBJECT IDs, so hand-entry is the
+    main way to lock every user out of AppBuilder; the picker removes that.
+    Degrades to ``{groups: [], warning}`` rather than erroring so the UI can
+    fall back to manual entry. Behind the normal session gate (``/setup/*`` is
+    not in the auth-exempt list)."""
+    import oidc as _o
+    cfg = _o.get_oidc_config()
+    if not (cfg.tenant_id and cfg.client_id):
+        return {"groups": [],
+                "warning": "Set the tenant ID and client ID first, then save."}
+    if not cfg.has_credential:
+        return {"groups": [],
+                "warning": "Set a client secret or certificate first, then save."}
+
+    def _friendly(msg: str) -> str:
+        low = msg.lower()
+        if ("authorization_requestdenied" in low or "insufficient privileges" in low
+                or " 403" in low):
+            return ("The app registration is missing the Microsoft Graph "
+                    "Group.Read.All (Application) permission with admin consent "
+                    "— add it under API permissions, grant admin consent, then "
+                    "retry. You can still type the group object ID by hand. "
+                    "(raw: " + msg[:160] + ")")
+        if " 401" in low or "invalid_client" in low:
+            return ("Entra rejected the app token — check the client secret, or "
+                    "that the certificate is uploaded and its thumbprint "
+                    "matches. (raw: " + msg[:160] + ")")
+        return msg
+
+    try:
+        groups = await _o.fetch_directory_groups(cfg)
+        groups.sort(key=lambda g: (g.get("displayName") or "").lower())
+        return {"groups": groups}
+    except _o.OidcError as e:
+        return {"groups": [], "warning": _friendly(str(e))}
+    except Exception as e:  # noqa: BLE001
+        logger.exception("oidc: could not list directory groups")
+        return {"groups": [], "warning": _friendly(str(e))}
+
+
 @router.post("/setup/oidc-config")
 async def oidc_config_set(request: Request):
     """Persist the operator-editable OIDC config from the Settings UI."""

--- a/templates/index.html
+++ b/templates/index.html
@@ -1794,14 +1794,25 @@
                                 <p class="text-xs text-slate-400">Turning this off hides the "Sign in with Microsoft" button; local passwords keep working.</p>
                             </div>
                             <div class="space-y-2 md:col-span-2">
-                                <label class="text-sm font-medium text-slate-600">Allowed group (admin group)</label>
-                                <input type="text" id="oidc-allowed-group" class="w-full p-2 rounded-lg outline-none focus:ring-2 focus:ring-[#01A982]" placeholder="00000000-0000-0000-0000-000000000000">
+                                <label class="text-sm font-medium text-slate-600">Allowed groups (admin groups)</label>
+                                <div class="flex gap-2">
+                                    <select id="oidc-group-select" onchange="onOidcGroupPick(this)" class="flex-1 p-2 rounded-lg outline-none focus:ring-2 focus:ring-[#01A982] hidden"></select>
+                                    <button type="button" id="oidc-group-btn" onclick="loadOidcGroupPicker()" class="px-3 py-2 rounded-md text-sm font-medium bg-slate-100 hover:bg-slate-200 whitespace-nowrap">Pick from Entra</button>
+                                </div>
+                                <p id="oidc-group-msg" class="text-xs text-amber-600 hidden"></p>
+                                <div id="oidc-group-chips" class="flex flex-wrap gap-2"></div>
+                                <input type="hidden" id="oidc-allowed-group">
+                                <details class="mt-1">
+                                    <summary class="text-xs text-slate-400 cursor-pointer select-none">Enter object IDs manually</summary>
+                                    <input type="text" id="oidc-allowed-group-manual" onchange="onOidcGroupManual(this)" class="w-full mt-2 p-2 rounded-lg outline-none focus:ring-2 focus:ring-[#01A982] font-mono text-xs" placeholder="comma-separated group object IDs">
+                                </details>
                                 <p class="text-xs text-slate-400">
-                                    Must be the group's <strong>object ID</strong> (a GUID), not its name &mdash; a
-                                    name silently matches nothing and locks everyone out. Comma-separate to allow
-                                    several groups. <strong>Leave blank and every user in the tenant can sign in as an admin.</strong>
-                                    Entra must also be configured to emit a <code>groups</code> claim, otherwise
-                                    every sign-in is rejected with a "read 0 groups" error.
+                                    Membership in <strong>any</strong> listed group grants access. Matching is by
+                                    group <strong>object ID</strong>, never by name &mdash; which is why picking from
+                                    the list is safer than typing.
+                                    <strong>Leave empty and every user in the tenant can sign in as an admin.</strong>
+                                    Entra must also emit a <code>groups</code> claim, otherwise every sign-in is
+                                    rejected with a "read 0 groups" error.
                                 </p>
                             </div>
                             <div class="space-y-2">
@@ -2709,11 +2720,119 @@
         })();
 
         // ---- Microsoft Entra SSO settings ----
+        // The allowed-group list is held in a hidden input as a comma-separated
+        // string (the wire format save_oidc_config expects) and mirrored into
+        // chips + an optional manual field. Every node here is built with
+        // createElement/textContent rather than innerHTML: AppBuilder has no
+        // escapeHtml helper, and Entra group display names are free text.
+        let _abOidcGroupNames = {};
+
+        function _abOidcGroups() {
+            const el = document.getElementById('oidc-allowed-group');
+            return ((el && el.value) || '').split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
+        }
+
+        function _abOidcSetGroups(list) {
+            const uniq = [];
+            (list || []).forEach(g => { if (g && !uniq.includes(g)) uniq.push(g); });
+            const el = document.getElementById('oidc-allowed-group');
+            if (el) el.value = uniq.join(', ');
+            const manual = document.getElementById('oidc-allowed-group-manual');
+            if (manual) manual.value = uniq.join(', ');
+            _abOidcRenderChips(uniq);
+        }
+
+        function _abOidcRenderChips(list) {
+            const box = document.getElementById('oidc-group-chips');
+            if (!box) return;
+            box.textContent = '';
+            if (!list.length) {
+                const p = document.createElement('span');
+                p.className = 'text-xs text-amber-600';
+                p.textContent = 'No groups selected — any user in the tenant can sign in as an admin.';
+                box.appendChild(p);
+                return;
+            }
+            list.forEach(id => {
+                const chip = document.createElement('span');
+                chip.className = 'inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-slate-100 text-xs';
+                const label = document.createElement('span');
+                const nm = _abOidcGroupNames[id];
+                label.textContent = nm ? nm : id;
+                if (nm) label.title = id;
+                chip.appendChild(label);
+                const x = document.createElement('button');
+                x.type = 'button';
+                x.className = 'text-slate-400 hover:text-red-500 font-bold leading-none';
+                x.textContent = '\u00d7';
+                x.title = 'Remove ' + id;
+                x.onclick = () => _abOidcSetGroups(_abOidcGroups().filter(g => g !== id));
+                chip.appendChild(x);
+                box.appendChild(chip);
+            });
+        }
+
+        window.onOidcGroupManual = function (input) {
+            _abOidcSetGroups((input.value || '').split(/[\s,]+/));
+        };
+
+        // Appends (never replaces) so several groups can be allowed, matching
+        // enforce_allowed_group: membership in ANY listed group grants access.
+        window.onOidcGroupPick = function (sel) {
+            const id = sel.value;
+            if (!id) return;
+            const opt = sel.options[sel.selectedIndex];
+            if (opt) _abOidcGroupNames[id] = opt.getAttribute('data-name') || id;
+            _abOidcSetGroups(_abOidcGroups().concat([id]));
+            sel.value = '';
+        };
+
+        window.loadOidcGroupPicker = async function () {
+            const btn = document.getElementById('oidc-group-btn');
+            const sel = document.getElementById('oidc-group-select');
+            const msg = document.getElementById('oidc-group-msg');
+            if (!sel) return;
+            if (btn) { btn.disabled = true; btn.textContent = 'Loading\u2026'; }
+            try {
+                const r = await fetch('/setup/oidc/groups');
+                const d = await r.json().catch(() => ({}));
+                const groups = (d && d.groups) || [];
+                if (!groups.length) {
+                    if (msg) {
+                        msg.textContent = (d && d.warning) ||
+                            'No Entra groups returned — you can still enter object IDs manually.';
+                        msg.classList.remove('hidden');
+                    }
+                    sel.classList.add('hidden');
+                } else {
+                    sel.textContent = '';
+                    sel.appendChild(new Option('\u2014 select an Entra group \u2014', ''));
+                    groups.forEach(g => {
+                        const o = new Option(g.displayName + '  \u2014  ' + g.id, g.id);
+                        o.setAttribute('data-name', g.displayName);
+                        _abOidcGroupNames[g.id] = g.displayName;
+                        sel.appendChild(o);
+                    });
+                    sel.classList.remove('hidden');
+                    if (msg) msg.classList.add('hidden');
+                    // Names are known now, so redraw chips to show them.
+                    _abOidcRenderChips(_abOidcGroups());
+                }
+            } catch (err) {
+                if (msg) {
+                    msg.textContent = 'Failed to load Entra groups: ' + (err.message || err);
+                    msg.classList.remove('hidden');
+                }
+            } finally {
+                if (btn) { btn.disabled = false; btn.textContent = 'Pick from Entra'; }
+            }
+        };
+
         // These fields deliberately carry NO `name` attribute: #settings-form
         // spans every tab and saveSettingsAjax posts the whole FormData to
-        // /save_settings, but OIDC is stored under config["oidc"] via its own
-        // secret-preserving endpoint. Naming them would post them to the wrong
-        // handler, which would drop them silently.
+        // /save_settings, but OIDC persists through its own secret-preserving
+        // endpoint. Naming them would post them to the wrong handler, which
+        // would drop them silently.
         window.loadOidcConfig = async function () {
             const status = document.getElementById('oidc-status');
             try {
@@ -2724,16 +2843,16 @@
                 set('oidc-tenant-id', d.tenant_id);
                 set('oidc-client-id', d.client_id);
                 set('oidc-redirect-uri', d.redirect_uri);
-                set('oidc-allowed-group', d.allowed_group);
                 set('oidc-cert-path', d.cert_path);
                 set('oidc-key-path', d.key_path);
+                _abOidcSetGroups(String(d.allowed_group || '').split(/[\s,]+/));
                 const en = document.getElementById('oidc-enabled');
                 if (en) en.checked = !!d.enabled;
                 const sec = document.getElementById('oidc-client-secret');
                 if (sec) {
                     sec.value = '';
                     sec.placeholder = d.client_secret_configured
-                        ? 'A secret is stored — leave blank to keep it'
+                        ? 'A secret is stored \u2014 leave blank to keep it'
                         : 'No secret stored';
                 }
                 if (status) {
@@ -2747,7 +2866,7 @@
                         status.textContent = 'Active — but no allowed group is set, so ANY user in the tenant can sign in as an admin.';
                         status.className = 'text-xs mb-4 text-amber-600';
                     } else {
-                        status.textContent = 'Active — restricted to the allowed group.';
+                        status.textContent = 'Active — restricted to the allowed groups.';
                         status.className = 'text-xs mb-4 text-emerald-600';
                     }
                 }
@@ -2769,18 +2888,19 @@
 
         window.saveOidcConfig = async function (btn) {
             const val = id => (document.getElementById(id) || {}).value || '';
+            const groups = _abOidcGroups();
             const body = {
                 enabled: !!(document.getElementById('oidc-enabled') || {}).checked,
                 tenant_id: val('oidc-tenant-id').trim(),
                 client_id: val('oidc-client-id').trim(),
                 redirect_uri: val('oidc-redirect-uri').trim(),
-                allowed_group: val('oidc-allowed-group').trim(),
+                allowed_group: groups.join(', '),
                 cert_path: val('oidc-cert-path').trim(),
                 key_path: val('oidc-key-path').trim(),
                 client_secret: val('oidc-client-secret'),
             };
-            if (body.enabled && !body.allowed_group &&
-                !confirm('No allowed group is set. Every user in your Microsoft tenant will be able to sign in, and AppBuilder gives every signed-in user full admin rights. Save anyway?')) {
+            if (body.enabled && !groups.length &&
+                !confirm('No allowed group is selected. Every user in your Microsoft tenant will be able to sign in, and AppBuilder gives every signed-in user full admin rights. Save anyway?')) {
                 return;
             }
             if (btn) btn.disabled = true;

--- a/test_oidc_directory_groups.py
+++ b/test_oidc_directory_groups.py
@@ -1,0 +1,194 @@
+"""Tests for the Entra allowed-group picker backend (``oidc.fetch_app_token`` /
+``oidc.fetch_directory_groups``).
+
+These back the Settings → Sign-in (SSO) group picker. The picker exists because
+``allowed_group`` only ever matches group OBJECT IDs, so an admin who types a
+group *name* silently locks every user out — the list has to return real IDs.
+
+No network: a stub stands in for ``httpx.AsyncClient`` so the request shape
+(grant type, credential choice, Authorization header) and the ``@odata.nextLink``
+paging are asserted directly.
+"""
+import asyncio
+
+import pytest
+
+import oidc
+
+
+class _Resp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _StubClient:
+    """Minimal async httpx.AsyncClient stand-in that records calls."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.posts = []
+        self.gets = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, data=None):
+        self.posts.append((url, data))
+        return self._responses.pop(0)
+
+    async def get(self, url, headers=None):
+        self.gets.append((url, headers))
+        return self._responses.pop(0)
+
+
+def _run(coro):
+    """Run a coroutine on a private loop.
+
+    Deliberately NOT asyncio.get_event_loop(): other modules in this suite
+    close or replace the global loop, which made these tests pass in isolation
+    and fail when run together."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+async def _tok(cfg, scope, http=None):
+    return "TOK"
+
+
+def _cfg(**over):
+    stored = {
+        "tenant_id": "tid",
+        "client_id": "cid",
+        "redirect_uri": "https://h/auth/oidc/callback",
+        "client_secret": "s3cret",
+    }
+    stored.update(over)
+    return oidc.OidcConfig(stored)
+
+
+# ── fetch_app_token ─────────────────────────────────────────────────────────
+
+def test_app_token_uses_client_secret_when_set():
+    stub = _StubClient([_Resp({"access_token": "TOK"})])
+    tok = _run(oidc.fetch_app_token(_cfg(), "https://graph.microsoft.com/.default", http=stub))
+    assert tok == "TOK"
+    url, data = stub.posts[0]
+    assert url.endswith("/tid/oauth2/v2.0/token")
+    assert data["grant_type"] == "client_credentials"
+    assert data["scope"] == "https://graph.microsoft.com/.default"
+    assert data["client_secret"] == "s3cret"
+    # A secret install must NOT also try to sign an assertion it has no key for.
+    assert "client_assertion" not in data
+
+
+def test_app_token_uses_cert_assertion_when_no_secret(monkeypatch):
+    monkeypatch.setattr(oidc, "build_client_assertion", lambda cfg, ep: "ASSERTION")
+    stub = _StubClient([_Resp({"access_token": "TOK"})])
+    _run(oidc.fetch_app_token(_cfg(client_secret=""), "scope/.default", http=stub))
+    _, data = stub.posts[0]
+    assert data["client_assertion"] == "ASSERTION"
+    assert data["client_assertion_type"].endswith("jwt-bearer")
+    assert "client_secret" not in data
+
+
+def test_app_token_raises_on_http_error():
+    stub = _StubClient([_Resp({"error": "invalid_client"}, status=401)])
+    with pytest.raises(oidc.OidcError):
+        _run(oidc.fetch_app_token(_cfg(), "scope/.default", http=stub))
+
+
+def test_app_token_raises_when_response_has_no_token():
+    stub = _StubClient([_Resp({"token_type": "Bearer"})])
+    with pytest.raises(oidc.OidcError):
+        _run(oidc.fetch_app_token(_cfg(), "scope/.default", http=stub))
+
+
+# ── fetch_directory_groups ──────────────────────────────────────────────────
+
+def _groups(responses, monkeypatch, **kw):
+    monkeypatch.setattr(oidc, "fetch_app_token", _tok)
+    stub = _StubClient(responses)
+    out = _run(oidc.fetch_directory_groups(_cfg(), http=stub, **kw))
+    return out, stub
+
+
+def test_directory_groups_returns_id_and_name(monkeypatch):
+    out, stub = _groups([_Resp({"value": [
+        {"id": "g1", "displayName": "Lab Admin Users"},
+        {"id": "g2", "displayName": "Lab Manager Admin"},
+    ]})], monkeypatch)
+    assert out == [{"id": "g1", "displayName": "Lab Admin Users"},
+                   {"id": "g2", "displayName": "Lab Manager Admin"}]
+    _, headers = stub.gets[0]
+    assert headers["Authorization"] == "Bearer TOK"
+
+
+def test_directory_groups_follows_odata_next_link(monkeypatch):
+    out, stub = _groups([
+        _Resp({"value": [{"id": "g1", "displayName": "A"}],
+               "@odata.nextLink": "https://graph.microsoft.com/page2"}),
+        _Resp({"value": [{"id": "g2", "displayName": "B"}]}),
+    ], monkeypatch)
+    assert [g["id"] for g in out] == ["g1", "g2"]
+    assert stub.gets[1][0] == "https://graph.microsoft.com/page2"
+
+
+def test_directory_groups_falls_back_to_id_when_unnamed(monkeypatch):
+    out, _ = _groups([_Resp({"value": [{"id": "g1"}]})], monkeypatch)
+    assert out == [{"id": "g1", "displayName": "g1"}]
+
+
+def test_directory_groups_skips_entries_without_id(monkeypatch):
+    out, _ = _groups([_Resp({"value": [{"displayName": "no id"},
+                                       {"id": "g1", "displayName": "A"}]})],
+                     monkeypatch)
+    assert [g["id"] for g in out] == ["g1"]
+
+
+def test_directory_groups_honours_limit(monkeypatch):
+    out, _ = _groups([_Resp({"value": [{"id": f"g{i}"} for i in range(10)],
+                             "@odata.nextLink": "https://graph/next"})],
+                     monkeypatch, limit=3)
+    assert len(out) == 3
+
+
+def test_directory_groups_raises_on_graph_error(monkeypatch):
+    monkeypatch.setattr(oidc, "fetch_app_token", _tok)
+    stub = _StubClient([_Resp({"error": "Authorization_RequestDenied"}, status=403)])
+    with pytest.raises(oidc.OidcError):
+        _run(oidc.fetch_directory_groups(_cfg(), http=stub))
+
+
+# ── the IDs the picker returns must be what login actually matches ──────────
+
+def test_picked_group_id_is_what_enforce_allowed_group_matches(monkeypatch):
+    """The picker's value is pasted straight into allowed_group, so a group the
+    admin picks must let a member in — and a group NAME must not."""
+    out, _ = _groups([_Resp({"value": [
+        {"id": "6ca5db04-502c-4af4-adb8-e27d4a8fa5bb",
+         "displayName": "Lab Manager Admin"}]})], monkeypatch)
+    picked = out[0]["id"]
+    # A member of the picked group is admitted.
+    oidc.enforce_allowed_group(picked, [picked])
+    # The display NAME must not be accepted as a substitute for the object ID.
+    with pytest.raises(oidc.OidcError):
+        oidc.enforce_allowed_group(out[0]["displayName"], [picked])
+
+
+def test_multiple_picked_groups_are_or_ed():
+    """The UI joins picks with ', ' — membership in ANY must grant access."""
+    allowed = "aaa, bbb"
+    oidc.enforce_allowed_group(allowed, ["bbb"])
+    with pytest.raises(oidc.OidcError):
+        oidc.enforce_allowed_group(allowed, ["ccc"])


### PR DESCRIPTION
Ports LM's group picker to AppBuilder. **Settings -> Sign-in (SSO)** now has a *Pick from Entra* button that lists tenant groups by name; picks append the object ID and render as removable chips. Manual entry stays behind a disclosure.

Why: `allowed_group` matches group **object IDs** only, and it is AppBuilder's entire access control (no roles). Typing a group *name* matches nothing and locks everyone out.

Backend: `oidc.fetch_app_token` + `oidc.fetch_directory_groups` (paged Graph read) and `GET /setup/oidc/groups`, which degrades to `{groups: [], warning}` with an actionable message rather than erroring. Accepts a client secret as well as a cert, unlike LM's cert-only version, since AB supports both.

All DOM built with `createElement`/`textContent` — AB has no `escapeHtml` helper and group names are free text.

Verified: 44 tests pass (12 new); list logic exercised against a DOM stub (append/dedupe/normalise/remove/empty-state); Jinja + JS syntax checked. Graph `Group.Read.All` (application) has been granted and admin-consented on the AppBuilder app registration.