### PR TITLE
Exclude hard-failing LLM entries from the picker's pool, not just Settings' badge

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -2083,12 +2083,21 @@ _ENTRY_HEALTH = {}
 # flags an otherwise-fine entry; a hard config error fails every call, so it
 # crosses this within 2 attempts.
 _ENTRY_UNHEALTHY_THRESHOLD = 2
+# Once unhealthy, how long the picker keeps skipping the entry before trying
+# it again on its own (matches _CREDIT_COOLDOWN_SECONDS and the fix-review
+# retry cadence elsewhere in this app, so behavior stays consistent). Unlike
+# a rate/credit cooldown, a hard failure has no server-reported "retry after"
+# — this is a guess, not a real signal, so it errs long: a config error
+# (wrong model name) needs an operator anyway, and a real outage is rare
+# enough that checking hourly costs nothing.
+_ENTRY_UNHEALTHY_RETRY_SECONDS = 3600
 
 
 def _record_llm_success(key):
     with _ENTRY_HEALTH_LOCK:
         _ENTRY_HEALTH[key] = {"consecutive_failures": 0, "last_error": None,
-                              "last_error_at": None, "last_ok_at": datetime.now().isoformat()}
+                              "last_error_at": None, "last_ok_at": datetime.now().isoformat(),
+                              "retry_after": 0.0}
 
 
 def _record_llm_failure(key, exc):
@@ -2097,7 +2106,33 @@ def _record_llm_failure(key, exc):
         entry["consecutive_failures"] = entry.get("consecutive_failures", 0) + 1
         entry["last_error"] = str(exc)[:300]
         entry["last_error_at"] = datetime.now().isoformat()
+        if entry["consecutive_failures"] >= _ENTRY_UNHEALTHY_THRESHOLD:
+            entry["retry_after"] = time.time() + _ENTRY_UNHEALTHY_RETRY_SECONDS
         _ENTRY_HEALTH[key] = entry
+
+
+def _entry_is_unhealthy(key):
+    """The single source of truth for "unhealthy" — shared by
+    get_llm_entry_health (the Settings badge) and _enumerate_candidates (the
+    picker). Sharing this, rather than each computing its own threshold
+    check, is what makes routing self-healing rather than just visible:
+    lm#452/#469/#444 kept re-selecting a permanently-broken Copilot entry
+    every retry, because nothing EXCLUDED it from selection — a human had to
+    notice the badge and disable it by hand. Now the same signal that lights
+    the badge also removes the candidate from the picker's pool, the same
+    way an existing rate/credit cooldown already does.
+
+    TIMED, not permanent: past _ENTRY_UNHEALTHY_THRESHOLD consecutive
+    failures, the entry stays excluded only until its retry_after elapses —
+    excluding it from the pool means it can never be called again to record
+    a success, so a purely one-shot exclusion would be permanent for the
+    life of the process. After retry_after, one real attempt is allowed
+    through; if it fails again, _record_llm_failure extends the cooldown."""
+    with _ENTRY_HEALTH_LOCK:
+        entry = _ENTRY_HEALTH.get(key)
+    if not entry or entry.get("consecutive_failures", 0) < _ENTRY_UNHEALTHY_THRESHOLD:
+        return False
+    return time.time() < entry.get("retry_after", 0.0)
 
 
 def get_llm_entry_health(provider, base_url, model):
@@ -2107,12 +2142,12 @@ def get_llm_entry_health(provider, base_url, model):
     An entry with no recorded calls yet reads as healthy, not unhealthy —
     silence isn't failure."""
     key = _model_key(provider, base_url, model)
+    unhealthy = _entry_is_unhealthy(key)
     with _ENTRY_HEALTH_LOCK:
         entry = _ENTRY_HEALTH.get(key)
     if not entry:
         return {"unhealthy": False, "consecutive_failures": 0, "last_error": None, "last_error_at": None}
-    return {"unhealthy": entry.get("consecutive_failures", 0) >= _ENTRY_UNHEALTHY_THRESHOLD,
-            "consecutive_failures": entry.get("consecutive_failures", 0),
+    return {"unhealthy": unhealthy, "consecutive_failures": entry.get("consecutive_failures", 0),
             "last_error": entry.get("last_error"), "last_error_at": entry.get("last_error_at")}
 
 
@@ -2353,6 +2388,15 @@ def _enumerate_candidates(config):
             available, unavailable_reason = False, "rate_limited"
         elif _routed_model_dead(provider, model):
             available, unavailable_reason = False, "dead_model"
+        elif _entry_is_unhealthy(key):
+            # A hard error every call (e.g. a model/endpoint pairing the
+            # provider's API rejects outright) has no timed recovery like a
+            # rate/credit cooldown does — it stays excluded from the picker's
+            # pool until a call succeeds again (an operator fixes the entry,
+            # or the provider starts serving that model). See
+            # _entry_is_unhealthy's docstring for why this must share state
+            # with the Settings badge rather than compute its own check.
+            available, unavailable_reason = False, "hard_failing"
         candidates.append({
             "key": key, "provider": provider, "model": model, "base_url": base_url,
             "api_key": api_key, "rpm": rpm, "caps": caps,

--- a/test_llm_client_entry_health.py
+++ b/test_llm_client_entry_health.py
@@ -17,20 +17,23 @@ wired into _call_provider_timed (every LLM call in the app routes through
 it) so a hard-failing entry becomes visible without reading ab.log."""
 import ast
 import threading
+import time
 from datetime import datetime
 
 
 def _load_ns():
     src = open("llm_client.py").read()
     tree = ast.parse(src)
-    names = {"_model_key", "_record_llm_success", "_record_llm_failure", "get_llm_entry_health"}
-    ns = {"threading": threading, "datetime": datetime}
+    names = {"_model_key", "_record_llm_success", "_record_llm_failure",
+              "get_llm_entry_health", "_entry_is_unhealthy"}
+    ns = {"threading": threading, "datetime": datetime, "time": time}
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name in names:
             exec(ast.get_source_segment(src, node), ns)
         elif isinstance(node, ast.Assign) and any(
             isinstance(t, ast.Name) and t.id in ("_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH",
-                                                  "_ENTRY_UNHEALTHY_THRESHOLD")
+                                                  "_ENTRY_UNHEALTHY_THRESHOLD",
+                                                  "_ENTRY_UNHEALTHY_RETRY_SECONDS")
             for t in node.targets
         ):
             exec(ast.get_source_segment(src, node), ns)
@@ -87,6 +90,22 @@ def main():
     other = get_health("ollama_cloud", "", "nemotron-3-ultra")
     ok &= _check("a distinct (provider, base_url, model) key is tracked independently",
                 not other["unhealthy"] and other["consecutive_failures"] == 0)
+
+    # ── timed recovery: unhealthy is not permanent (see _entry_is_unhealthy's
+    # docstring — a one-shot exclusion would be permanent, since an excluded
+    # entry can never be called again to record the success that clears it) ─
+    is_unhealthy = ns["_entry_is_unhealthy"]
+    retry_key = ("copilot", "", "gpt-5.5")
+    record_failure(retry_key, Exception("boom"))
+    record_failure(retry_key, Exception("boom again"))
+    ok &= _check("2 consecutive failures -> unhealthy", is_unhealthy(retry_key))
+    with ns["_ENTRY_HEALTH_LOCK"]:
+        ns["_ENTRY_HEALTH"][retry_key]["retry_after"] = time.time() + 3600
+    ok &= _check("still within the retry window -> stays unhealthy", is_unhealthy(retry_key))
+    with ns["_ENTRY_HEALTH_LOCK"]:
+        ns["_ENTRY_HEALTH"][retry_key]["retry_after"] = time.time() - 1
+    ok &= _check("retry_after elapsed -> no longer reported unhealthy (one fresh attempt allowed)",
+                not is_unhealthy(retry_key))
 
     print()
     if ok:

--- a/test_llm_client_requirements_path.py
+++ b/test_llm_client_requirements_path.py
@@ -31,6 +31,10 @@ def _load_ns():
         "_model_key", "get_llm_perf_snapshot", "_get_llm_perf_store",
         "_provider_configured", "_provider_is_nokey", "_is_ollama", "_is_ollama_cloud", "_is_lmstudio",
         "_routed_model_dead", "_get_category_semaphore",
+        # per-entry health (lm#452/#469/#444: a hard-failing entry must be
+        # EXCLUDED from the picker's pool, not just visible in Settings —
+        # see _entry_is_unhealthy's docstring in llm_client.py)
+        "_record_llm_failure", "_record_llm_success", "_entry_is_unhealthy",
     }
     want_assign = {
         "_ALL_SLOTS", "_CODE_SLOTS", "_LOG_SLOTS", "_REVIEW_SLOTS", "_TOOL_400_MARKERS",
@@ -41,6 +45,8 @@ def _load_ns():
         "_CREDIT_COOLDOWN_SECONDS", "_RATELIMIT_COOLDOWN_SECONDS",
         "_ROUTED_404", "_ROUTED_404_LOCK",
         "OLLAMA_CLOUD_PROVIDER", "OLLAMA_CLOUD_BASE_URL",
+        "_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH", "_ENTRY_UNHEALTHY_THRESHOLD",
+        "_ENTRY_UNHEALTHY_RETRY_SECONDS",
     }
     segs = []
     for node in tree.body:
@@ -159,6 +165,55 @@ def main():
     ns["_cb_trip"](ns["_ENDPOINT_CREDIT_CB"], ns["_endpoint_key"]("ollama", ""), "bogus", 3600, "credit", "ollama")
     ok &= _check("a credit trip against a no-key local provider is ignored, not recorded",
                 ns["_endpoint_key"]("ollama", "") not in ns["_ENDPOINT_CREDIT_CB"])
+
+    # --- a hard-failing entry (lm#452/#469/#444's actual regression) is -------
+    # --- EXCLUDED from the picker's pool, not just flagged in Settings -------
+
+    hard_cfg = {"llm_entries": [_entry("e1", "copilot", "grok-4.6", base_url="")]}
+    hard_key = ns["_model_key"]("copilot", "", "grok-4.6")
+    hard_candidates_before = ns["_enumerate_candidates"](hard_cfg)
+    ok &= _check("before any failure, the entry is a normal available candidate",
+                len(hard_candidates_before) == 1 and hard_candidates_before[0]["available"] is True)
+
+    ns["_record_llm_failure"](hard_key, Exception('400 unsupported_api_for_model'))
+    ok &= _check("one failure alone does not exclude the candidate (avoids a one-off blip)",
+                ns["_enumerate_candidates"](hard_cfg)[0]["available"] is True)
+
+    ns["_record_llm_failure"](hard_key, Exception('400 unsupported_api_for_model (again)'))
+    hard_candidates_after = ns["_enumerate_candidates"](hard_cfg)
+    ok &= _check("after 2 consecutive failures, the SAME entry that keeps 400ing is excluded "
+                "from the pool — the actual fix for lm#452/#469/#444 (a broken reviewer no "
+                "longer burns both panel slots every retry)",
+                len(hard_candidates_after) == 1 and hard_candidates_after[0]["available"] is False
+                and hard_candidates_after[0]["unavailable_reason"] == "hard_failing")
+
+    ns["_record_llm_success"](hard_key)
+    ok &= _check("a success (e.g. after an operator fixes the model name) clears the exclusion "
+                "immediately — no need to wait out the hourly retry window",
+                ns["_enumerate_candidates"](hard_cfg)[0]["available"] is True)
+
+    # Timed recovery: re-trip it, then simulate the retry window elapsing —
+    # this is what lets the picker try it again on its own even if nobody
+    # fixes it (see _entry_is_unhealthy's docstring: a one-shot exclusion
+    # would be permanent, since an excluded entry can never be called again
+    # to record the success that would clear it).
+    ns["_record_llm_failure"](hard_key, Exception("boom"))
+    ns["_record_llm_failure"](hard_key, Exception("boom again"))
+    ok &= _check("re-tripped: excluded again", ns["_enumerate_candidates"](hard_cfg)[0]["available"] is False)
+    with ns["_ENTRY_HEALTH_LOCK"]:
+        ns["_ENTRY_HEALTH"][hard_key]["retry_after"] = ns["time"].time() - 1  # already elapsed
+    ok &= _check("once retry_after has elapsed, the picker allows one fresh attempt again",
+                ns["_enumerate_candidates"](hard_cfg)[0]["available"] is True)
+
+    # A distinct model at the same provider is unaffected by the broken one
+    # (a fresh key — not grok-4.6, which already carries state from above).
+    unrelated_cfg = {"llm_entries": [_entry("e1", "copilot", "gpt-5.5"),
+                                     _entry("e2", "copilot", "gpt-4o-2024-08-06")]}
+    ns["_record_llm_failure"](ns["_model_key"]("copilot", "", "gpt-5.5"), Exception("x"))
+    ns["_record_llm_failure"](ns["_model_key"]("copilot", "", "gpt-5.5"), Exception("x"))
+    unrelated_candidates = {c["model"]: c["available"] for c in ns["_enumerate_candidates"](unrelated_cfg)}
+    ok &= _check("a broken model does not drag down an unrelated model on the same provider",
+                unrelated_candidates == {"gpt-5.5": False, "gpt-4o-2024-08-06": True})
 
     # --- _configured_entries feeds safety_floor ---------------------------------
 


### PR DESCRIPTION
## Summary
Follow-up to #82 (the Settings "failing" badge). The user correctly pushed back: a panel with multiple configured models shouldn't be blocked by one or two broken ones — that's the whole point of having several. The badge made the problem *visible*; it did nothing to stop the picker from re-selecting the same dead entry on every retry, which is why lm#452/#469/#444 stayed stuck even after the badge shipped.

- `_enumerate_candidates` now treats an entry `_entry_is_unhealthy()` flags (2+ consecutive failures, no success in between — the same signal that lights the Settings badge) as `available: False`, exactly like an existing rate-limit or credit-exhaustion cooldown already does.
- `select_model` already skips any candidate marked unavailable, so this alone routes review/build calls around a hard-failing entry onto the other configured, working ones — no change needed there.
- **Timed, not permanent**: excluding an entry means it can never be called again to record the success that would clear it — a one-shot exclusion would be a silent permanent removal for the life of the process. `_record_llm_failure` now stamps a `retry_after` (1 hour, matching the existing review-retry cadence elsewhere in this app) once the threshold is crossed; `_entry_is_unhealthy` only reports unhealthy while that window hasn't elapsed, so the picker tries the entry again on its own periodically — in case a transient provider outage clears, or an operator's fix takes effect — without needing a success to already exist.

## Test plan
- [x] `test_llm_client_requirements_path.py`: new block against `_enumerate_candidates` — before any failure available, after 1 failure still available (avoids one-off blips), after 2 excluded with `unavailable_reason: "hard_failing"`, a success clears it immediately, re-tripping + simulating the retry window elapsing restores availability, and an unrelated model on the same provider is unaffected.
- [x] `test_llm_client_entry_health.py`: extended with the same timed-recovery behavior at the `_entry_is_unhealthy` level directly.
- [x] `test_llm_client_instrumentation.py`: unaffected, still green (doesn't touch `_enumerate_candidates`).
- [x] Full existing suite: all green except `test_feature_build.py`, confirmed pre-existing/unrelated.