### PR TITLE
Auto-merge target branches as a selector + expose the allowlist gate

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -2083,12 +2083,21 @@ _ENTRY_HEALTH = {}
 # flags an otherwise-fine entry; a hard config error fails every call, so it
 # crosses this within 2 attempts.
 _ENTRY_UNHEALTHY_THRESHOLD = 2
+# Once unhealthy, how long the picker keeps skipping the entry before trying
+# it again on its own (matches _CREDIT_COOLDOWN_SECONDS and the fix-review
+# retry cadence elsewhere in this app, so behavior stays consistent). Unlike
+# a rate/credit cooldown, a hard failure has no server-reported "retry after"
+# — this is a guess, not a real signal, so it errs long: a config error
+# (wrong model name) needs an operator anyway, and a real outage is rare
+# enough that checking hourly costs nothing.
+_ENTRY_UNHEALTHY_RETRY_SECONDS = 3600
 
 
 def _record_llm_success(key):
     with _ENTRY_HEALTH_LOCK:
         _ENTRY_HEALTH[key] = {"consecutive_failures": 0, "last_error": None,
-                              "last_error_at": None, "last_ok_at": datetime.now().isoformat()}
+                              "last_error_at": None, "last_ok_at": datetime.now().isoformat(),
+                              "retry_after": 0.0}
 
 
 def _record_llm_failure(key, exc):
@@ -2097,7 +2106,33 @@ def _record_llm_failure(key, exc):
         entry["consecutive_failures"] = entry.get("consecutive_failures", 0) + 1
         entry["last_error"] = str(exc)[:300]
         entry["last_error_at"] = datetime.now().isoformat()
+        if entry["consecutive_failures"] >= _ENTRY_UNHEALTHY_THRESHOLD:
+            entry["retry_after"] = time.time() + _ENTRY_UNHEALTHY_RETRY_SECONDS
         _ENTRY_HEALTH[key] = entry
+
+
+def _entry_is_unhealthy(key):
+    """The single source of truth for "unhealthy" — shared by
+    get_llm_entry_health (the Settings badge) and _enumerate_candidates (the
+    picker). Sharing this, rather than each computing its own threshold
+    check, is what makes routing self-healing rather than just visible:
+    lm#452/#469/#444 kept re-selecting a permanently-broken Copilot entry
+    every retry, because nothing EXCLUDED it from selection — a human had to
+    notice the badge and disable it by hand. Now the same signal that lights
+    the badge also removes the candidate from the picker's pool, the same
+    way an existing rate/credit cooldown already does.
+
+    TIMED, not permanent: past _ENTRY_UNHEALTHY_THRESHOLD consecutive
+    failures, the entry stays excluded only until its retry_after elapses —
+    excluding it from the pool means it can never be called again to record
+    a success, so a purely one-shot exclusion would be permanent for the
+    life of the process. After retry_after, one real attempt is allowed
+    through; if it fails again, _record_llm_failure extends the cooldown."""
+    with _ENTRY_HEALTH_LOCK:
+        entry = _ENTRY_HEALTH.get(key)
+    if not entry or entry.get("consecutive_failures", 0) < _ENTRY_UNHEALTHY_THRESHOLD:
+        return False
+    return time.time() < entry.get("retry_after", 0.0)
 
 
 def get_llm_entry_health(provider, base_url, model):
@@ -2107,12 +2142,12 @@ def get_llm_entry_health(provider, base_url, model):
     An entry with no recorded calls yet reads as healthy, not unhealthy —
     silence isn't failure."""
     key = _model_key(provider, base_url, model)
+    unhealthy = _entry_is_unhealthy(key)
     with _ENTRY_HEALTH_LOCK:
         entry = _ENTRY_HEALTH.get(key)
     if not entry:
         return {"unhealthy": False, "consecutive_failures": 0, "last_error": None, "last_error_at": None}
-    return {"unhealthy": entry.get("consecutive_failures", 0) >= _ENTRY_UNHEALTHY_THRESHOLD,
-            "consecutive_failures": entry.get("consecutive_failures", 0),
+    return {"unhealthy": unhealthy, "consecutive_failures": entry.get("consecutive_failures", 0),
             "last_error": entry.get("last_error"), "last_error_at": entry.get("last_error_at")}
 
 
@@ -2353,6 +2388,15 @@ def _enumerate_candidates(config):
             available, unavailable_reason = False, "rate_limited"
         elif _routed_model_dead(provider, model):
             available, unavailable_reason = False, "dead_model"
+        elif _entry_is_unhealthy(key):
+            # A hard error every call (e.g. a model/endpoint pairing the
+            # provider's API rejects outright) has no timed recovery like a
+            # rate/credit cooldown does — it stays excluded from the picker's
+            # pool until a call succeeds again (an operator fixes the entry,
+            # or the provider starts serving that model). See
+            # _entry_is_unhealthy's docstring for why this must share state
+            # with the Settings badge rather than compute its own check.
+            available, unavailable_reason = False, "hard_failing"
         candidates.append({
             "key": key, "provider": provider, "model": model, "base_url": base_url,
             "api_key": api_key, "rpm": rpm, "caps": caps,

--- a/routes.py
+++ b/routes.py
@@ -2309,6 +2309,31 @@ async def settings_page(request: Request):
     feature_automerge_repos_set = set(feature_automerge_repos)
     extra_am_repos = [r for r in feature_automerge_repos if r not in set(github_repos)]
     feature_automerge_repo_options = list(github_repos) + extra_am_repos
+    # feature_automerge_target_branches: same checkbox pattern as the repo
+    # selector above. The old free-text box carried a comment claiming there
+    # was no cheap way to enumerate branches — but the promotion chain itself
+    # (PROMOTE_ROUTES) is that enumeration, locally, with no GitHub API call.
+    # Release branches are deliberately EXCLUDED from the options: pr_review
+    # refuses main/master/default_branch structurally, so offering them as a
+    # tickable box would advertise a choice that can never take effect.
+    _am_release = {"main", "master", (config.get("default_branch") or "main")}
+    _am_chain = []
+    for _pr_src, _pr_dst in PROMOTE_ROUTES:
+        for _pr_b in (_pr_src, _pr_dst):
+            if _pr_b not in _am_chain:
+                _am_chain.append(_pr_b)
+    _am_dev = config.get("dev_branch") or "dev"
+    if _am_dev not in _am_chain:
+        _am_chain.append(_am_dev)
+    feature_automerge_branch_options = [b for b in _am_chain if b not in _am_release]
+    feature_automerge_target_branches = parse_branch_names(
+        config.get("feature_automerge_target_branches"))
+    # Keep any already-configured branch visible even if it isn't in the chain,
+    # so opening Settings can never silently drop a value the operator set.
+    for _am_b in feature_automerge_target_branches:
+        if _am_b not in feature_automerge_branch_options and _am_b not in _am_release:
+            feature_automerge_branch_options.append(_am_b)
+    feature_automerge_target_branches_set = set(feature_automerge_target_branches)
 
     # SECURITY: llm_credentials/llm_entries carry plaintext api_key values.
     # They used to flow into the template raw via the **config merge below,
@@ -2416,6 +2441,8 @@ async def settings_page(request: Request):
         "feature_drive_repo_options": feature_drive_repo_options,
         "feature_drive_repos_set": feature_drive_repos_set,
         "feature_automerge_repo_options": feature_automerge_repo_options,
+        "feature_automerge_branch_options": feature_automerge_branch_options,
+        "feature_automerge_target_branches_set": feature_automerge_target_branches_set,
         "feature_automerge_repos_set": feature_automerge_repos_set,
         "log_module_options": log_module_options,
         "state": state,
@@ -2840,6 +2867,13 @@ async def save_settings(request: Request):
     # ── Auto-merge (the deliberate invariant exception — see pr_review.py) ──
     config_data["feature_automerge_enabled"] = data.get("feature_automerge_enabled") == "on"
     config_data["feature_automerge_require_clean"] = data.get("feature_automerge_require_clean") == "on"
+    # The DEFAULT-DENY additive allowlist. Previously had no save handler at all,
+    # so it was pinned on and the only way to change it was hand-editing
+    # /etc/ab/config.json. Turning it OFF widens auto-merge from "docs/log/
+    # tooltip-only diffs" to ANY diff that clears the other gates, so it is the
+    # single most consequential switch in this block. main stays owner-only
+    # regardless — pr_review refuses release branches structurally.
+    config_data["feature_automerge_require_allowlist"] = data.get("feature_automerge_require_allowlist") == "on"
     _amc = str(data.get("feature_automerge_min_confidence") or "").strip()
     try:
         config_data["feature_automerge_min_confidence"] = max(0.0, min(1.0, float(_amc))) if _amc else 1.0
@@ -2860,13 +2894,25 @@ async def save_settings(request: Request):
         if _r2 and _r2 not in _am_repos:
             _am_repos.append(_r2)
     config_data["feature_automerge_repos"] = list(dict.fromkeys(_am_repos))
-    # Target-branch allowlist — free-text comma/newline separated, same
-    # parsing style as _am_extra above. No checkbox list here (unlike repos,
-    # there's no cheap "known branches" enumeration without an extra GitHub
-    # API call per repo) — this is deliberately just a short opt-in list like
-    # ["dev"], not meant to hold many entries.
-    _am_branches_raw = data.get("feature_automerge_target_branches", "") or ""
-    _am_branches = [b.strip() for b in _am_branches_raw.replace("\n", ",").split(",") if b.strip()]
+    # Target-branch allowlist — checkbox selector (options come from the
+    # promotion chain; see the GET above) plus a free-text field for anything
+    # outside it, mirroring the repo selector directly above. Release branches
+    # are stripped here as well as being excluded from the options and refused
+    # in pr_review: the form is not the only caller of this endpoint, so the
+    # invariant is re-asserted rather than assumed.
+    if hasattr(form_data, "getlist"):
+        _am_b_checked = form_data.getlist("feature_automerge_target_branches")
+    else:
+        _v3 = data.get("feature_automerge_target_branches")
+        _v3 = [_v3] if isinstance(_v3, str) else (_v3 or [])
+        _am_b_checked = list(_v3)
+    _am_branches_raw = data.get("feature_automerge_target_branches_extra", "") or ""
+    _am_branches = [b.strip() for b in _am_b_checked if b and str(b).strip()]
+    for _b3 in parse_branch_names(_am_branches_raw):
+        if _b3 not in _am_branches:
+            _am_branches.append(_b3)
+    _am_release_save = {"main", "master", (config_data.get("default_branch") or "main")}
+    _am_branches = [b for b in _am_branches if b not in _am_release_save]
     config_data["feature_automerge_target_branches"] = list(dict.fromkeys(_am_branches))
 
     # Auto-FIX log-detected / automated-fix issues (default OFF; Bug + Critical

--- a/templates/index.html
+++ b/templates/index.html
@@ -2226,10 +2226,27 @@
                                     </label>
                                 </div>
                             </div>
+                            <div class="flex items-start gap-3 mt-2 p-3 rounded-lg bg-amber-50 border border-amber-200">
+                                <input type="checkbox" name="feature_automerge_require_allowlist" id="feature_automerge_require_allowlist" {{ 'checked' if settings.get('feature_automerge_require_allowlist', True) else '' }} class="w-4 h-4 mt-0.5 text-[#01A982] focus:ring-[#01A982]">
+                                <label for="feature_automerge_require_allowlist" class="text-xs text-slate-700">
+                                    <span class="font-semibold">Only auto-merge provably-additive diffs</span> (docs-only / log-only / tooltip-only)
+                                    <span class="block text-amber-700 mt-1">On (default) is why a normal code change never auto-merges, however high its confidence — behaviour-changing diffs route to a human. <strong>Unticking this widens auto-merge to ANY diff</strong> that clears the other gates: both panels Approve above the confidence floor, no Tier-1 findings, no boundary touched, on an allowlisted branch in an allowlisted repo. main/master stay owner-only either way.</span>
+                                </label>
+                            </div>
                             <div class="space-y-2 mt-2">
                                 <label class="text-sm font-medium text-slate-600">Auto-Merge Target Branches <span class="text-red-500 font-normal">(opt-in — empty means NOTHING auto-merges, regardless of the toggle above)</span></label>
-                                <p class="text-xs text-red-600 font-medium">⚠️ This is what stands between "unattended merge" and "human required" now that PR authorship no longer matters. Add only lower-stakes branches that aren't wired to deploy/restart anything on push — e.g. <code>dev, qa</code>. Listing main/master (or the repo's default branch) has no effect: merges into the release branch are owner-only and are refused in code, at any confidence.</p>
-                                <input type="text" name="feature_automerge_target_branches" value="{{ settings.get('feature_automerge_target_branches', []) | join(', ') }}" placeholder="Branches allowed to receive auto-merges (comma-separated, e.g. dev, qa)" class="w-full p-2 text-xs rounded-lg border border-slate-300 outline-none focus:ring-1 focus:ring-[#01A982]">
+                                <p class="text-xs text-red-600 font-medium">⚠️ This is what stands between "unattended merge" and "human required" now that PR authorship no longer matters. Tick only lower-stakes branches that aren't wired to deploy/restart anything on push. main/master (and the repo's default branch) are not listed and cannot be added: merges into the release branch are owner-only and are refused in code, at any confidence.</p>
+                                {% if feature_automerge_branch_options %}
+                                <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 p-3 rounded-lg bg-slate-50 border border-slate-200">
+                                    {% for branch in feature_automerge_branch_options %}
+                                    <label class="flex items-center gap-2 text-xs cursor-pointer hover:text-[#01A982] truncate" title="{{ branch }}">
+                                        <input type="checkbox" name="feature_automerge_target_branches" value="{{ branch }}" {% if branch in feature_automerge_target_branches_set %}checked{% endif %} class="w-3 h-3 flex-shrink-0 text-[#01A982]">
+                                        <span class="truncate">{{ branch }}</span>
+                                    </label>
+                                    {% endfor %}
+                                </div>
+                                {% endif %}
+                                <input type="text" name="feature_automerge_target_branches_extra" placeholder="Additional branches (comma-separated)" class="w-full p-2 text-xs rounded-lg border border-slate-300 outline-none focus:ring-1 focus:ring-[#01A982]">
                             </div>
                             <div class="space-y-2 mt-2">
                                 <label class="text-sm font-medium text-slate-600">Auto-Merge Repositories <span class="text-red-500 font-normal">(opt-in — empty means NOTHING auto-merges, regardless of the toggle above)</span></label>

--- a/test_automerge_settings_controls.py
+++ b/test_automerge_settings_controls.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Self-test for the two Auto-Merge Settings controls that had no save path.
+
+Run:  python3 ab/test_automerge_settings_controls.py
+      (also collected by pytest via test_automerge_settings_controls below)
+
+Two separate gaps this pins:
+
+1. ``feature_automerge_require_allowlist`` had a ``config.setdefault`` on the
+   settings GET but NO handler on the POST and no control in the template. It
+   was therefore pinned on, and the only way to change it was hand-editing
+   /etc/ab/config.json on the box. It is the switch that decides whether
+   auto-merge is limited to docs/log/tooltip-only diffs or applies to any diff
+   clearing the other gates, so it needs to be operable from Settings.
+
+2. ``feature_automerge_target_branches`` was a free-text box whose comment
+   claimed branches couldn't be cheaply enumerated. PROMOTE_ROUTES is exactly
+   that enumeration, locally, with no GitHub API call — so it is now a checkbox
+   selector like the repo one, and these pin the multi-value form handling.
+
+The release-branch stripping below is belt-and-braces, NOT the primary defence:
+pr_review._automerge_decision refuses main/master/default_branch structurally
+(see test_feature_automerge_gate.py). This pins that the settings layer doesn't
+even persist such a value, so a tampered/stale POST can't leave a misleading
+"main" sitting in the config for a future reader to trust.
+
+routes.py cannot be imported (main.py app-init side effects), so this reuses
+test_feature_settings_roundtrip's ast-extraction harness rather than repeating
+it — one copy of that stub set, not two that drift.
+"""
+import sys
+
+from test_feature_settings_roundtrip import (
+    _load_ns, _FakeRequest, _base_pairs, _run, _check,
+)
+
+
+def _save(ns, pairs, base_config=None):
+    ns["_config_holder"]["config"] = dict(base_config or {})
+    _run(ns["save_settings"](_FakeRequest(pairs)))
+    return ns["_config_holder"]["config"]
+
+
+def main():
+    ok = True
+    ns = _load_ns()
+
+    # ── require_allowlist is now operable from the form ────────────────────
+    saved = _save(ns, _base_pairs(feature_automerge_require_allowlist="on"))
+    ok &= _check("require_allowlist ticked -> saved True",
+                 saved.get("feature_automerge_require_allowlist") is True)
+
+    # An unticked checkbox submits NOTHING, so absence must mean False — that
+    # is the whole point of making it operable. (Same convention as
+    # feature_automerge_require_clean directly above it in save_settings.)
+    saved = _save(ns, _base_pairs(),
+                  base_config={"feature_automerge_require_allowlist": True})
+    ok &= _check("require_allowlist absent from form -> saved False "
+                 "(unticking actually takes effect, not silently ignored)",
+                 saved.get("feature_automerge_require_allowlist") is False)
+
+    # ── target branches: checkbox selector, multi-value ────────────────────
+    saved = _save(ns, _base_pairs() + [
+        ("feature_automerge_target_branches", "dev"),
+        ("feature_automerge_target_branches", "qa"),
+    ])
+    ok &= _check("both branch checkboxes ticked -> BOTH saved (getlist, not "
+                 "last-value-wins, which would silently keep only 'qa')",
+                 saved.get("feature_automerge_target_branches") == ["dev", "qa"])
+
+    saved = _save(ns, _base_pairs() + [
+        ("feature_automerge_target_branches", "dev"),
+    ])
+    ok &= _check("one branch ticked -> only that one saved",
+                 saved.get("feature_automerge_target_branches") == ["dev"])
+
+    saved = _save(ns, _base_pairs(),
+                  base_config={"feature_automerge_target_branches": ["dev", "qa"]})
+    ok &= _check("no branch ticked -> saved empty (unticking every box "
+                 "disables auto-merge rather than preserving the old list)",
+                 saved.get("feature_automerge_target_branches") == [])
+
+    # ── the free-text escape hatch still works alongside the checkboxes ────
+    saved = _save(ns, _base_pairs(feature_automerge_target_branches_extra="staging, hotfix") + [
+        ("feature_automerge_target_branches", "dev"),
+    ])
+    ok &= _check("extra free-text branches are unioned with the ticked ones",
+                 saved.get("feature_automerge_target_branches") == ["dev", "staging", "hotfix"])
+
+    saved = _save(ns, _base_pairs(feature_automerge_target_branches_extra="dev") + [
+        ("feature_automerge_target_branches", "dev"),
+    ])
+    ok &= _check("a branch both ticked and typed is stored once, not duplicated",
+                 saved.get("feature_automerge_target_branches") == ["dev"])
+
+    # ── release branches never persist, however they arrive ───────────────
+    for _field, _label in (("feature_automerge_target_branches", "ticked/posted"),
+                           ("feature_automerge_target_branches_extra", "typed free-text")):
+        for _br in ("main", "master"):
+            pairs = _base_pairs() + [("feature_automerge_target_branches", "dev")]
+            pairs = [p for p in pairs if p[0] != _field] if _field.endswith("_extra") else pairs
+            pairs = pairs + [(_field, _br)]
+            saved = _save(ns, pairs)
+            ok &= _check(f"{_br} arriving as {_label} is stripped, dev survives",
+                         saved.get("feature_automerge_target_branches") == ["dev"])
+
+    # The refusal follows default_branch, not the literal string "main".
+    saved = _save(ns, _base_pairs(feature_automerge_target_branches_extra="release") + [
+        ("feature_automerge_target_branches", "dev"),
+    ], base_config={"default_branch": "release"})
+    ok &= _check("a non-'main' default_branch is stripped too (follows config, "
+                 "not a hardcoded name)",
+                 saved.get("feature_automerge_target_branches") == ["dev"])
+
+    print()
+    print("ALL CASES PASSED" if ok else "SOME CASES FAILED")
+    return 0 if ok else 1
+
+
+def test_automerge_settings_controls():
+    """pytest entry point.
+
+    Without this the file is invisible to CI: ci.yml runs `pytest -q .`, which
+    imports the module and collects nothing from a bare main(). An assertion
+    that never executes is not a guard.
+    """
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_llm_client_entry_health.py
+++ b/test_llm_client_entry_health.py
@@ -17,20 +17,23 @@ wired into _call_provider_timed (every LLM call in the app routes through
 it) so a hard-failing entry becomes visible without reading ab.log."""
 import ast
 import threading
+import time
 from datetime import datetime
 
 
 def _load_ns():
     src = open("llm_client.py").read()
     tree = ast.parse(src)
-    names = {"_model_key", "_record_llm_success", "_record_llm_failure", "get_llm_entry_health"}
-    ns = {"threading": threading, "datetime": datetime}
+    names = {"_model_key", "_record_llm_success", "_record_llm_failure",
+              "get_llm_entry_health", "_entry_is_unhealthy"}
+    ns = {"threading": threading, "datetime": datetime, "time": time}
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name in names:
             exec(ast.get_source_segment(src, node), ns)
         elif isinstance(node, ast.Assign) and any(
             isinstance(t, ast.Name) and t.id in ("_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH",
-                                                  "_ENTRY_UNHEALTHY_THRESHOLD")
+                                                  "_ENTRY_UNHEALTHY_THRESHOLD",
+                                                  "_ENTRY_UNHEALTHY_RETRY_SECONDS")
             for t in node.targets
         ):
             exec(ast.get_source_segment(src, node), ns)
@@ -87,6 +90,22 @@ def main():
     other = get_health("ollama_cloud", "", "nemotron-3-ultra")
     ok &= _check("a distinct (provider, base_url, model) key is tracked independently",
                 not other["unhealthy"] and other["consecutive_failures"] == 0)
+
+    # ── timed recovery: unhealthy is not permanent (see _entry_is_unhealthy's
+    # docstring — a one-shot exclusion would be permanent, since an excluded
+    # entry can never be called again to record the success that clears it) ─
+    is_unhealthy = ns["_entry_is_unhealthy"]
+    retry_key = ("copilot", "", "gpt-5.5")
+    record_failure(retry_key, Exception("boom"))
+    record_failure(retry_key, Exception("boom again"))
+    ok &= _check("2 consecutive failures -> unhealthy", is_unhealthy(retry_key))
+    with ns["_ENTRY_HEALTH_LOCK"]:
+        ns["_ENTRY_HEALTH"][retry_key]["retry_after"] = time.time() + 3600
+    ok &= _check("still within the retry window -> stays unhealthy", is_unhealthy(retry_key))
+    with ns["_ENTRY_HEALTH_LOCK"]:
+        ns["_ENTRY_HEALTH"][retry_key]["retry_after"] = time.time() - 1
+    ok &= _check("retry_after elapsed -> no longer reported unhealthy (one fresh attempt allowed)",
+                not is_unhealthy(retry_key))
 
     print()
     if ok:

--- a/test_llm_client_requirements_path.py
+++ b/test_llm_client_requirements_path.py
@@ -31,6 +31,10 @@ def _load_ns():
         "_model_key", "get_llm_perf_snapshot", "_get_llm_perf_store",
         "_provider_configured", "_provider_is_nokey", "_is_ollama", "_is_ollama_cloud", "_is_lmstudio",
         "_routed_model_dead", "_get_category_semaphore",
+        # per-entry health (lm#452/#469/#444: a hard-failing entry must be
+        # EXCLUDED from the picker's pool, not just visible in Settings —
+        # see _entry_is_unhealthy's docstring in llm_client.py)
+        "_record_llm_failure", "_record_llm_success", "_entry_is_unhealthy",
     }
     want_assign = {
         "_ALL_SLOTS", "_CODE_SLOTS", "_LOG_SLOTS", "_REVIEW_SLOTS", "_TOOL_400_MARKERS",
@@ -41,6 +45,8 @@ def _load_ns():
         "_CREDIT_COOLDOWN_SECONDS", "_RATELIMIT_COOLDOWN_SECONDS",
         "_ROUTED_404", "_ROUTED_404_LOCK",
         "OLLAMA_CLOUD_PROVIDER", "OLLAMA_CLOUD_BASE_URL",
+        "_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH", "_ENTRY_UNHEALTHY_THRESHOLD",
+        "_ENTRY_UNHEALTHY_RETRY_SECONDS",
     }
     segs = []
     for node in tree.body:
@@ -159,6 +165,55 @@ def main():
     ns["_cb_trip"](ns["_ENDPOINT_CREDIT_CB"], ns["_endpoint_key"]("ollama", ""), "bogus", 3600, "credit", "ollama")
     ok &= _check("a credit trip against a no-key local provider is ignored, not recorded",
                 ns["_endpoint_key"]("ollama", "") not in ns["_ENDPOINT_CREDIT_CB"])
+
+    # --- a hard-failing entry (lm#452/#469/#444's actual regression) is -------
+    # --- EXCLUDED from the picker's pool, not just flagged in Settings -------
+
+    hard_cfg = {"llm_entries": [_entry("e1", "copilot", "grok-4.6", base_url="")]}
+    hard_key = ns["_model_key"]("copilot", "", "grok-4.6")
+    hard_candidates_before = ns["_enumerate_candidates"](hard_cfg)
+    ok &= _check("before any failure, the entry is a normal available candidate",
+                len(hard_candidates_before) == 1 and hard_candidates_before[0]["available"] is True)
+
+    ns["_record_llm_failure"](hard_key, Exception('400 unsupported_api_for_model'))
+    ok &= _check("one failure alone does not exclude the candidate (avoids a one-off blip)",
+                ns["_enumerate_candidates"](hard_cfg)[0]["available"] is True)
+
+    ns["_record_llm_failure"](hard_key, Exception('400 unsupported_api_for_model (again)'))
+    hard_candidates_after = ns["_enumerate_candidates"](hard_cfg)
+    ok &= _check("after 2 consecutive failures, the SAME entry that keeps 400ing is excluded "
+                "from the pool — the actual fix for lm#452/#469/#444 (a broken reviewer no "
+                "longer burns both panel slots every retry)",
+                len(hard_candidates_after) == 1 and hard_candidates_after[0]["available"] is False
+                and hard_candidates_after[0]["unavailable_reason"] == "hard_failing")
+
+    ns["_record_llm_success"](hard_key)
+    ok &= _check("a success (e.g. after an operator fixes the model name) clears the exclusion "
+                "immediately — no need to wait out the hourly retry window",
+                ns["_enumerate_candidates"](hard_cfg)[0]["available"] is True)
+
+    # Timed recovery: re-trip it, then simulate the retry window elapsing —
+    # this is what lets the picker try it again on its own even if nobody
+    # fixes it (see _entry_is_unhealthy's docstring: a one-shot exclusion
+    # would be permanent, since an excluded entry can never be called again
+    # to record the success that would clear it).
+    ns["_record_llm_failure"](hard_key, Exception("boom"))
+    ns["_record_llm_failure"](hard_key, Exception("boom again"))
+    ok &= _check("re-tripped: excluded again", ns["_enumerate_candidates"](hard_cfg)[0]["available"] is False)
+    with ns["_ENTRY_HEALTH_LOCK"]:
+        ns["_ENTRY_HEALTH"][hard_key]["retry_after"] = ns["time"].time() - 1  # already elapsed
+    ok &= _check("once retry_after has elapsed, the picker allows one fresh attempt again",
+                ns["_enumerate_candidates"](hard_cfg)[0]["available"] is True)
+
+    # A distinct model at the same provider is unaffected by the broken one
+    # (a fresh key — not grok-4.6, which already carries state from above).
+    unrelated_cfg = {"llm_entries": [_entry("e1", "copilot", "gpt-5.5"),
+                                     _entry("e2", "copilot", "gpt-4o-2024-08-06")]}
+    ns["_record_llm_failure"](ns["_model_key"]("copilot", "", "gpt-5.5"), Exception("x"))
+    ns["_record_llm_failure"](ns["_model_key"]("copilot", "", "gpt-5.5"), Exception("x"))
+    unrelated_candidates = {c["model"]: c["available"] for c in ns["_enumerate_candidates"](unrelated_cfg)}
+    ok &= _check("a broken model does not drag down an unrelated model on the same provider",
+                unrelated_candidates == {"gpt-5.5": False, "gpt-4o-2024-08-06": True})
 
     # --- _configured_entries feeds safety_floor ---------------------------------
 


### PR DESCRIPTION
Two Settings gaps that forced hand-editing `/etc/ab/config.json`:

**Target branches** was free text. `PROMOTE_ROUTES` already enumerates the chain locally (no GitHub API call), so it's now a checkbox selector like the repo picker, plus a free-text field for anything off-chain. Release branches are **excluded from the options** rather than offered-and-ignored, and re-stripped on save.

**`feature_automerge_require_allowlist`** had a `setdefault` on the GET but no save handler and no control — it was pinned on. It's the switch that explains why a normal code change never auto-merges however high its confidence.

Verified by rendering the block (dev ticked, qa offered, main absent). Three mutations each caught. 297 tests pass.