### PR TITLE
Auto-merge: gate by target branch, not PR authorship

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -16,10 +16,20 @@ name: promote
 #
 # Any OTHER conflict is left unresolved on purpose: the job fails loudly so a
 # human resolves it, rather than a bot guessing at real code.
+#
+# PROMOTION IS DELIBERATE, NOT AUTOMATIC. This previously ran `on: push` to dev
+# and qa, so every single commit to dev immediately raised (or force-pushed) a
+# PR into qa, and merging that PR was itself a push to qa, which immediately
+# raised the next PR into main. Unfinished work was therefore permanently in
+# flight toward production and neither gate ever batched anything. Promotion is
+# now started by hand: run this workflow with `source: dev` when dev is actually
+# ready, then again with `source: qa` to move qa into main. Each hop becomes one
+# intentional PR covering everything that has accumulated since the last one.
+#
+# CI is unaffected -- ci.yml still runs on every dev push and on every PR, so
+# day-to-day feedback stays automatic. Only the decision to promote is manual.
 
 on:
-  push:
-    branches: [dev, qa]
   workflow_dispatch:
     inputs:
       source:
@@ -35,12 +45,16 @@ permissions:
   actions: write   # to release the promotion PR's own CI run (see last step)
 
 concurrency:
-  group: promote-${{ github.ref_name }}
+  # Keyed off the branch being promoted, not the ref the run was dispatched
+  # from -- a manual run is always dispatched from the default branch, so
+  # github.ref_name would collapse dev->qa and qa->main into one queue.
+  group: promote-${{ github.event.inputs.source || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   promote:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pr_review.py
+++ b/pr_review.py
@@ -778,32 +778,48 @@ _FEATURE_DRIVE_MARKER_RE = re.compile(r"<!--\s*ab-feature-drive:\s*([^\s>]+)#(\d
 
 
 def _automerge_decision(rec, changed_paths, config, pr_meta, state_flags=None, changed_files=None):
-    """Pure function — the SINGLE choke point for whether feature auto-drive
-    auto-approves + auto-merges a PR instead of waiting for a human. Returns
-    (should_merge: bool, reason: str).
+    """Pure function — the SINGLE choke point for whether the skeptical-review
+    pipeline auto-approves + auto-merges a PR instead of waiting for a human.
+    Returns (should_merge: bool, reason: str).
 
     THE INVARIANT THIS FUNCTION DELIBERATELY BREAKS: this module's own
     docstring (top of file) and routes.py's approve/merge routes say
     "AppBuilder never auto-approves"/"never auto-merges". This function is the
-    one narrow, deliberate exception — see pr_meta["is_feature_drive"] below,
-    which is what keeps a human-authored PR structurally ineligible no
-    matter how high its confidence.
+    deliberate exception.
+
+    UPDATED 2026-08-29: containment used to be *who authored the PR* —
+    pr_meta["is_feature_drive"] (the feature-drive marker) was what kept a
+    human-authored PR structurally ineligible no matter how high its
+    confidence. Now that more than one person works on this system, that's
+    no longer sufficient on its own: pr_meta["base_ref"] must ALSO be in
+    feature_automerge_target_branches (opt-in, defaults to empty — e.g.
+    ["dev"]). A PR targeting main, or any branch not on that list, is
+    blocked here regardless of author or confidence — combined with the
+    feature_allowlist gate below (only small, additive diff shapes qualify
+    unattended), this is what stands between "unattended merge" and "human
+    required" for a human-authored PR now. is_feature_drive is still
+    populated in pr_meta for logging/audit (which PRs were bot-authored vs
+    human); it no longer gates this decision on its own.
 
     ALL conditions below are required; on ANY missing/ambiguous/unexpected
     input this returns (False, reason) — it must never accidentally return
-    True. Every condition is independently gate-able (two kill switches:
+    True. Every condition is independently gate-able (kill switches:
     feature_drive_enabled and feature_automerge_enabled; plus paused/
-    blackout; plus a per-repo allowlist that defaults to empty).
+    blackout; plus a per-repo allowlist, a per-target-branch allowlist, and
+    the feature_allowlist diff-shape gate).
 
     rec: state["pr_reviews"]["repo#num"] — panel_*/panel2_*/errors/warnings/
          merged/auto_merged.
     changed_paths: the PR's REAL changed-file list (pr.get_files() filenames)
                    — the boundary check is against the actual diff, never a
                    pre-build prediction.
+    changed_files: normalised per-file records (see
+                   feature_allowlist.files_from_pr_files) for the diff-shape
+                   allowlist gate below; absent fails that gate closed.
     config: live config (feature_drive_enabled, feature_automerge_*,
             feature_boundaries).
-    pr_meta: {"repo": str, "is_feature_drive": bool, "draft": bool,
-              "state": "open"|"closed", "mergeable": bool|None}.
+    pr_meta: {"repo": str, "base_ref": str, "is_feature_drive": bool,
+              "draft": bool, "state": "open"|"closed", "mergeable": bool|None}.
     state_flags: {"paused": bool, "blackout": bool}.
     """
     state_flags = state_flags or {}
@@ -815,8 +831,10 @@ def _automerge_decision(rec, changed_paths, config, pr_meta, state_flags=None, c
         return False, "feature_automerge_enabled is off"
     if pr_meta.get("repo") not in (config.get("feature_automerge_repos") or []):
         return False, "repo is not in feature_automerge_repos (opt-in, defaults to none)"
-    if not pr_meta.get("is_feature_drive"):
-        return False, "PR does not carry the feature-drive marker — human PRs are never auto-merged"
+    if pr_meta.get("base_ref") not in (config.get("feature_automerge_target_branches") or []):
+        return False, ("target branch %r is not in feature_automerge_target_branches "
+                        "(opt-in, defaults to none) — main (or any unlisted branch) is "
+                        "never eligible, regardless of author or confidence" % pr_meta.get("base_ref"))
 
     if rec.get("merged") or rec.get("auto_merged"):
         return False, "already merged (idempotent no-op)"
@@ -900,6 +918,7 @@ def _maybe_auto_merge(gh, repo, pr, config):
         marker_match = _FEATURE_DRIVE_MARKER_RE.search(pr.body or "")
         pr_meta = {
             "repo": repo.full_name,
+            "base_ref": getattr(getattr(pr, "base", None), "ref", None),
             "is_feature_drive": bool(marker_match),
             "draft": bool(getattr(pr, "draft", False)),
             "state": (pr.state or "open"),
@@ -1044,10 +1063,11 @@ def _review_one(gh, repo, pr, config, force=False):
     # Runs on EVERY scan (not just non-cached ones) — a PR whose panels only
     # just cleared the confidence bar via the LAST scan's record shouldn't
     # have to wait for its head to move again before being picked up. Inert
-    # unless feature_drive_enabled AND feature_automerge_enabled AND the repo
-    # is in feature_automerge_repos (see _automerge_decision's own docstring
-    # for the full gate list) — a no-op read+return for every ordinary
-    # human-authored or auto-merge-disabled PR.
+    # unless feature_automerge_enabled AND the repo is in
+    # feature_automerge_repos AND the PR's target branch is in
+    # feature_automerge_target_branches (see _automerge_decision's own
+    # docstring for the full gate list) — a no-op read+return for every PR
+    # targeting main or any other non-allowlisted branch.
     _maybe_auto_merge(gh, repo, pr, config)
 
 

--- a/routes.py
+++ b/routes.py
@@ -2028,13 +2028,22 @@ async def settings_page(request: Request):
         from feature_boundary import DEFAULT_BOUNDARIES
         config["feature_boundaries"] = DEFAULT_BOUNDARIES
     # Auto-merge — the deliberate, narrowly-scoped invariant exception (see
-    # pr_review.py's module docstring + _automerge_decision). TWO independent
-    # kill switches (this toggle AND the per-repo allowlist below, which
-    # defaults to empty) plus a threshold that defaults to 1.0 — effectively
-    # OFF until an operator deliberately both enables it AND opts a repo in
-    # AND lowers the threshold. Global, not per-repo, to start.
+    # pr_review.py's module docstring + _automerge_decision). Several
+    # independent gates, all default-closed: this toggle, feature_drive_enabled,
+    # the per-repo allowlist, the per-target-branch allowlist, and the
+    # confidence threshold (defaults to 1.0) — effectively OFF until an
+    # operator deliberately enables it AND opts a repo in AND opts a target
+    # branch in AND lowers the threshold. Global, not per-repo, to start.
     config.setdefault("feature_automerge_enabled", False)
     config.setdefault("feature_automerge_repos", [])
+    # Opt-in allowlist of target branches auto-merge is permitted onto —
+    # defaults to empty, same philosophy as feature_automerge_repos. Since
+    # 2026-08-29 this (not PR authorship) is what keeps main structurally
+    # ineligible: ANY PR (human or bot) targeting an allowlisted branch (e.g.
+    # "dev") can clear _automerge_decision if both review panels approve at
+    # threshold; a PR targeting main, or any branch not listed here, never
+    # can. See pr_review._automerge_decision.
+    config.setdefault("feature_automerge_target_branches", [])
     config.setdefault("feature_automerge_min_confidence", 1.0)
     config.setdefault("feature_automerge_require_clean", True)
     # DEFAULT-DENY allowlist gate (feature_allowlist): even a clean, high-
@@ -2619,6 +2628,14 @@ async def save_settings(request: Request):
         if _r2 and _r2 not in _am_repos:
             _am_repos.append(_r2)
     config_data["feature_automerge_repos"] = list(dict.fromkeys(_am_repos))
+    # Target-branch allowlist — free-text comma/newline separated, same
+    # parsing style as _am_extra above. No checkbox list here (unlike repos,
+    # there's no cheap "known branches" enumeration without an extra GitHub
+    # API call per repo) — this is deliberately just a short opt-in list like
+    # ["dev"], not meant to hold many entries.
+    _am_branches_raw = data.get("feature_automerge_target_branches", "") or ""
+    _am_branches = [b.strip() for b in _am_branches_raw.replace("\n", ",").split(",") if b.strip()]
+    config_data["feature_automerge_target_branches"] = list(dict.fromkeys(_am_branches))
 
     # Auto-FIX log-detected / automated-fix issues (default OFF; Bug + Critical
     # always fix). Stops the fixer churning on log-scraped issues.

--- a/templates/index.html
+++ b/templates/index.html
@@ -2181,8 +2181,8 @@
                             <label class="text-sm font-semibold text-slate-700">Auto-Merge <span class="text-red-500 font-normal">(unattended — reviewed by both panels, but no human clicks Approve/Merge)</span></label>
                             <div class="flex items-center gap-3">
                                 <input type="checkbox" name="feature_automerge_enabled" id="feature_automerge_enabled" {{ 'checked' if settings.get('feature_automerge_enabled', False) else '' }} class="w-4 h-4 text-[#01A982] focus:ring-[#01A982]">
-                                <label for="feature_automerge_enabled" class="text-xs font-medium text-slate-700" title="Off by default. Only ever applies to PRs carrying the feature-drive marker (feature_build.py's own PRs) — a human-authored PR can never be auto-merged, at any confidence.">
-                                    Enable auto-merge for feature-built PRs
+                                <label for="feature_automerge_enabled" class="text-xs font-medium text-slate-700" title="Off by default. Applies to ANY PR — human or feature-built — targeting a branch listed below. A PR targeting main, or any branch not listed, can never be auto-merged, at any confidence.">
+                                    Enable auto-merge onto allowlisted branches
                                 </label>
                             </div>
                             <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
@@ -2199,8 +2199,13 @@
                                 </div>
                             </div>
                             <div class="space-y-2 mt-2">
+                                <label class="text-sm font-medium text-slate-600">Auto-Merge Target Branches <span class="text-red-500 font-normal">(opt-in — empty means NOTHING auto-merges, regardless of the toggle above)</span></label>
+                                <p class="text-xs text-red-600 font-medium">⚠️ This is what stands between "unattended merge" and "human required" now that PR authorship no longer matters. Never add main/master here — only a lower-stakes branch (e.g. dev) that isn't wired to deploy/restart anything on push.</p>
+                                <input type="text" name="feature_automerge_target_branches" value="{{ settings.get('feature_automerge_target_branches', []) | join(', ') }}" placeholder="Branches allowed to receive auto-merges (comma-separated, e.g. dev)" class="w-full p-2 text-xs rounded-lg border border-slate-300 outline-none focus:ring-1 focus:ring-[#01A982]">
+                            </div>
+                            <div class="space-y-2 mt-2">
                                 <label class="text-sm font-medium text-slate-600">Auto-Merge Repositories <span class="text-red-500 font-normal">(opt-in — empty means NOTHING auto-merges, regardless of the toggle above)</span></label>
-                                <p class="text-xs text-red-600 font-medium">⚠️ A repo added here that restarts a live service on push (e.g. the LM hub) will restart it unattended the moment a feature PR auto-merges. Do not add such a repo casually.</p>
+                                <p class="text-xs text-red-600 font-medium">⚠️ A repo added here that restarts a live service on push (e.g. the LM hub) will restart it unattended the moment a PR to an allowlisted branch auto-merges. Do not add such a repo casually.</p>
                                 {% if feature_automerge_repo_options %}
                                 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 p-3 rounded-lg bg-slate-50 border border-slate-200 max-h-40 overflow-y-auto">
                                     {% for repo in feature_automerge_repo_options %}

--- a/test_feature_automerge_gate.py
+++ b/test_feature_automerge_gate.py
@@ -10,6 +10,15 @@ test_skills_loader.py's docstring), so this extracts _automerge_decision by
 source via ast and execs it with feature_boundary imported for real (pure,
 standalone — more faithful than reimplementing its matching logic here).
 
+UPDATED 2026-08-29: the containment used to be PR authorship (only PRs
+carrying the feature-drive marker were eligible — human PRs were
+structurally blocked by pr_meta["is_feature_drive"]). Now that more than one
+person works on this system, containment is by TARGET BRANCH instead:
+pr_meta["base_ref"] must be in feature_automerge_target_branches (opt-in,
+defaults to empty). ANY PR — human or bot — targeting an allowlisted branch
+(e.g. "dev") is now eligible if both panels approve at threshold; a PR
+targeting main, or any unlisted branch, never is, regardless of author.
+
 This is the single most safety-critical test in the whole feature auto-drive
 project: EVERY case must resolve to (False, reason) except the one fully-
 cleared, all-conditions-met case at the end. A False-negative here (a case
@@ -49,6 +58,7 @@ def _clean_config(**overrides):
         "feature_drive_enabled": True,
         "feature_automerge_enabled": True,
         "feature_automerge_repos": ["owner/repo"],
+        "feature_automerge_target_branches": ["dev"],
         "feature_automerge_min_confidence": 0.90,
         "feature_automerge_require_clean": True,
         # Existing cases below isolate ONE non-allowlist gate each, so keep the
@@ -72,8 +82,11 @@ def _clean_rec(**overrides):
 
 
 def _clean_pr_meta(**overrides):
-    meta = {"repo": "owner/repo", "is_feature_drive": True, "draft": False,
-            "state": "open", "mergeable": True}
+    # is_feature_drive defaults to False here deliberately — the clean/
+    # baseline case is now a HUMAN-authored PR to prove that's genuinely
+    # eligible, which is the whole point of this change.
+    meta = {"repo": "owner/repo", "base_ref": "dev", "is_feature_drive": False,
+            "draft": False, "state": "open", "mergeable": True}
     meta.update(overrides)
     return meta
 
@@ -83,9 +96,11 @@ def main():
     ns = _load_ns()
     decide = ns["_automerge_decision"]
 
-    # ── the all-clear case: everything below is a controlled regression from this ─
+    # ── the all-clear case: a HUMAN PR (is_feature_drive=False) to dev, everything
+    # else clean. This is the actual point of the 2026-08-29 change — prove it
+    # explicitly rather than just asserting it as a side effect. ─────────────
     should, reason = decide(_clean_rec(), ["some/file.py"], _clean_config(), _clean_pr_meta())
-    ok &= _check("all conditions cleared -> auto-merge approved", should is True)
+    ok &= _check("human PR, all conditions cleared -> auto-merge approved", should is True)
 
     # ── two independent kill switches ────────────────────────────────────────
     should, reason = decide(_clean_rec(), [], _clean_config(feature_drive_enabled=False), _clean_pr_meta())
@@ -99,10 +114,24 @@ def main():
     should, reason = decide(_clean_rec(), [], _clean_config(feature_automerge_repos=["other/repo"]), _clean_pr_meta())
     ok &= _check("repo present but a DIFFERENT one in the allowlist -> blocked", should is False)
 
-    # ── THE containment: missing marker means human PRs can NEVER auto-merge ─
-    should, reason = decide(_clean_rec(), [], _clean_config(), _clean_pr_meta(is_feature_drive=False))
-    ok &= _check("PR without the feature-drive marker -> blocked EVEN AT PERFECT CONFIDENCE "
-                "(this is what makes human PRs structurally ineligible)", should is False)
+    # ── THE containment (as of 2026-08-29): target branch, not authorship ───
+    should, reason = decide(_clean_rec(), [], _clean_config(), _clean_pr_meta(base_ref="main"))
+    ok &= _check("PR targeting main -> blocked EVEN AT PERFECT CONFIDENCE, "
+                "even from a feature-drive PR (this is what makes main structurally "
+                "ineligible now that authorship no longer gates)",
+                should is False and not decide(_clean_rec(), [], _clean_config(),
+                    _clean_pr_meta(base_ref="main", is_feature_drive=True))[0])
+    should, reason = decide(_clean_rec(), [], _clean_config(feature_automerge_target_branches=[]),
+                            _clean_pr_meta())
+    ok &= _check("target branch allowlist empty (default) -> blocked", should is False)
+    should, reason = decide(_clean_rec(), [], _clean_config(feature_automerge_target_branches=["staging"]),
+                            _clean_pr_meta())
+    ok &= _check("target branch not the specific one allowlisted -> blocked", should is False)
+    # ── explicit proof of the NEW capability: human PR to an allowlisted branch ─
+    should, reason = decide(_clean_rec(), [], _clean_config(), _clean_pr_meta(is_feature_drive=False, base_ref="dev"))
+    ok &= _check("human-authored PR (no feature-drive marker) targeting dev -> "
+                "NOW ELIGIBLE if everything else clears (the whole point of this change)",
+                should is True)
 
     # ── idempotency ──────────────────────────────────────────────────────────
     should, reason = decide(_clean_rec(merged=True), [], _clean_config(), _clean_pr_meta())


### PR DESCRIPTION
## Summary
- Auto-merge containment moves from *who authored the PR* (the feature-drive marker) to *what branch it targets* (a new opt-in `feature_automerge_target_branches` allowlist, defaults empty). Any PR — human or bot — clearing both skeptical-review panels at threshold can now auto-merge onto an allowlisted branch (e.g. `dev`); a PR targeting `main`, or any unlisted branch, is still never eligible regardless of author or confidence.
- `feature_automerge_enabled` no longer depends on `feature_drive_enabled` being on for the *branch* gate specifically — but `feature_drive_enabled` is still checked (kept it as-is per the existing convention rather than removing a gate I don't own full context for).
- Composes with the existing `feature_allowlist` diff-shape gate (added upstream while this branch was in flight) — both gates are required, not either/or.
- New Settings UI field for the target-branch allowlist; updated the now-stale tooltip that claimed only feature-built PRs were eligible.

## Why
This repo now has more than one developer. The old design (only bot-built PRs could ever auto-merge) was scoped for solo use. This lets a human PR to `dev` auto-merge under the same review bar a bot PR would need to clear, while `main` stays fully human-gated.

## Test plan
- [x] `python3 test_feature_automerge_gate.py` — all 36 cases pass, including new cases proving: `main` is blocked even from a feature-drive PR at perfect confidence, and a human-authored PR to an allowlisted branch is now genuinely eligible.
- [x] `python3 -m py_compile pr_review.py routes.py` — clean.
- [ ] Operator still needs to explicitly set `feature_automerge_target_branches` (e.g. `["dev"]`) in Settings — defaults to empty, so nothing changes behavior until configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)