### PR TITLE
PR pre-review: show the target branch, and make the review readable

### DIFF
--- a/app_state.py
+++ b/app_state.py
@@ -68,7 +68,8 @@ def update_task_state(task_id, task_name="Unknown Task", action="start", kind="s
 _PR_REVIEWS_MAX = 100
 
 
-def record_pr_review(repo, number, title, url, findings, head_sha, summary="", review=None, review2=None):
+def record_pr_review(repo, number, title, url, findings, head_sha, summary="", review=None, review2=None,
+                     base_ref="", head_ref=""):
     """Persist a PR pre-review result so the UI can list/filter 'PRs Reviewed'.
     Bounded to the most recent _PR_REVIEWS_MAX. findings = list of {level,...} dicts.
 
@@ -140,6 +141,15 @@ def record_pr_review(repo, number, title, url, findings, head_sha, summary="", r
                 "title": (title or "")[:120],
                 "url": url,
                 "head": head_sha,
+                # Which branch this PR would land on (and from where). In a
+                # dev -> qa -> main chain the target is the most important fact
+                # about a PR, and the list previously showed only "repo #N" —
+                # indistinguishable between a routine dev PR and one aimed at
+                # main. Falls back to "" for records written before this field
+                # existed, which the template treats as "unknown" rather than
+                # rendering an empty badge.
+                "base_ref": str(base_ref or "")[:120] or prev.get("base_ref", ""),
+                "head_ref": str(head_ref or "")[:120] or prev.get("head_ref", ""),
                 "summary": (summary or "")[:600],
                 "findings": len(findings or []),
                 "errors": levels["error"],

--- a/fix_engine.py
+++ b/fix_engine.py
@@ -1249,6 +1249,21 @@ def review_fix(repo_path, issue_body, proposed_fixes, force_cloud=None, task_id=
     critiques = " | ".join(
         f"[{v.get('reviewer', '?')}] {v.get('critique', '')}" for v in votes
     )
+    # Structured counterpart to `critiques`. That string flattens every
+    # reviewer's prose into one " | "-joined blob and DROPS each reviewer's own
+    # verdict and confidence, so anything rendering it (the GitHub PR comment,
+    # the WebUI row) could only show a wall of text and could not say which
+    # reviewer objected or how strongly. Callers that want to present the panel
+    # readably use this; `critique` is kept unchanged for every existing caller.
+    reviews = [
+        {
+            "reviewer": v.get("reviewer", "?"),
+            "verdict": v.get("verdict"),
+            "confidence": v.get("confidence"),
+            "critique": v.get("critique", ""),
+        }
+        for v in votes
+    ]
 
     # If some reviewers were skipped, decide whether to proceed or queue.
     if failed_reviewers:
@@ -1269,6 +1284,7 @@ def review_fix(repo_path, issue_body, proposed_fixes, force_cloud=None, task_id=
                 "partial_confidence": avg_conf,
                 "partial_votes": votes,
                 "critique": critiques,
+                "reviews": reviews,
             }
 
     # If avg confidence >= 90%, approve regardless of vote split — high-confidence
@@ -1279,7 +1295,8 @@ def review_fix(repo_path, issue_body, proposed_fixes, force_cloud=None, task_id=
         final_verdict = "Approve"
     else:
         final_verdict = "Reject"
-    return {"confidence": avg_conf, "verdict": final_verdict, "critique": critiques}
+    return {"confidence": avg_conf, "verdict": final_verdict, "critique": critiques,
+            "reviews": reviews}
 
 #: Failure kind -> operator-facing label. The pipeline knows precisely why it
 #: gave up; before this the UI showed a generic sentence and the reason lived

--- a/pr_review.py
+++ b/pr_review.py
@@ -591,91 +591,209 @@ def _state_logic_review(pr, files, config, repo=None, head_sha=None):
     return review if isinstance(review, dict) else None
 
 
-def _render_state_panel(review):
-    """Render the state-logic panel section (empty list when no review) —
-    same rendering shape as _render_panel, distinct header/framing so the two
-    advisory panels are never confused for one combined verdict."""
-    if not review:
-        return []
-    if review.get("status"):
-        return [_STATE_PANEL_HEADER, "",
-                "_Panel unavailable this pass (%s)._" % (review.get("reason") or review.get("status")),
-                ""]
-    verdict = str(review.get("verdict") or "—")
-    crit = review.get("critique", "").strip()
+#: Matches the "[reviewer-name] " tag fix_engine prefixes onto each critique
+#: when it joins them into the legacy single-string `critique` blob.
+_REVIEWER_TAG_RE = re.compile(r"^\[([^\]]{1,60})\]\s*")
+
+#: Splits that blob back apart. The lookahead for "[" matters: a critique's own
+#: prose can contain " | " (table rows, shell pipes, code snippets), and
+#: splitting on the bare separator would slice a single reviewer's text into
+#: fragments attributed to nobody.
+_REVIEWER_SPLIT_RE = re.compile(r"\s+\|\s+(?=\[[^\]]{1,60}\]\s)")
+
+#: An enumerated point inside a critique: "1.", "2)", "(3)", "-", "*", "•".
+#: Reviewers overwhelmingly write their findings as such a list, which the
+#: whitespace-collapsed blob renders as one unbroken paragraph.
+_ENUM_MARK_RE = re.compile(r"(?:(?<=^)|(?<=\s))(?:\(?\d{1,2}[\).:]|[-*\u2022])\s+")
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z(\"'`])")
+
+
+def _norm_conf_pct(value):
+    """Confidence as a "58%" string, or None when it isn't a usable number."""
     try:
         from fix_engine import _norm_confidence
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001 — never let comment rendering fail on this
         def _norm_confidence(v):
             c = float(v)
             return max(0.0, min(1.0, c / 100.0 if c > 1.0 else c))
     try:
-        conf_str = "%.0f%%" % (_norm_confidence(review.get("confidence")) * 100)
+        return "%.0f%%" % (_norm_confidence(value) * 100)
     except (TypeError, ValueError):
-        conf_str = "n/a"
-    vicon = "\U0001F7E2" if verdict == "Approve" else "\U0001F534"
+        return None
+
+
+def _reviewer_blocks(review):
+    """[(name, verdict|None, confidence|None, critique)] for one panel result.
+
+    Prefers the structured ``reviews`` list fix_engine now returns. Falls back
+    to parsing the legacy " | "-joined ``critique`` string so PRs reviewed
+    before that change — and any other producer of this shape — still render
+    per-reviewer rather than as one blob.
+    """
+    structured = review.get("reviews")
+    if isinstance(structured, list) and structured:
+        out = []
+        for r in structured:
+            if isinstance(r, dict):
+                out.append((str(r.get("reviewer") or "?"), r.get("verdict"),
+                            r.get("confidence"), str(r.get("critique") or "").strip()))
+        if out:
+            return out
+
+    text = str(review.get("critique") or "").strip()
+    if not text:
+        return []
+    blocks = []
+    for part in _REVIEWER_SPLIT_RE.split(text):
+        part = part.strip()
+        if not part:
+            continue
+        m = _REVIEWER_TAG_RE.match(part)
+        if m:
+            blocks.append((m.group(1), None, None, part[m.end():].strip()))
+        else:
+            # Untagged (a single-reviewer panel, or a caller that never tagged).
+            blocks.append((None, None, None, part))
+    return blocks
+
+
+def _structure_critique(text):
+    """(preamble, [points]) — turn one reviewer's prose into readable parts.
+
+    Reviewers write findings as enumerated lists that arrive whitespace-
+    collapsed into a single paragraph. Where that enumeration is present it is
+    the reviewer's OWN topic split, so it is used rather than invented. Where
+    it isn't, sentences are grouped into short paragraphs instead of guessing
+    at topics — a wrong split reads worse than no split.
+    """
+    text = " ".join((text or "").split())
+    if not text:
+        return "", []
+
+    marks = [m for m in _ENUM_MARK_RE.finditer(text)]
+    if len(marks) >= 2:
+        preamble = text[:marks[0].start()].strip(" :;,-")
+        points = []
+        for i, m in enumerate(marks):
+            end = marks[i + 1].start() if i + 1 < len(marks) else len(text)
+            point = text[m.end():end].strip(" ;,")
+            if point:
+                points.append(point)
+        return preamble, points
+
+    sentences = [s.strip() for s in _SENTENCE_SPLIT_RE.split(text) if s.strip()]
+    if len(sentences) <= 2:
+        return text, []
+    # Two sentences per paragraph: enough to break the wall without severing
+    # a point from the sentence that qualifies it.
+    paras = [" ".join(sentences[i:i + 2]) for i in range(0, len(sentences), 2)]
+    return "", paras
+
+
+def _render_review_body(review, header, blurb):
+    """Shared renderer for both advisory panels.
+
+    Leads with the recommendation and the concerns behind it, then the
+    per-reviewer detail. Highlighting is driven by each reviewer's actual
+    verdict, never by keyword-sniffing their prose, so it cannot invent a
+    concern that no reviewer raised or miss one phrased unusually.
+    """
+    if not review:
+        return []
+    if review.get("status"):
+        return [header, "",
+                "_Panel unavailable this pass (%s)._" % (review.get("reason") or review.get("status")),
+                ""]
+
+    verdict = str(review.get("verdict") or "—")
+    approved = verdict == "Approve"
+    conf_str = _norm_conf_pct(review.get("confidence")) or "n/a"
+    blocks = _reviewer_blocks(review)
+    dissenting = [b for b in blocks if b[1] and b[1] != "Approve"]
+    known_verdicts = [b for b in blocks if b[1]]
+
     out = [
-        _STATE_PANEL_HEADER, "",
-        "_Narrow-scope panel: state/status coverage + control-flow reachability "
-        "ONLY (see pr_review.py `_state_logic_review` for what it does/doesn't "
-        "check). Advisory — a human still approves/denies._",
-        "",
-        "%s **Advisory verdict: %s** · confidence **%s**" % (vicon, verdict, conf_str),
+        header, "",
+        blurb, "",
+        "%s **Recommendation: %s** · panel confidence **%s**" % (
+            "\U0001F7E2" if approved else "\U0001F534",     # 🟢 / 🔴
+            "APPROVE" if approved else "DENY",
+            conf_str),
         "",
     ]
-    if crit:
-        out += [crit, ""]
+
+    # ── concerns, up front ────────────────────────────────────────────────
+    if dissenting:
+        out += ["#### \u26A0\uFE0F Concerns (%d of %d reviewers did not approve)" % (
+            len(dissenting), len(known_verdicts)), ""]
+        for name, v_verdict, v_conf, crit in dissenting:
+            gist = _structure_critique(crit)
+            headline = (gist[1][0] if gist[1] else gist[0]) or "(no critique text returned)"
+            if len(headline) > 240:
+                headline = headline[:237].rstrip() + "…"
+            pct = _norm_conf_pct(v_conf)
+            out.append("- \U0001F534 **%s**%s — %s" % (
+                name or "reviewer", " (%s)" % pct if pct else "", headline))
+        out.append("")
+    elif known_verdicts:
+        out += ["#### \u2705 No objections", "",
+                "All %d reviewer(s) approved. Detail below." % len(known_verdicts), ""]
+    elif not approved:
+        # Legacy panel results (and any producer that doesn't report per-
+        # reviewer verdicts) still recommend DENY, so say what the concern is
+        # rather than silently showing none — but don't attribute it to a
+        # particular reviewer, which this shape genuinely cannot support.
+        out += ["#### \u26A0\uFE0F Concerns", "",
+                "The panel did not approve. Per-reviewer verdicts weren't recorded "
+                "for this review, so the objections are in the detail below.", ""]
+
+    # ── per-reviewer detail ───────────────────────────────────────────────
+    if blocks:
+        out += ["#### Reviewer detail", ""]
+        for name, v_verdict, v_conf, crit in blocks:
+            bits = []
+            if v_verdict:
+                bits.append("%s %s" % (
+                    "\U0001F7E2" if v_verdict == "Approve" else "\U0001F534", v_verdict))
+            pct = _norm_conf_pct(v_conf)
+            if pct:
+                bits.append("confidence %s" % pct)
+            suffix = " — %s" % " · ".join(bits) if bits else ""
+            out += ["**%s**%s" % (name or "Reviewer", suffix), ""]
+            preamble, points = _structure_critique(crit)
+            if preamble:
+                out += [preamble, ""]
+            for p in points:
+                out.append("- %s" % p)
+            if points:
+                out.append("")
+            if not preamble and not points:
+                out += ["_No critique text returned._", ""]
     return out
+
+
+def _render_state_panel(review):
+    """Render the state-logic panel section (empty list when no review) — same
+    shape as _render_panel, distinct header/framing so the two advisory panels
+    are never confused for one combined verdict."""
+    return _render_review_body(
+        review, _STATE_PANEL_HEADER,
+        "_Narrow-scope panel: state/status coverage + control-flow reachability "
+        "ONLY (see pr_review.py `_state_logic_review` for what it does/doesn't "
+        "check). Advisory — a human still approves/denies._")
 
 
 def _render_panel(review):
     """Render the advisory skeptical-panel section (empty list when no review)."""
-    if not review:
-        return []
-    if review.get("status"):
-        return [_PANEL_HEADER, "",
-                "_Panel unavailable this pass (%s)._" % (review.get("reason") or review.get("status")),
-                ""]
-    verdict = str(review.get("verdict") or "—")
-    crit = review.get("critique", "").strip()
-    # Normalize defensively: review_fix already clamps to 0.0-1.0, but this value
-    # crosses a module boundary and rendering "confidence 9500%" on a public PR
-    # comment is the most visible way the scale bug can surface. Imported lazily —
-    # fix_engine imports late (see the review_fix call below), so a module-level
-    # import here would cycle.
-    try:
-        from fix_engine import _norm_confidence
-    except Exception:  # noqa: BLE001 — never let the comment render fail on this
-        def _norm_confidence(v):
-            c = float(v)
-            return max(0.0, min(1.0, c / 100.0 if c > 1.0 else c))
-    try:
-        conf_str = "%.0f%%" % (_norm_confidence(review.get("confidence")) * 100)
-    except (TypeError, ValueError):
-        conf_str = "n/a"
-    vicon = "\U0001F7E2" if verdict == "Approve" else "\U0001F534"  # 🟢 / 🔴
-    out = [
-        _PANEL_HEADER, "",
+    return _render_review_body(
+        review, _PANEL_HEADER,
         "_Cross-provider skeptical panel (same engine as the bot-fix reviewer) — "
-        "an **advisory** confidence signal. A human still approves/denies; this bot never does._",
-        "",
-        "%s **Advisory verdict: %s** · confidence **%s**" % (vicon, verdict, conf_str),
-        "",
-    ]
-    if crit:
-        out += [crit, ""]
-    return out
+        "an **advisory** confidence signal. A human still approves/denies; this "
+        "bot never does._")
 
 
 def _render(findings, head_sha, summary="", review=None, state_review=None):
-    lines = [
-        PR_REVIEW_MARKER,
-        "<!-- head: %s -->" % head_sha,
-        "## \U0001F916 AppBuilder PR pre-review",
-        "",
-        "_Automated pre-review — **informational only**. A human is the sole approver; this bot never approves, denies, or edits the branch._",
-        "",
-    ]
     lines = [
         PR_REVIEW_MARKER,
         "<!-- head: %s -->" % head_sha,

--- a/pr_review.py
+++ b/pr_review.py
@@ -793,12 +793,39 @@ def _render_panel(review):
         "bot never does._")
 
 
-def _render(findings, head_sha, summary="", review=None, state_review=None):
+def _render_route(base_ref, head_ref, default_branch=""):
+    """The "where is this PR going" line.
+
+    GitHub shows base<-head at the top of the PR page, but this comment is also
+    read in email notifications and the WebUI, where that context is absent —
+    and in a dev -> qa -> main chain, which branch a PR targets is the single
+    most important thing about it. Protected targets are called out explicitly
+    so a PR aimed at main is never mistaken for a routine one.
+    """
+    base = str(base_ref or "").strip()
+    if not base:
+        return []
+    head = str(head_ref or "").strip()
+    protected = base.lower() in ("main", "master") or (
+        default_branch and base == default_branch)
+    line = "\U0001F500 **Merging into `%s`**" % base          # 🔀
+    if head:
+        line += " \u2190 `%s`" % head                          # ←
+    if protected:
+        line += "  \u2014 \u26A0\uFE0F **protected branch**"    # — ⚠️
+    return [line, ""]
+
+
+def _render(findings, head_sha, summary="", review=None, state_review=None,
+            base_ref="", head_ref="", default_branch=""):
     lines = [
         PR_REVIEW_MARKER,
         "<!-- head: %s -->" % head_sha,
         "## \U0001F916 AppBuilder PR pre-review",
         "",
+    ]
+    lines += _render_route(base_ref, head_ref, default_branch)
+    lines += [
         "_Automated pre-review — **informational only**. A human is the sole approver; "
         "this bot never approves, denies, or edits the branch._",
         "",
@@ -1230,7 +1257,10 @@ def _review_one(gh, repo, pr, config, force=False):
         summary = _summarize_changes(pr, files, config, repo=repo)
         review = _skeptical_review(pr, files, config, repo=repo, head_sha=head_sha, gh=gh)
         state_review = _state_logic_review(pr, files, config, repo=repo, head_sha=head_sha)
-        body = _render(findings, head_sha, summary, review=review, state_review=state_review)
+        body = _render(findings, head_sha, summary, review=review, state_review=state_review,
+                       base_ref=getattr(getattr(pr, "base", None), "ref", "") or "",
+                       head_ref=_head_ref,
+                       default_branch=getattr(repo, "default_branch", "") or "")
         if existing:
             existing.edit(body)
             action = "updated"
@@ -1255,7 +1285,9 @@ def _review_one(gh, repo, pr, config, force=False):
     # this fixes the pre-existing gap where that panel's verdict was invisible
     # in AppBuilder's own UI for every PR, not just feature-built ones.
     record_pr_review(repo.full_name, pr.number, pr.title, pr.html_url, findings, head_sha,
-                     summary=summary, review=review, review2=state_review)
+                     summary=summary, review=review, review2=state_review,
+                     base_ref=getattr(getattr(pr, "base", None), "ref", "") or "",
+                     head_ref=_head_ref)
     if action != "cached":
         logger.info("pr_review: %s PR #%s reviewed (%d findings, comment %s)",
                     repo.full_name, pr.number, len(findings), action)

--- a/templates/index.html
+++ b/templates/index.html
@@ -645,6 +645,14 @@
                     <tr class="hover:bg-slate-50 transition-colors" data-status="pr_review" data-pr-state="{% if pr.auto_merged %}auto_merged{% elif pr.merged %}merged{% elif pr.denied %}denied{% elif pr.closed %}closed{% elif pr.approved %}approved{% else %}reviewed{% endif %}" style="display:none">
                         <td class="px-3 py-2 font-mono align-middle truncate">
                             <a href="{{ pr.url }}" target="_blank" class="text-indigo-600 hover:underline"><i class="fas fa-code-branch mr-1"></i>{{ pr.repo }} #{{ pr.number }}</a>
+                            {# Where this PR is HEADED. In a dev -> qa -> main chain the target
+                               branch is the most important fact about a PR, and this row used to
+                               show only repo #N -- a routine dev PR looked identical to one aimed
+                               at main. Records written before base_ref existed have no value, so
+                               the badge is omitted entirely rather than rendered blank. #}
+                            {% if pr.base_ref %}
+                            <span class="ml-1 px-1.5 py-0.5 rounded text-[10px] font-bold whitespace-nowrap {{ 'text-amber-800 bg-amber-100 border border-amber-300' if pr.base_ref in ('main', 'master') else 'text-slate-600 bg-slate-100' }}" title="This PR merges into {{ pr.base_ref }}{% if pr.head_ref %} from {{ pr.head_ref }}{% endif %}.{% if pr.base_ref in ('main', 'master') %} This is a protected branch.{% endif %}"><i class="fas fa-arrow-right-long mr-1"></i>{{ pr.base_ref }}</span>
+                            {% endif %}
                         </td>
                         <td class="px-3 py-2 text-right align-middle">
                             <div class="flex flex-wrap gap-1 justify-end items-center">

--- a/test_pr_review_panel_format.py
+++ b/test_pr_review_panel_format.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Self-test: the advisory review panels render as readable, structured markdown.
+
+The panels used to dump every reviewer's prose as one whitespace-collapsed
+paragraph, with each reviewer's own verdict/confidence thrown away. These cases
+pin the replacement: recommendation first, concerns next, per-reviewer detail
+below — and pin that highlighting follows actual verdicts rather than
+keyword-guessing the prose.
+
+pr_review.py can't be imported (circular: pr_review -> github_ops -> main ->
+log_scan -> main), so the renderers are ast-extracted, matching the other
+pr_review self-tests.
+"""
+import ast
+import re
+import sys
+
+FAILURES = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print("  ok   %s" % name)
+    else:
+        print("  FAIL %s %s" % (name, detail))
+        FAILURES.append(name)
+
+
+def _load_ns():
+    src = open("pr_review.py").read()
+    tree = ast.parse(src)
+    want_fn = {"_norm_conf_pct", "_reviewer_blocks", "_structure_critique",
+               "_render_review_body", "_render_panel", "_render_state_panel"}
+    want_as = {"_REVIEWER_TAG_RE", "_REVIEWER_SPLIT_RE", "_ENUM_MARK_RE",
+               "_SENTENCE_SPLIT_RE", "_PANEL_HEADER", "_STATE_PANEL_HEADER"}
+    segs = []
+    for n in tree.body:
+        if isinstance(n, ast.FunctionDef) and n.name in want_fn:
+            segs.append(ast.get_source_segment(src, n))
+        elif isinstance(n, ast.Assign):
+            for t in n.targets:
+                if getattr(t, "id", "") in want_as:
+                    segs.append(ast.get_source_segment(src, n))
+    ns = {"re": re}
+    exec("\n\n".join(segs), ns)
+    missing = (want_fn | want_as) - set(ns)
+    if missing:
+        raise SystemExit("could not extract from pr_review.py: %s" % sorted(missing))
+    return ns
+
+
+NS = _load_ns()
+
+
+def render(review):
+    return "\n".join(NS["_render_panel"](review))
+
+
+MIXED = {
+    "verdict": "Reject", "confidence": 0.58,
+    "reviews": [
+        {"reviewer": "gpt-5", "verdict": "Reject", "confidence": 0.41,
+         "critique": "Mostly reasonable but has problems. 1) The loop mutates "
+                     "the list it iterates. 2) No test covers the empty branch."},
+        {"reviewer": "claude", "verdict": "Reject", "confidence": 0.55,
+         "critique": "Existing configs lack the new key and this raises KeyError."},
+        {"reviewer": "gemini", "verdict": "Approve", "confidence": 0.78,
+         "critique": "Additive and well-scoped."},
+    ],
+}
+
+
+def main():
+    print("== recommendation header ==")
+    out = render(MIXED)
+    check("deny recommendation is at the top",
+          out.index("Recommendation: DENY") < out.index("Reviewer detail"))
+    check("deny is marked red", "\U0001F534 **Recommendation: DENY**" in out)
+    check("panel confidence shown as pct", "panel confidence **58%**" in out)
+
+    approve = dict(MIXED, verdict="Approve", confidence=0.93,
+                   reviews=[dict(MIXED["reviews"][2])])
+    aout = render(approve)
+    check("approve is marked green", "\U0001F7E2 **Recommendation: APPROVE**" in aout)
+    check("approve shows no-objections block", "No objections" in aout)
+    check("approve shows no concerns block", "Concerns" not in aout)
+
+    print("== concerns block ==")
+    check("concerns precede detail", out.index("Concerns") < out.index("Reviewer detail"))
+    check("counts only dissenters", "2 of 3 reviewers did not approve" in out)
+    check("names each dissenter", "**gpt-5**" in out and "**claude**" in out)
+    check("dissenter confidence shown", "(41%)" in out and "(55%)" in out)
+    approving = [ln for ln in out.split("\n")
+                 if ln.startswith("- \U0001F534") and "gemini" in ln]
+    check("approving reviewer is not listed as a concern", not approving, approving)
+
+    print("== per-reviewer detail ==")
+    check("each reviewer's own verdict is kept",
+          out.count("\U0001F534 Reject") == 2 and "\U0001F7E2 Approve" in out)
+    check("each reviewer's own confidence is kept", "confidence 78%" in out)
+    check("enumerated points become bullets",
+          "- The loop mutates the list it iterates." in out)
+    check("enumeration markers are stripped", "1) The loop" not in out)
+
+    print("== legacy blob fallback ==")
+    legacy = {"verdict": "Reject", "confidence": 0.62,
+              "critique": "[gpt-5] Two issues. 1) Mutates while iterating. "
+                          "2) Swallows the exception. | [gemini] Small and additive."}
+    lout = render(legacy)
+    check("legacy splits per reviewer", "**gpt-5**" in lout and "**gemini**" in lout)
+    check("legacy strips the name tag", "[gpt-5]" not in lout)
+    check("legacy bullets the points", "- Mutates while iterating." in lout)
+    check("legacy deny still states a concern", "Concerns" in lout)
+    check("legacy invents no verdicts", "Reject ·" not in lout)
+
+    # A " | " inside one reviewer's prose must not be read as a reviewer break.
+    piped = {"verdict": "Approve", "confidence": 0.9,
+             "critique": "[gpt-5] Use `ps aux | grep foo` here | [gemini] Fine."}
+    pout = render(piped)
+    check("pipe inside prose is not a reviewer split",
+          pout.count("**gpt-5**") == 1 and "grep foo" in pout
+          and pout.count("Reviewer**") == 0, pout)
+
+    print("== degenerate inputs ==")
+    check("no review renders nothing", NS["_render_panel"](None) == [])
+    check("empty review renders nothing", NS["_render_panel"]({}) == [])
+    unavail = render({"status": "error", "reason": "provider timeout"})
+    check("status path explains itself", "Panel unavailable" in unavail
+          and "provider timeout" in unavail)
+    check("status path emits no verdict", "Recommendation" not in unavail)
+
+    blank = render({"verdict": "Reject", "confidence": 0.5,
+                    "reviews": [{"reviewer": "gpt-5", "verdict": "Reject",
+                                 "confidence": 0.5, "critique": ""}]})
+    check("empty critique says so", "No critique text returned" in blank)
+
+    bad = render({"verdict": "Reject", "confidence": "n/a",
+                  "reviews": [{"reviewer": "x", "verdict": "Reject", "critique": "y."}]})
+    check("unparseable confidence degrades to n/a", "confidence **n/a**" in bad)
+    check("missing reviewer confidence is omitted, not zeroed",
+          "confidence 0%" not in bad)
+
+    long_crit = "Sentence one is here. " * 12
+    lng = render({"verdict": "Reject", "confidence": 0.5,
+                  "reviews": [{"reviewer": "x", "verdict": "Reject",
+                               "confidence": 0.5, "critique": long_crit}]})
+    concern = [l for l in lng.split("\n") if l.startswith("- \U0001F534")][0]
+    check("long headline is truncated in concerns", len(concern) < 300, len(concern))
+    check("unenumerated prose is broken into paragraphs",
+          lng.count("Sentence one is here. Sentence one is here.") > 1)
+
+    print("== state panel shares the format ==")
+    sout = "\n".join(NS["_render_state_panel"](MIXED))
+    check("state panel uses its own header", NS["_STATE_PANEL_HEADER"] in sout)
+    check("state panel is structured too",
+          "Recommendation: DENY" in sout and "Reviewer detail" in sout)
+
+    print("\n%s" % ("FAILED: %s" % FAILURES if FAILURES else "all checks passed"))
+    return 1 if FAILURES else 0
+
+
+def test_pr_review_panel_format():
+    """pytest wrapper so this runs in CI as well as standalone."""
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_pr_review_panel_format.py
+++ b/test_pr_review_panel_format.py
@@ -30,7 +30,8 @@ def _load_ns():
     src = open("pr_review.py").read()
     tree = ast.parse(src)
     want_fn = {"_norm_conf_pct", "_reviewer_blocks", "_structure_critique",
-               "_render_review_body", "_render_panel", "_render_state_panel"}
+               "_render_review_body", "_render_panel", "_render_state_panel",
+               "_render_route", "_render"}
     want_as = {"_REVIEWER_TAG_RE", "_REVIEWER_SPLIT_RE", "_ENUM_MARK_RE",
                "_SENTENCE_SPLIT_RE", "_PANEL_HEADER", "_STATE_PANEL_HEADER"}
     segs = []
@@ -38,9 +39,14 @@ def _load_ns():
         if isinstance(n, ast.FunctionDef) and n.name in want_fn:
             segs.append(ast.get_source_segment(src, n))
         elif isinstance(n, ast.Assign):
-            for t in n.targets:
-                if getattr(t, "id", "") in want_as:
-                    segs.append(ast.get_source_segment(src, n))
+            t = n.targets[0]
+            # _render pulls in module constants (marker, headers, icons); take
+            # every module-level constant rather than enumerating them, so
+            # adding one to pr_review.py doesn't silently break this loader.
+            if isinstance(t, ast.Name) and (t.id.isupper() or t.id in want_as):
+                seg = ast.get_source_segment(src, n)
+                if seg:
+                    segs.append(seg)
     ns = {"re": re}
     exec("\n\n".join(segs), ns)
     missing = (want_fn | want_as) - set(ns)
@@ -148,6 +154,53 @@ def main():
     check("long headline is truncated in concerns", len(concern) < 300, len(concern))
     check("unenumerated prose is broken into paragraphs",
           lng.count("Sentence one is here. Sentence one is here.") > 1)
+
+    print("== PR routing line ==")
+    dev = NS["_render"]([], "abc123", base_ref="dev", head_ref="ux/foo")
+    check("names the target branch", "Merging into `dev`" in dev)
+    check("names the source branch", "\u2190 `ux/foo`" in dev)
+    check("routing is above the disclaimer",
+          dev.index("Merging into") < dev.index("informational only"))
+    check("routing is above the findings",
+          dev.index("Merging into") < dev.index("Tier-1"))
+    check("non-protected target carries no warning", "protected branch" not in dev)
+
+    for target in ("main", "master"):
+        prot = NS["_render"]([], "abc123", base_ref=target, head_ref="qa")
+        check("%s is flagged protected" % target, "protected branch" in prot)
+    named = NS["_render"]([], "abc123", base_ref="trunk", head_ref="qa",
+                          default_branch="trunk")
+    check("a non-standard default branch is flagged protected",
+          "protected branch" in named)
+    qa = NS["_render"]([], "abc123", base_ref="qa", head_ref="dev",
+                       default_branch="main")
+    check("qa is not flagged protected", "protected branch" not in qa)
+
+    bare = NS["_render"]([], "abc123")
+    check("missing refs emit no routing line", "Merging into" not in bare)
+    check("missing refs still render the comment", "Tier-1" in bare)
+    nohead = NS["_render"]([], "abc123", base_ref="dev")
+    check("target alone still renders", "Merging into `dev`" in nohead
+          and "\u2190" not in nohead)
+
+    # Everything above tests _render in isolation, which would still pass if the
+    # real caller never passed the refs — the line would just silently vanish in
+    # production. Pin the wiring at the one call site.
+    src = open("pr_review.py").read()
+    call = [n for n in ast.walk(ast.parse(src))
+            if isinstance(n, ast.Call) and getattr(n.func, "id", "") == "_render"]
+    check("exactly one _render call site", len(call) == 1, len(call))
+    kw = {k.arg: ast.dump(k.value) for k in call[0].keywords} if call else {}
+    check("call site passes a base_ref", "base_ref" in kw)
+    check("call site reads the PR's base ref, not a literal",
+          "base" in kw.get("base_ref", ""), kw.get("base_ref"))
+    check("call site passes a head_ref", "head_ref" in kw)
+    check("call site passes the repo default branch",
+          "default_branch" in kw and "default_branch" in kw["default_branch"])
+    check("missing refs still render the comment", "Tier-1" in bare)
+    nohead = NS["_render"]([], "abc123", base_ref="dev")
+    check("target alone still renders", "Merging into `dev`" in nohead
+          and "\u2190" not in nohead)
 
     print("== state panel shares the format ==")
     sout = "\n".join(NS["_render_state_panel"](MIXED))


### PR DESCRIPTION
Two related changes to how AppBuilder's PR pre-review comment reads.

## 1. Show where the PR is going

Neither the comment nor the WebUI PR list said which branch a PR targets. In a `dev → qa → main` chain that's the most important fact about a PR — a routine dev PR looked identical to one aimed at `main`.

**Comment**, directly under the title:

> 🔀 **Merging into `dev`** ← `ux/foo`

> 🔀 **Merging into `main`** ← `qa`  — ⚠️ **protected branch**

**PR list row**: target branch as a badge beside `repo #N`, amber for `main`/`master`, tooltip naming both branches.

"Protected" isn't just a `main` string match — it also checks the repo's actual `default_branch`, so a repo using `trunk` is still flagged. `record_pr_review` persists `base_ref`/`head_ref`, falling back to the prior record so a cached re-scan can't blank them. Records written before these fields existed omit the line/badge rather than render an empty one.

## 2. Make the review itself readable

**Before:** every reviewer's critique was flattened into one `" | "`-joined paragraph, and `fix_engine` discarded each reviewer's own verdict/confidence — so the comment structurally *could not* say who objected or how strongly.

**After:**
- 🟢/🔴 **Recommendation** + panel confidence on the first line
- **⚠️ Concerns** — each non-approving reviewer, their confidence, their headline finding
- **Reviewer detail** — per reviewer, own verdict/confidence, enumerated points as bullets

Highlighting follows actual verdicts, not keyword-matching the prose, so it can't invent a concern nobody raised or miss one phrased unusually. Bullets come from the reviewer's own enumeration; where there is none, sentences are grouped into short paragraphs rather than inventing topic splits.

Applies to both the skeptical and state-logic panels via one shared formatter. Legacy already-reviewed PRs still render per-reviewer via a fallback parser — the split requires a following `[tag]`, so a `" | "` inside a reviewer's own prose (shell pipes, tables) isn't mistaken for a reviewer break. The `critique` string is unchanged for existing callers.

## Verification

- Comment output run through **GitHub's own markdown API** → renders as h3/h4/bullets, not a paragraph.
- Headers rendered for dev / main / master / custom-default / absent refs; WebUI row rendered as a fragment for dev, main and a legacy record.
- Tests pin the **call-site wiring**, not just the renderer — rendering assertions alone would still pass if the real caller never passed `pr.base.ref` and the line silently vanished in production. Mutating the call site to a literal is caught only by that check.
- 43 self-test checks; 6 mutations, each caught. Tooltip checker clean.
- Merged `dev` in to pick up the stricter CI from #112: **352 passed**.
