### PR TITLE
Refuse release branches as auto-merge targets, regardless of config

### DIFF
--- a/pr_review.py
+++ b/pr_review.py
@@ -14,7 +14,10 @@ INVARIANTS (see memory pr-gate-ab-prereview):
     broadened 2026-08-29): ``_maybe_auto_merge``/``_automerge_decision`` CAN
     approve+merge a PR unattended — but ONLY when its target branch is
     explicitly opted into ``feature_automerge_target_branches`` (defaults to
-    empty — opt-in, not opt-out; e.g. ["dev"], NEVER main), both review
+    empty — opt-in, not opt-out; e.g. ["dev", "qa"]). main/master (and the
+    configured ``default_branch``) are refused structurally, so listing one
+    there does nothing — merges into the release branch stay owner-only.
+    Beyond that gate: both review
     panels Approve above a configurable confidence floor, the diff is a
     provably-additive shape (``feature_allowlist``), the diff touches no
     configured boundary, and the repo is explicitly opted into
@@ -895,10 +898,23 @@ def _automerge_decision(rec, changed_paths, config, pr_meta, state_flags=None, c
         return False, "feature_automerge_enabled is off"
     if pr_meta.get("repo") not in (config.get("feature_automerge_repos") or []):
         return False, "repo is not in feature_automerge_repos (opt-in, defaults to none)"
-    if pr_meta.get("base_ref") not in (config.get("feature_automerge_target_branches") or []):
+    # Structural refusal of the release branch, checked BEFORE the operator's
+    # allowlist so configuration cannot override it. The allowlist is a free-text
+    # field in Settings; both it and this function's docstring say "NEVER main",
+    # but saying it is not enforcing it — typing "main" into that box was enough
+    # to make an unattended merge onto the release branch eligible. Only the repo
+    # owner merges into main, so that invariant lives in code, not in guidance.
+    _base_ref = pr_meta.get("base_ref")
+    _release_branches = {"main", "master", (config.get("default_branch") or "main")}
+    if _base_ref in _release_branches:
+        return False, (f"target branch {_base_ref!r} is a release branch — never eligible for "
+                       "auto-merge at any confidence, even if listed in "
+                       "feature_automerge_target_branches (merges into it are owner-only)")
+
+    if _base_ref not in (config.get("feature_automerge_target_branches") or []):
         return False, ("target branch %r is not in feature_automerge_target_branches "
                         "(opt-in, defaults to none) — main (or any unlisted branch) is "
-                        "never eligible, regardless of author or confidence" % pr_meta.get("base_ref"))
+                        "never eligible, regardless of author or confidence" % _base_ref)
 
     if rec.get("merged") or rec.get("auto_merged"):
         return False, "already merged (idempotent no-op)"

--- a/templates/index.html
+++ b/templates/index.html
@@ -2228,8 +2228,8 @@
                             </div>
                             <div class="space-y-2 mt-2">
                                 <label class="text-sm font-medium text-slate-600">Auto-Merge Target Branches <span class="text-red-500 font-normal">(opt-in — empty means NOTHING auto-merges, regardless of the toggle above)</span></label>
-                                <p class="text-xs text-red-600 font-medium">⚠️ This is what stands between "unattended merge" and "human required" now that PR authorship no longer matters. Never add main/master here — only a lower-stakes branch (e.g. dev) that isn't wired to deploy/restart anything on push.</p>
-                                <input type="text" name="feature_automerge_target_branches" value="{{ settings.get('feature_automerge_target_branches', []) | join(', ') }}" placeholder="Branches allowed to receive auto-merges (comma-separated, e.g. dev)" class="w-full p-2 text-xs rounded-lg border border-slate-300 outline-none focus:ring-1 focus:ring-[#01A982]">
+                                <p class="text-xs text-red-600 font-medium">⚠️ This is what stands between "unattended merge" and "human required" now that PR authorship no longer matters. Add only lower-stakes branches that aren't wired to deploy/restart anything on push — e.g. <code>dev, qa</code>. Listing main/master (or the repo's default branch) has no effect: merges into the release branch are owner-only and are refused in code, at any confidence.</p>
+                                <input type="text" name="feature_automerge_target_branches" value="{{ settings.get('feature_automerge_target_branches', []) | join(', ') }}" placeholder="Branches allowed to receive auto-merges (comma-separated, e.g. dev, qa)" class="w-full p-2 text-xs rounded-lg border border-slate-300 outline-none focus:ring-1 focus:ring-[#01A982]">
                             </div>
                             <div class="space-y-2 mt-2">
                                 <label class="text-sm font-medium text-slate-600">Auto-Merge Repositories <span class="text-red-500 font-normal">(opt-in — empty means NOTHING auto-merges, regardless of the toggle above)</span></label>

--- a/test_feature_automerge_gate.py
+++ b/test_feature_automerge_gate.py
@@ -127,6 +127,42 @@ def main():
     should, reason = decide(_clean_rec(), [], _clean_config(feature_automerge_target_branches=["staging"]),
                             _clean_pr_meta())
     ok &= _check("target branch not the specific one allowlisted -> blocked", should is False)
+
+    # ── release branches are refused STRUCTURALLY, not just by omission ─────
+    # The cases above only prove main is blocked when it is absent from the
+    # allowlist. That is containment by configuration: the allowlist is a
+    # free-text Settings field, so a single typo used to make an unattended
+    # merge onto the release branch eligible. These pin that main/master/the
+    # configured default_branch are refused EVEN WHEN EXPLICITLY LISTED —
+    # merges into the release branch are owner-only, and that now lives in code.
+    for _br in ("main", "master"):
+        should, reason = decide(_clean_rec(), [],
+                                _clean_config(feature_automerge_target_branches=["dev", "qa", _br]),
+                                _clean_pr_meta(base_ref=_br))
+        ok &= _check(f"{_br} EXPLICITLY listed in feature_automerge_target_branches -> "
+                     "still blocked (config cannot override the release-branch refusal)",
+                     should is False and "release branch" in reason)
+    should, reason = decide(_clean_rec(), [],
+                            _clean_config(feature_automerge_target_branches=["release"],
+                                          default_branch="release"),
+                            _clean_pr_meta(base_ref="release"))
+    ok &= _check("a non-'main' default_branch, explicitly listed -> still blocked "
+                 "(the refusal follows default_branch, not the literal name 'main')",
+                 should is False and "release branch" in reason)
+
+    # ── the qa/dev chain stays eligible: the refusal must not over-reach ────
+    for _br in ("dev", "qa"):
+        should, reason = decide(_clean_rec(), [],
+                                _clean_config(feature_automerge_target_branches=["dev", "qa"]),
+                                _clean_pr_meta(base_ref=_br))
+        ok &= _check(f"{_br} listed -> ALLOWED (release-branch refusal does not "
+                     "over-block the non-release chain)", should is True)
+    should, reason = decide(_clean_rec(), [],
+                            _clean_config(feature_automerge_target_branches=["dev", "qa"],
+                                          default_branch="release"),
+                            _clean_pr_meta(base_ref="qa"))
+    ok &= _check("qa still allowed when default_branch is some other branch entirely",
+                 should is True)
     # ── explicit proof of the NEW capability: human PR to an allowlisted branch ─
     should, reason = decide(_clean_rec(), [], _clean_config(), _clean_pr_meta(is_feature_drive=False, base_ref="dev"))
     ok &= _check("human-authored PR (no feature-drive marker) targeting dev -> "


### PR DESCRIPTION
Extending the >=90% confidence auto-merge from `dev` to the `dev`/`qa` chain made an existing hole materially more likely to be hit.

`feature_automerge_target_branches` is a free-text Settings field. Both the UI copy and `_automerge_decision`'s docstring said "NEVER main", but nothing enforced it — `main` was blocked only by being *absent* from the list. Executing the gate with `main` explicitly listed returned `auto_merge=True`.

This refuses `main`/`master` and the configured `default_branch` structurally, checked **before** the operator allowlist so configuration cannot override it. `qa`/`dev` are unaffected.

No branch is opted in here — auto-merge stays default-deny behind `feature_automerge_enabled` + `feature_automerge_repos`, and the confidence floor still fails closed at 1.0 when unset.

Tests pin main/master/custom default_branch as blocked even when explicitly listed, and that dev/qa are not over-blocked. Three mutations each caught. 296 tests pass.