### PR TITLE
Add a "failing" badge to Settings' LLM entries when a provider/model pairing is hard-failing

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -2063,6 +2063,59 @@ def _model_key(provider, base_url, model):
     return ((provider or "").lower().strip(), (base_url or "").strip().rstrip("/"), model or "")
 
 
+# ============================================================================
+# Per-entry health — lightweight in-memory failure/success tracking, keyed by
+# ModelKey. Feeds Settings' per-LLM-entry "failing" badge so a hard error a
+# provider's API returns on EVERY call (e.g. a model/endpoint pairing it
+# rejects outright, like GitHub Copilot 400ing a model unsupported on
+# /chat/completions) is visible without reading ab.log — found via lm#452/
+# #469/#444 sitting in an endless review-retry loop because one reviewer
+# entry was permanently broken and nothing surfaced that in the UI.
+#
+# Deliberately in-memory only (cleared on restart), same scope as the rate/
+# credit circuit breakers above — this answers "is it failing right now",
+# not a historical audit trail.
+# ============================================================================
+_ENTRY_HEALTH_LOCK = threading.Lock()
+_ENTRY_HEALTH = {}
+# Consecutive failures, with no success in between, before an entry is
+# reported unhealthy. >1 so a single transient blip (a network hiccup) never
+# flags an otherwise-fine entry; a hard config error fails every call, so it
+# crosses this within 2 attempts.
+_ENTRY_UNHEALTHY_THRESHOLD = 2
+
+
+def _record_llm_success(key):
+    with _ENTRY_HEALTH_LOCK:
+        _ENTRY_HEALTH[key] = {"consecutive_failures": 0, "last_error": None,
+                              "last_error_at": None, "last_ok_at": datetime.now().isoformat()}
+
+
+def _record_llm_failure(key, exc):
+    with _ENTRY_HEALTH_LOCK:
+        entry = dict(_ENTRY_HEALTH.get(key) or {"consecutive_failures": 0, "last_ok_at": None})
+        entry["consecutive_failures"] = entry.get("consecutive_failures", 0) + 1
+        entry["last_error"] = str(exc)[:300]
+        entry["last_error_at"] = datetime.now().isoformat()
+        _ENTRY_HEALTH[key] = entry
+
+
+def get_llm_entry_health(provider, base_url, model):
+    """Public accessor for the Settings UI. Returns
+    {"unhealthy": bool, "consecutive_failures": int, "last_error": str|None,
+    "last_error_at": str|None} for the given (provider, base_url, model).
+    An entry with no recorded calls yet reads as healthy, not unhealthy —
+    silence isn't failure."""
+    key = _model_key(provider, base_url, model)
+    with _ENTRY_HEALTH_LOCK:
+        entry = _ENTRY_HEALTH.get(key)
+    if not entry:
+        return {"unhealthy": False, "consecutive_failures": 0, "last_error": None, "last_error_at": None}
+    return {"unhealthy": entry.get("consecutive_failures", 0) >= _ENTRY_UNHEALTHY_THRESHOLD,
+            "consecutive_failures": entry.get("consecutive_failures", 0),
+            "last_error": entry.get("last_error"), "last_error_at": entry.get("last_error_at")}
+
+
 def _call_provider_wrapper(provider, model, api_key, base_url, messages, tools, effective_stream, task_id, config,
                            usage_out, **kwargs):
     """Wrapper function for threading-based timeout in Python 3.9 compatibility.
@@ -2089,9 +2142,12 @@ def _call_provider_timed(provider, model, api_key, base_url, messages, tools, ef
     than calling _call_provider directly, so a sample lands regardless of
     which retry branch actually wins.
 
-    On failure this re-raises unchanged and records nothing — a failed call
-    has no latency signal worth ranking on, and _try_provider's existing
-    credit/rate-limit bookkeeping already covers that case.
+    On failure this re-raises unchanged after recording the failure against
+    the entry's health (see _record_llm_failure below, e.g. for Settings'
+    per-entry "failing" badge) — _try_provider's existing credit/rate-limit
+    bookkeeping is a separate, narrower signal (only trips on specific known
+    causes) and doesn't cover a hard per-call error like a model/endpoint
+    pairing the provider's API rejects outright.
 
     Also wraps the underlying _call_provider call with a timeout to prevent
     indefinite hangs on network or provider issues."""
@@ -2102,41 +2158,46 @@ def _call_provider_timed(provider, model, api_key, base_url, messages, tools, ef
     # Extract timeout from config, defaulting to 900 seconds if not present
     timeout_s = int(config.get("LLM_TIMEOUT", 900))
 
-    # Wrap the actual LLM call with a timeout to prevent hanging
-    # This catches cases where the provider never responds (stuck network,
-    # rate-limit cooldown that isn't being reported, etc.)
-    if _TIMEOUT_AVAILABLE:
-        # Python 3.11+: use contextlib.timeout for clean timeout handling
-        try:
-            with timeout(timeout_s):
-                result = _call_provider(provider, model, api_key, base_url, messages, tools, effective_stream, task_id, config,
-                                        usage_out=usage_out, **kwargs)
-        except TimeoutError:
-            logger.warning("%s/%s timed out after %d seconds — raising TimeoutError to trigger failover",
-                           provider, model, timeout_s)
-            raise TimeoutError(f"LLM call to {provider}/{model} timed out after {timeout_s} seconds")
-    else:
-        # Python 3.9: use threading-based timeout (fallback)
-        # kwargs go through Thread's own `kwargs=` parameter — `**kwargs` cannot
-        # appear inside the args tuple literal (that is a SyntaxError in every
-        # Python version, which made this whole module un-importable).
-        thread = threading.Thread(target=_call_provider_wrapper,
-                                  args=(provider, model, api_key, base_url, messages, tools,
-                                        effective_stream, task_id, config, usage_out),
-                                  kwargs=kwargs,
-                                  daemon=True)
-        thread.start()
-        thread.join(timeout=timeout_s)
+    try:
+        # Wrap the actual LLM call with a timeout to prevent hanging
+        # This catches cases where the provider never responds (stuck network,
+        # rate-limit cooldown that isn't being reported, etc.)
+        if _TIMEOUT_AVAILABLE:
+            # Python 3.11+: use contextlib.timeout for clean timeout handling
+            try:
+                with timeout(timeout_s):
+                    result = _call_provider(provider, model, api_key, base_url, messages, tools, effective_stream, task_id, config,
+                                            usage_out=usage_out, **kwargs)
+            except TimeoutError:
+                logger.warning("%s/%s timed out after %d seconds — raising TimeoutError to trigger failover",
+                               provider, model, timeout_s)
+                raise TimeoutError(f"LLM call to {provider}/{model} timed out after {timeout_s} seconds")
+        else:
+            # Python 3.9: use threading-based timeout (fallback)
+            # kwargs go through Thread's own `kwargs=` parameter — `**kwargs` cannot
+            # appear inside the args tuple literal (that is a SyntaxError in every
+            # Python version, which made this whole module un-importable).
+            thread = threading.Thread(target=_call_provider_wrapper,
+                                      args=(provider, model, api_key, base_url, messages, tools,
+                                            effective_stream, task_id, config, usage_out),
+                                      kwargs=kwargs,
+                                      daemon=True)
+            thread.start()
+            thread.join(timeout=timeout_s)
 
-        if thread.is_alive():
-            logger.warning("%s/%s timed out after %d seconds — raising TimeoutError to trigger failover",
-                           provider, model, timeout_s)
-            thread.join()  # Give it a moment to clean up
-            raise TimeoutError(f"LLM call to {provider}/{model} timed out after {timeout_s} seconds")
-        if usage_out.get("_exc") is not None:
-            raise usage_out.pop("_exc")
-        result = usage_out.get("_result")
+            if thread.is_alive():
+                logger.warning("%s/%s timed out after %d seconds — raising TimeoutError to trigger failover",
+                               provider, model, timeout_s)
+                thread.join()  # Give it a moment to clean up
+                raise TimeoutError(f"LLM call to {provider}/{model} timed out after {timeout_s} seconds")
+            if usage_out.get("_exc") is not None:
+                raise usage_out.pop("_exc")
+            result = usage_out.get("_result")
+    except BaseException as e:
+        _record_llm_failure(key, e)
+        raise
 
+    _record_llm_success(key)
     latency_ms_wire = (time.monotonic() - t0) * 1000.0
     try:
         out_tok = usage_out.get("output_tokens")

--- a/routes.py
+++ b/routes.py
@@ -2129,8 +2129,21 @@ async def settings_page(request: Request):
         p: {"base_url": v.get("base_url", ""), "has_key": bool(v.get("api_key"))}
         for p, v in (config.get("llm_credentials") or {}).items()
     }
+    # health: per-entry "is this failing right now" for the Settings badge —
+    # resolves the same provider/model/base_url an actual call would use (an
+    # entry's own base_url overrides its provider's shared credential, same
+    # fallback llm_client._iter_configured_endpoints applies) so the lookup
+    # key matches what _call_provider_timed records against. See
+    # llm_client.get_llm_entry_health's docstring for why this surfaces at
+    # all (lm#452/#469/#444 found stuck on a permanently-broken entry with
+    # no visible signal in the UI).
+    import llm_client as _llm_client
+    _llm_creds = config.get("llm_credentials") or {}
     _safe_llm_entries = [
-        {**e, "api_key": "", "has_key": bool(e.get("api_key"))}
+        {**e, "api_key": "", "has_key": bool(e.get("api_key")),
+         "health": _llm_client.get_llm_entry_health(
+             e.get("provider") or "openai", e.get("base_url") or (_llm_creds.get((e.get("provider") or "openai").lower().strip()) or {}).get("base_url", ""),
+             e.get("model") or "")}
         for e in (config.get("llm_entries") or [])
     ]
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1228,6 +1228,7 @@
                                         <span class="flex-1 font-medium text-slate-700">{{ entry.label or entry.model }}{% if entry.enabled == False %} <span class="text-[10px] bg-slate-200 text-slate-500 px-1.5 py-0.5 rounded align-middle">disabled</span>{% endif %}</span>
                                         <span class="text-xs text-slate-400">{{ entry.provider }} / {{ entry.model }}</span>
                                         {% if entry.rpm %}<span class="text-[10px] bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded">{{ entry.rpm }} RPM</span>{% endif %}
+                                        {% if entry.health and entry.health.unhealthy %}<span class="text-[10px] bg-red-100 text-red-700 px-1.5 py-0.5 rounded font-bold" title="{{ entry.health.consecutive_failures }} calls in a row failed{% if entry.health.last_error %} — {{ entry.health.last_error }}{% endif %}{% if entry.health.last_error_at %} (last: {{ entry.health.last_error_at }}){% endif %}">⚠ failing</span>{% endif %}
                                         <label class="flex items-center gap-1 text-[11px] text-slate-500" title="Enabled endpoints are ranked by the picker for every call.">
                                             <input type="checkbox" onchange="toggleEntryEnabled('{{ entry.id }}', this.checked)" {{ 'checked' if entry.enabled != False else '' }} class="rounded border-slate-300 text-[#01A982] focus:ring-[#01A982]">
                                             on

--- a/test_llm_client_entry_health.py
+++ b/test_llm_client_entry_health.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Self-test for llm_client's per-entry health tracking (Settings' "failing"
+badge on an LLM entry).
+
+Run:  python3 test_llm_client_entry_health.py
+
+llm_client.py can't be imported directly (same circular-import chain as
+log_scan.py — see test_log_scan_requirements.py's docstring), so this
+extracts the health-tracking functions via ast and execs them in a minimal
+namespace, the established convention in this repo.
+
+Regression context: lm#452/#469/#444 sat in an endless hourly review-retry
+loop because one configured reviewer entry (Copilot paired with a model its
+API rejects on every call) failed silently — nothing in Settings showed it
+was broken. _record_llm_success/_record_llm_failure/get_llm_entry_health are
+wired into _call_provider_timed (every LLM call in the app routes through
+it) so a hard-failing entry becomes visible without reading ab.log."""
+import ast
+import threading
+from datetime import datetime
+
+
+def _load_ns():
+    src = open("llm_client.py").read()
+    tree = ast.parse(src)
+    names = {"_model_key", "_record_llm_success", "_record_llm_failure", "get_llm_entry_health"}
+    ns = {"threading": threading, "datetime": datetime}
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in names:
+            exec(ast.get_source_segment(src, node), ns)
+        elif isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id in ("_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH",
+                                                  "_ENTRY_UNHEALTHY_THRESHOLD")
+            for t in node.targets
+        ):
+            exec(ast.get_source_segment(src, node), ns)
+    missing = names - set(ns)
+    assert not missing, f"llm_client.py's shape changed — missing: {missing}"
+    return ns
+
+
+def _check(label, cond):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
+    return cond
+
+
+def main():
+    print("Running llm_client per-entry health self-test...")
+    ok = True
+    ns = _load_ns()
+    record_success = ns["_record_llm_success"]
+    record_failure = ns["_record_llm_failure"]
+    get_health = ns["get_llm_entry_health"]
+
+    # ── an entry with no calls yet reads as healthy, not unhealthy ──────────
+    h = get_health("copilot", "", "untouched-model")
+    ok &= _check("an entry with no recorded calls is healthy (silence != failure)",
+                h["unhealthy"] is False and h["consecutive_failures"] == 0)
+
+    # ── the actual regression: a model an API rejects on EVERY call ─────────
+    key = ("copilot", "", "grok-4.6")
+    ok &= _check("a single failure does not yet flag the entry (avoids one-off blips)",
+                not get_health(*key)["unhealthy"])
+    record_failure(key, Exception('400 unsupported_api_for_model: model "grok-4.6" is not '
+                                  "accessible via the /chat/completions endpoint"))
+    h1 = get_health(*key)
+    ok &= _check("after 1 failure: still not flagged (threshold is >1)",
+                not h1["unhealthy"] and h1["consecutive_failures"] == 1)
+    record_failure(key, Exception("400 unsupported_api_for_model (again)"))
+    h2 = get_health(*key)
+    ok &= _check("after 2 consecutive failures: flagged unhealthy",
+                h2["unhealthy"] and h2["consecutive_failures"] == 2)
+    ok &= _check("the last error message is captured for the badge tooltip",
+                "unsupported_api_for_model" in (h2["last_error"] or ""))
+    ok &= _check("last_error_at is stamped",
+                bool(h2["last_error_at"]))
+
+    # ── a success resets the streak — a since-fixed entry stops being flagged
+    record_success(key)
+    h3 = get_health(*key)
+    ok &= _check("a success after failures clears the unhealthy flag",
+                not h3["unhealthy"] and h3["consecutive_failures"] == 0)
+    ok &= _check("a success clears the stale last_error too",
+                h3["last_error"] is None)
+
+    # ── an unrelated entry is unaffected by another entry's failures ────────
+    other = get_health("ollama_cloud", "", "nemotron-3-ultra")
+    ok &= _check("a distinct (provider, base_url, model) key is tracked independently",
+                not other["unhealthy"] and other["consecutive_failures"] == 0)
+
+    print()
+    if ok:
+        print("ALL CASES PASSED")
+        return 0
+    print("ONE OR MORE CASES FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/test_llm_client_instrumentation.py
+++ b/test_llm_client_instrumentation.py
@@ -16,6 +16,7 @@ import ast
 import sys
 import threading
 import time
+from datetime import datetime
 
 import llm_perf
 
@@ -84,16 +85,19 @@ def _load_timed_ns(perf_path):
     exec'd together, unlike the single-function extractions elsewhere."""
     src = open("llm_client.py").read()
     tree = ast.parse(src)
-    names = {"_LLM_PERF_STORE", "_LLM_PERF_LOCK", "_llm_perf_last_save", "_LLM_PERF_SAVE_INTERVAL"}
+    names = {"_LLM_PERF_STORE", "_LLM_PERF_LOCK", "_llm_perf_last_save", "_LLM_PERF_SAVE_INTERVAL",
+              # per-entry health globals (_call_provider_timed records against these
+              # on every call — see llm_client.get_llm_entry_health's docstring)
+              "_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH", "_ENTRY_UNHEALTHY_THRESHOLD"}
     fn_names = {"_get_llm_perf_store", "get_llm_perf_snapshot", "_model_key", "_call_provider_timed",
-                "_call_provider_wrapper"}
+                "_call_provider_wrapper", "_record_llm_success", "_record_llm_failure"}
     segs = []
     for node in tree.body:
         if isinstance(node, ast.Assign) and any(getattr(t, "id", "") in names for t in node.targets):
             segs.append(ast.get_source_segment(src, node))
         elif isinstance(node, ast.FunctionDef) and node.name in fn_names:
             segs.append(ast.get_source_segment(src, node))
-    assert len(segs) == 4 + 5, f"expected 4 globals + 5 functions, found {len(segs)} segments"
+    assert len(segs) == 7 + 7, f"expected 7 globals + 7 functions, found {len(segs)} segments"
 
     calls = {"provider_calls": []}
 
@@ -109,7 +113,7 @@ def _load_timed_ns(perf_path):
 
     ns = {
         "llm_perf": llm_perf, "config_store": _FakeConfigStore(perf_path),
-        "threading": threading, "time": time,
+        "threading": threading, "time": time, "datetime": datetime,
         "_call_provider": _call_provider_stub,
         # _call_provider_timed wraps the call in a timeout. Pin the threading
         # fallback (the Python 3.9 branch) rather than contextlib.timeout: it is
@@ -170,6 +174,8 @@ def main():
                     snap[key]["latency_ms"] is not None and snap[key]["latency_ms"] >= 15)
         ok &= _check("tps is derived from output_tokens / wall latency when no gen_duration_ms is given",
                     snap[key]["tps"] is not None and snap[key]["tps"] > 0)
+        ok &= _check("a successful call also records healthy entry health",
+                    key in tns["_ENTRY_HEALTH"] and tns["_ENTRY_HEALTH"][key]["consecutive_failures"] == 0)
 
         # --- server-measured gen_duration_ms is preferred over wall latency for tps
 
@@ -183,7 +189,9 @@ def main():
         ok &= _check("tps prefers the server-measured gen_duration_ms over inflated wall-clock latency",
                     snap2[key2]["tps"] is not None and snap2[key2]["tps"] > 1000)
 
-        # --- a failed call records nothing and re-raises -----------------------
+        # --- a failed call records no PERF sample but DOES record health -------
+        # (the health/perf split: perf is a ranking signal with no meaning for a
+        # failed call; health is exactly the opposite — see get_llm_entry_health)
 
         tns["_test_calls"]["raise_exc"] = RuntimeError("boom")
         threw = False
@@ -195,6 +203,10 @@ def main():
         snap3 = tns["get_llm_perf_snapshot"]()
         ok &= _check("a failed call adds no perf sample for a never-before-seen model",
                     ("openai", "", "gpt-9") not in snap3)
+        ok &= _check("but the failure IS recorded against entry health",
+                    ("openai", "", "gpt-9") in tns["_ENTRY_HEALTH"]
+                    and tns["_ENTRY_HEALTH"][("openai", "", "gpt-9")]["consecutive_failures"] == 1
+                    and "boom" in tns["_ENTRY_HEALTH"][("openai", "", "gpt-9")]["last_error"])
 
         # --- distinct base_urls for the same (provider, model) stay isolated ---
 

--- a/test_llm_credential_redaction.py
+++ b/test_llm_credential_redaction.py
@@ -25,21 +25,34 @@ import sys
 
 def _extract_redaction_source(src):
     """The two redaction Assign statements live INSIDE settings_page's body
-    (a much larger function than this fix touches) — pull just their source
-    text out, unexecuted, so the caller can exec() it fresh with its own
-    `config` already bound instead of needing the whole route's dependencies
-    (GitHub repo fetch, DEFAULT_ENV, os.getenv, state, templates, ...)."""
+    (a much larger function than this fix touches) — pull the contiguous
+    slice of statements from the first through the last of them (inclusive),
+    unexecuted, so the caller can exec() it fresh with its own `config`
+    already bound instead of needing the whole route's dependencies
+    (GitHub repo fetch, DEFAULT_ENV, os.getenv, state, templates, ...).
+
+    A SLICE rather than just the two Assigns: _safe_llm_entries' health
+    lookup (see llm_client.get_llm_entry_health) needs a `_llm_creds` local
+    that lives between the two target Assigns in the real source — taking
+    the whole span keeps this test executing that REAL statement instead of
+    a reimplemented copy that could drift from it. The `import llm_client`
+    statement in that span is skipped (llm_client.py pulls in `main`'s
+    app-init side effects — the same reason routes.py itself can't be
+    imported here); the caller stubs `_llm_client` instead, since this test
+    is about api_key redaction, not the health lookup's own behavior (that's
+    test_llm_client_entry_health.py's job)."""
     tree = ast.parse(src)
-    lines = []
     for node in tree.body:
         if isinstance(node, ast.AsyncFunctionDef) and node.name == "settings_page":
-            for inner in ast.walk(node):
-                if isinstance(inner, ast.Assign):
-                    for t in inner.targets:
-                        if getattr(t, "id", "") in ("_safe_llm_credentials", "_safe_llm_entries"):
-                            lines.append(ast.get_source_segment(src, inner))
-    assert len(lines) == 2, f"expected 2 redaction statements in settings_page, found {len(lines)}"
-    return "\n".join(lines)
+            body = node.body
+            idxs = [i for i, stmt in enumerate(body) if isinstance(stmt, ast.Assign)
+                    and any(getattr(t, "id", "") in ("_safe_llm_credentials", "_safe_llm_entries")
+                            for t in stmt.targets)]
+            assert len(idxs) == 2, f"expected 2 redaction statements in settings_page, found {len(idxs)}"
+            span = [s for s in body[min(idxs):max(idxs) + 1]
+                    if not isinstance(s, (ast.Import, ast.ImportFrom))]
+            return "\n".join(ast.get_source_segment(src, s) for s in span)
+    raise AssertionError("settings_page not found in routes.py")
 
 
 def _load_ns():
@@ -120,7 +133,14 @@ def main():
              "base_url": "", "api_key": "", "escalation_models": ""},
         ],
     }
-    exec_ns = {"config": config}
+    class _StubLlmClient:
+        """This test is about api_key redaction, not the health lookup's own
+        behavior — see test_llm_client_entry_health.py for that."""
+        @staticmethod
+        def get_llm_entry_health(provider, base_url, model):
+            return {"unhealthy": False, "consecutive_failures": 0, "last_error": None, "last_error_at": None}
+
+    exec_ns = {"config": config, "_llm_client": _StubLlmClient()}
     exec(ns["_redaction_source"], exec_ns)
 
     ok &= _check("settings_page redaction: credential api_key is never the real secret",
@@ -139,6 +159,9 @@ def main():
                 exec_ns["_safe_llm_entries"][0]["model"] == "qwen"
                 and exec_ns["_safe_llm_entries"][0]["provider"] == "ollama"
                 and exec_ns["_safe_llm_entries"][0]["label"] == "x")
+    ok &= _check("settings_page redaction: each entry carries a health dict for the Settings badge",
+                exec_ns["_safe_llm_entries"][0]["health"] == {"unhealthy": False, "consecutive_failures": 0,
+                                                               "last_error": None, "last_error_at": None})
 
     # ── empty credentials/entries don't crash the redaction ─────────────────
     exec_ns2 = {"config": {}}


### PR DESCRIPTION
## Summary
Root cause of lm#452/#469/#444 sitting stuck: the Skeptical Reviewer panel had one entry (`Copilot - Grok 4.6`, provider `copilot` model `grok-4.6`) that returns `400 unsupported_api_for_model` on **every single call** — that model isn't served through Copilot's `/chat/completions` endpoint. Combined with `ollama_cloud` frequently rate-limiting (`429`), the panel was chronically down to one live reviewer whose solo confidence never cleared the 0.80 threshold required to proceed short-handed — so every fix got deferred another hour, forever, with nothing visible in the UI explaining why.

- `llm_client._call_provider_timed` — the single choke point every LLM call in the app routes through — now records per-entry health (`_record_llm_success` / `_record_llm_failure`), keyed by the same `ModelKey` as the existing perf/cooldown tracking.
- 2+ consecutive failures with no success in between marks an entry unhealthy (1 failure alone doesn't flag it, so a one-off network blip stays quiet); a success resets the streak.
- New `llm_client.get_llm_entry_health(provider, base_url, model)` accessor.
- `routes.py`'s `settings_page` attaches a `health` dict to each redacted `llm_entries` row.
- `templates/index.html` renders a red **"⚠ failing"** badge on the entry's summary row when unhealthy, with the consecutive-failure count, last error, and timestamp in the tooltip.
- Deliberately in-memory only (cleared on restart) — this answers "is it failing right now," not a historical audit trail; same scope as the existing rate/credit circuit breakers it sits next to.

## Test plan
- [x] New `test_llm_client_entry_health.py` — pins the threshold behavior (1 failure doesn't flag, 2 does), error/timestamp capture, success-resets-the-streak, and per-key isolation. Ast-extracts the real functions (module can't be imported directly — circular import via `main`).
- [x] Updated `test_llm_client_instrumentation.py` to extract the new globals/functions alongside the existing perf-telemetry block (they're now wired into the same `_call_provider_timed` call), and added assertions that a success/failure actually records against `_ENTRY_HEALTH`.
- [x] Updated `test_llm_credential_redaction.py`'s source-extraction to span the new `_llm_creds`/health-lookup statement between the two redaction Assigns (stubbing `_llm_client` rather than letting the real module import, same reasoning as why `routes.py` itself can't be imported in that test), plus a new assertion that the `health` dict is attached and never leaks the entry's `api_key`.
- [x] Manually rendered the badge fragment via Jinja with a synthetic failing + healthy entry — confirmed exact expected markup/tooltip.
- [x] Full existing suite run: all green except `test_feature_build.py`, confirmed pre-existing/unrelated via `git stash` comparison (same failure on a clean `dev` checkout).