### PR TITLE
Run the script-style self-tests in CI, and fix the one they were hiding

### DIFF
--- a/test_feature_build.py
+++ b/test_feature_build.py
@@ -29,6 +29,7 @@ import sys
 
 from github import GithubException
 
+import branch_policy as real_branch_policy
 import feature_boundary as real_feature_boundary
 
 
@@ -132,6 +133,18 @@ def _load_ns():
         "_authenticated_remote": _authenticated_remote,
         "skills_loader": _FakeSkillsLoader(),
         "feature_boundary": real_feature_boundary,  # pure/standalone — used for real
+        # branch_policy's helpers are pure functions of their arguments, so the
+        # real ones are used rather than stubs — same rationale as
+        # feature_boundary above. Their ABSENCE was silently defeating this
+        # file: build_feature calls auto_branch_name() before the build agent
+        # runs, so every case that got that far died with
+        # NameError: name 'auto_branch_name' is not defined, which
+        # build_feature's broad `except Exception` recorded as a generic
+        # "Unexpected error" -> feature_failed. The docs-gate cases below then
+        # asserted against a run that never reached the docs gate at all.
+        "auto_branch_name": real_branch_policy.auto_branch_name,
+        "integration_branch": real_branch_policy.integration_branch,
+        "may_force_push": real_branch_policy.may_force_push,
         "call_llm": call_llm,
         "GithubException": GithubException,
         "git": real_git,  # patched per-test-case via _patch_clone(); real module otherwise

--- a/test_script_selftests.py
+++ b/test_script_selftests.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Makes the repo's script-style self-tests actually run in CI.
+
+Most test files here are standalone scripts: they do their work in ``main()``,
+print ``[PASS]``/``[FAIL]`` lines, and ``sys.exit(main())``. That form is
+invisible to pytest -- it imports the module, finds no ``test_*`` function, and
+collects nothing. ci.yml runs ``pytest -q .``, so at the time this file was
+added **51 of the 52** such files never executed a single assertion in CI. They
+only ran if someone remembered to invoke them by hand.
+
+That is the worst failure mode for a test: present, detailed, reviewed, and
+silently inert. It had already let a real defect sit -- test_feature_build.py
+was dying on a missing ``auto_branch_name`` stub, so every assertion past its
+first few cases was asserting against a run that had already aborted.
+
+This module discovers those files and runs each one in a subprocess, asserting
+a zero exit status. A subprocess (rather than importing and calling ``main()``)
+is deliberate: these scripts ast-extract functions from the app modules, mutate
+module globals, monkeypatch ``git.Repo.clone_from``, and chdir -- running them
+in-process would let one leak state into the next and into the real pytest
+tests. Each gets a clean interpreter, exactly as when run by hand.
+
+Discovery is dynamic on purpose: a new self-test file is picked up with no edit
+here, so the next one cannot be born invisible.
+"""
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+_HERE = pathlib.Path(__file__).resolve().parent
+
+
+def _is_script_selftest(path):
+    """A file that defines main() but exposes no pytest-collectable test."""
+    try:
+        src = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return "\ndef main()" in src and "\ndef test_" not in src
+
+
+def _discover():
+    return sorted(p.name for p in _HERE.glob("test_*.py") if _is_script_selftest(p))
+
+
+SCRIPT_SELFTESTS = _discover()
+
+
+def test_script_selftests_are_discovered():
+    """Guards the discovery itself.
+
+    If a refactor broke the predicate this module would silently pass with an
+    empty parameter list -- the same invisibility it exists to fix.
+    """
+    assert SCRIPT_SELFTESTS, (
+        "no script-style self-tests discovered — the predicate in "
+        "_is_script_selftest is probably wrong; this module would otherwise "
+        "pass while testing nothing"
+    )
+
+
+@pytest.mark.parametrize("script", SCRIPT_SELFTESTS)
+def test_script_selftest(script):
+    proc = subprocess.run(
+        [sys.executable, script],
+        cwd=str(_HERE),
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+    if proc.returncode != 0:
+        failures = [l for l in proc.stdout.splitlines() if "[FAIL]" in l]
+        detail = "\n".join(failures) if failures else proc.stdout[-3000:]
+        pytest.fail(
+            f"{script} exited {proc.returncode}\n"
+            f"--- failing cases ---\n{detail}\n"
+            f"--- stderr (tail) ---\n{proc.stderr[-2000:]}"
+        )


### PR DESCRIPTION
`ci.yml` runs `pytest -q .`, which collects nothing from a bare `main()`. Most test files here are standalone scripts, so **51 of 52 never executed a single assertion in CI** — they only ran if invoked by hand.

That had already let a real defect sit: `test_feature_build.py` was aborting on a missing `auto_branch_name` stub. `build_feature` calls it *before* the build agent runs, so the `NameError` was swallowed by its broad `except Exception` and recorded as a generic "Unexpected error" → `feature_failed`. Every assertion past the first few cases was checking a run that had already died — including the entire docs-gate section, which never once reached the docs gate. Supplying the real `branch_policy` helpers fixes it; **20+ previously-unreachable cases now run and pass**.

`test_script_selftests.py` discovers these files and runs each in a subprocess (not in-process — they ast-extract app functions, mutate globals and monkeypatch `git.Repo.clone_from`, so they'd leak state into each other and into the real tests). Discovery is dynamic so a new self-test can't be born invisible, and a guard test fails if discovery ever returns nothing.

**Verified:** a deliberately failing probe self-test is caught and its `[FAIL]` line surfaced. **350 tests pass (was 297)**, full suite 13s.