### PR TITLE
Remove the "Automated Issue Triage" label from the footer

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2699,8 +2699,6 @@
         <div class="flex justify-between w-full items-center">
             <div class="flex items-center gap-4 opacity-70">
                 <span>© 2026 AppBuilder</span>
-                <span class="text-slate-400">|</span>
-                <span class="font-bold">Automated Issue Triage</span>
             </div>
             <div class="flex items-center gap-2">
                 <form action="/update_now" method="post" onsubmit="handleFormSubmit(event, '/update_now')" class="inline">


### PR DESCRIPTION
Removes the label and the `|` separator that preceded it, which would otherwise dangle after a bare "© 2026 AppBuilder".

No other references to the string exist in templates, JS or Python. Template still parses; 297 tests pass.