### PR TITLE
Let reviewers read files over 1MB (locally, not streamed from GitHub)

### DIFF
--- a/fix_engine.py
+++ b/fix_engine.py
@@ -1,5 +1,5 @@
 """AI fix pipeline: issue analysis, sandboxed fix generation/application, verification, and per-issue orchestration (extracted from main.py)."""
-import contextlib, git, json, os, re, requests, tempfile, threading, time, traceback
+import base64, contextlib, git, json, os, re, requests, tempfile, threading, time, traceback
 from datetime import datetime
 from github import Github, GithubException
 
@@ -669,17 +669,26 @@ def prepare_environment(repo_path):
 _REVIEW_TOOLS = [
     {"type": "function", "function": {
         "name": "fetch_repo_file",
-        "description": "Fetch the FULL content of a file from this repo at the "
+        "description": "Fetch the content of a file from this repo at the "
                         "commit being reviewed. Use this when the diff doesn't "
                         "show whether a referenced symbol (function, route, "
                         "constant) actually exists, or when the diff was "
                         "truncated and you need more of a file than you were "
                         "shown. Do not guess or default to rejecting when a "
                         "tool call would settle it — but don't call this for "
-                        "every trivial PR either; most reviews don't need it.",
+                        "every trivial PR either; most reviews don't need it. "
+                        "Large files are capped, so for anything big pass "
+                        "`pattern` to get the regions around a symbol instead "
+                        "of just the start of the file. The reply includes "
+                        "`total_lines` so you can tell how much you were shown.",
         "parameters": {"type": "object",
                        "properties": {"path": {"type": "string",
-                                                "description": "repo-relative file path"}},
+                                                "description": "repo-relative file path"},
+                                      "pattern": {"type": "string",
+                                                  "description": "optional literal substring "
+                                                  "(e.g. a function name) — returns the lines "
+                                                  "around each occurrence rather than the "
+                                                  "truncated head of the file"}},
                        "required": ["path"]},
     }},
 ]
@@ -747,31 +756,90 @@ def _parse_review_text_tool_calls(text):
     return _REVIEW_TOOLCALL_TAG_RE.sub("", text).strip(), calls
 
 
-def _fetch_repo_file_for_review(repo, head_sha, path):
-    """Executor for fetch_repo_file — read-only, bounded, never raises (a bad
-    path/binary/oversized file degrades to an {"error": ...} the reviewer can
-    react to instead of crashing the panel turn)."""
+def _repo_file_text(repo, head_sha, path, checkout_path=None):
+    """Resolve one file's text for the reviewer. Returns (text, error) — exactly
+    one is None.
+
+    Order matters, and it is LOCAL-FIRST on purpose:
+
+      1. ``checkout_path`` — the on-disk clone AppBuilder already has (the fix
+         pipeline works in one; the PR pre-review path clones at head_sha via
+         _ensure_review_checkout). Reading here has no size ceiling and costs
+         no API call.
+      2. Contents API — the fallback when no checkout could be arranged.
+      3. Git Blobs API — because the Contents API REFUSES to inline any file
+         over 1MB: it returns ``encoding: "none"`` with an empty ``content``,
+         so PyGithub's decoded_content raises "unsupported encoding: none".
+         That is what made every fix attempt on lm's WebUI/main.js (1.99MB)
+         impossible — the reviewer got "no fetchable content", never saw the
+         file, and the model invented search anchors that could not match.
+         The Blobs API has no such limit (100MB), so it recovers the exact
+         case the Contents API drops.
+    """
+    if checkout_path and os.path.isdir(checkout_path):
+        full = _safe_repo_target(checkout_path, path, what="read file")
+        if full and os.path.isfile(full):
+            try:
+                with open(full, encoding="utf-8") as fh:
+                    return fh.read(), None
+            except UnicodeDecodeError:
+                return None, f"{path} is not valid UTF-8 (binary file?)"
+            except Exception as e:  # noqa: BLE001 — fall through to the API
+                logger.info("review file read from checkout failed for %r (%s) — trying API",
+                            path, e)
+    if repo is None:
+        return None, f"{path} not found in the local checkout (and no API access)"
     try:
         c = repo.get_contents(path, ref=head_sha)
     except Exception as e:  # noqa: BLE001
-        return {"error": f"could not fetch {path}@{head_sha}: {e}"}
-    # getattr(..., None) only swallows AttributeError (the directory-listing
-    # case, where `c` is a list). PyGithub's decoded_content property instead
-    # raises AssertionError ("unsupported encoding: none") when GitHub's
-    # Contents API doesn't inline the file (seen for files >1MB) — that
-    # escaped getattr entirely and broke this function's "never raises"
-    # contract, crashing the reviewer's whole tool-call turn (ab#753).
+        return None, f"could not fetch {path}@{head_sha}: {e}"
+    raw = None
     try:
         raw = c.decoded_content
-    except Exception as e:  # noqa: BLE001
-        return {"error": f"{path} has no fetchable content ({e})"}
+    except Exception:  # noqa: BLE001 — the >1MB "unsupported encoding: none" case
+        raw = None
     if raw is None:
-        return {"error": f"{path} has no fetchable content (directory or binary?)"}
+        sha = getattr(c, "sha", None)
+        if not sha:
+            return None, f"{path} has no fetchable content (directory or binary?)"
+        try:
+            blob = repo.get_git_blob(sha)
+            raw = base64.b64decode(blob.content or "")
+        except Exception as e:  # noqa: BLE001
+            return None, f"{path} has no fetchable content ({e})"
     try:
-        text = raw.decode("utf-8")
+        return raw.decode("utf-8"), None
     except UnicodeDecodeError:
-        return {"error": f"{path} is not valid UTF-8 (binary file?)"}
-    return {"path": path, "content": _trunc(text, _REVIEW_FILE_MAX_CHARS),
+        return None, f"{path} is not valid UTF-8 (binary file?)"
+
+
+def _fetch_repo_file_for_review(repo, head_sha, path, checkout_path=None, pattern=None):
+    """Executor for fetch_repo_file — read-only, bounded, never raises (a bad
+    path/binary/oversized file degrades to an {"error": ...} the reviewer can
+    react to instead of crashing the panel turn).
+
+    ``pattern`` exists because head-truncation is useless on a genuinely large
+    file: capped at _REVIEW_FILE_MAX_CHARS, a 1.99MB/30k-line file returns its
+    first ~1%, so a reviewer asking about a symbol at line 1669 was shown
+    nothing relevant and had to guess. With a pattern, the reviewer gets the
+    windows AROUND each match instead of the head, which is what makes an
+    exact, copyable search anchor available at all.
+    """
+    text, err = _repo_file_text(repo, head_sha, path, checkout_path)
+    if err:
+        return {"error": err}
+    total_lines = text.count("\n") + 1
+    if pattern:
+        windows = _targeted_file_context(text, [pattern], _REVIEW_FILE_MAX_CHARS)
+        if windows is None:
+            return {"path": path, "pattern": pattern, "total_lines": total_lines,
+                    "matches": 0,
+                    "error": f"pattern {pattern!r} not found in {path} "
+                             f"({total_lines} lines) — it does not appear in this file"}
+        return {"path": path, "pattern": pattern, "total_lines": total_lines,
+                "content": windows, "windowed": True}
+    return {"path": path, "total_lines": total_lines,
+            "content": _trunc(text, _REVIEW_FILE_MAX_CHARS),
             "truncated": len(text) > _REVIEW_FILE_MAX_CHARS}
 
 
@@ -902,9 +970,11 @@ def _run_reviewer_turn(prompt, system_prompt, reviewer_candidate, task_id, repo,
         "You have a fetch_repo_file tool that reads the ACTUAL file at this "
         "commit — use it to confirm whether a referenced symbol exists, or "
         "to see the rest of a file the diff cut off, INSTEAD OF rejecting "
-        "because you can't verify something. Most reviews won't need it; "
-        "use it when a specific, nameable uncertainty would change your "
-        "verdict, not as a first step."
+        "because you can't verify something. For a large file, pass its "
+        "`pattern` argument (a symbol name) to get the surrounding lines "
+        "rather than the truncated start of the file. Most reviews won't "
+        "need it; use it when a specific, nameable uncertainty would change "
+        "your verdict, not as a first step."
     )
     messages = [{"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt}]
@@ -932,7 +1002,10 @@ def _run_reviewer_turn(prompt, system_prompt, reviewer_candidate, task_id, repo,
                 args = {}
             if name == "fetch_repo_file" and files_fetched < _REVIEW_TOOL_MAX_FILES:
                 files_fetched += 1
-                out = _fetch_repo_file_for_review(repo, head_sha, str(args.get("path") or ""))
+                out = _fetch_repo_file_for_review(
+                    repo, head_sha, str(args.get("path") or ""),
+                    checkout_path=repo_checkout_path,
+                    pattern=(str(args["pattern"]) if args.get("pattern") else None))
             elif name == "fetch_repo_file":
                 out = {"error": "file-fetch budget exhausted for this review (%d files) "
                                 "— decide from what you've already seen" % _REVIEW_TOOL_MAX_FILES}
@@ -1154,12 +1227,22 @@ def review_fix(repo_path, issue_body, proposed_fixes, force_cloud=None, task_id=
     # docstring for why (claude_cli silently drops tools and got confused).
 
     # A local checkout for claude_cli reviewers' native Read/Grep/Glob/git
-    # tools (see _run_reviewer_turn / _ensure_review_checkout) — only worth
-    # acquiring (and, if cloned fresh, cleaning up) when a claude_cli
-    # reviewer is actually in the panel; every other provider ignores it.
+    # tools (see _run_reviewer_turn / _ensure_review_checkout), and — for any
+    # provider — a size-limit-free, API-call-free source for fetch_repo_file.
+    #
+    # Deliberately NOT acquired unconditionally: _ensure_review_checkout does a
+    # FULL clone (no --depth) when it has to make one, which is far too costly
+    # to pay on every PR pre-review. So:
+    #   * an EXISTING checkout (the bug-fix pipeline's working tree) is reused
+    #     whenever there is one — that path is free, it just returns repo_path;
+    #   * a fresh clone is still only made for claude_cli, which cannot work
+    #     without one.
+    # Every other reviewer falls back to the API, which now handles >1MB files
+    # via the Git Blobs API (see _repo_file_text), so nothing depends on this.
     checkout_path, checkout_is_temp = (None, False)
-    if any(((r.get("candidate") or {}).get("provider") or "").lower().strip() == "claude_cli"
-           for r in reviewers):
+    _wants_clone = any(((r.get("candidate") or {}).get("provider") or "").lower().strip() == "claude_cli"
+                       for r in reviewers)
+    if _wants_clone or (repo_path and os.path.isdir(repo_path)):
         checkout_path, checkout_is_temp = _ensure_review_checkout(repo_path, repo, head_sha, config)
 
     votes = []
@@ -1360,22 +1443,29 @@ def _norm_confidence(value):
     return max(0.0, min(1.0, c))
 
 
-def _safe_repo_target(repo_root, filepath):
+def _safe_repo_target(repo_root, filepath, what="apply fix"):
     """Resolve *filepath* under *repo_root*, rejecting absolute paths, ``..``
     traversal, and symlinks that escape the repo. Returns the absolute path or
     None (logging the reason). Shared by the full-file and targeted-edit apply
-    paths so both enforce identical containment."""
+    paths so both enforce identical containment.
+
+    ``what`` only labels the log lines. The reviewer's read-only file fetch
+    reuses this guard (one containment implementation, never a second copy to
+    drift), but a refused READ must not log "Refusing to apply fix …": those
+    ERROR lines are harvested verbatim by log_scan.py, which would then file a
+    write-failure bug for what was actually a reviewer asking for a bad path.
+    """
     if (not isinstance(filepath, str) or os.path.isabs(filepath)
             or ".." in filepath.replace("\\", "/").split("/")):
-        logger.error(f"Refusing to apply fix with unsafe path: {filepath!r}")
+        logger.error(f"Refusing to {what} with unsafe path: {filepath!r}")
         return None
     full_path = os.path.abspath(os.path.join(repo_root, filepath))
     try:
         if os.path.commonpath([repo_root, full_path]) != repo_root:
-            logger.error(f"Refusing to apply fix escaping repo root: {filepath!r}")
+            logger.error(f"Refusing to {what} escaping repo root: {filepath!r}")
             return None
     except ValueError:
-        logger.error(f"Refusing to apply fix with unresolvable path: {filepath!r}")
+        logger.error(f"Refusing to {what} with unresolvable path: {filepath!r}")
         return None
     if os.path.islink(full_path):
         try:

--- a/test_fix_apply.py
+++ b/test_fix_apply.py
@@ -16,6 +16,7 @@ window the file around issue identifiers, and accept targeted search/replace
 edits that scale to any file size.
 """
 import ast
+import base64
 import json
 import os
 import re
@@ -32,7 +33,8 @@ def _load_funcs():
             "parse_and_apply", "_claim_issue", "_release_issue",
             "_robust_json_loads", "_sanitize_json_string_newlines",
             "_relax_json_fix_strings",
-            "_fetch_repo_file_for_review", "_snippet_language_mismatch_hint",
+            "_fetch_repo_file_for_review", "_repo_file_text",
+            "_snippet_language_mismatch_hint",
             "_relaxed_edit_span"}
     want_assign = {"_ISSUE_STOP_TOKENS", "_inflight_lock", "_inflight_issues",
                     "_JSON_BAD_ESCAPE_RE", "_JS_ONLY_TOKENS_RE", "_PY_ONLY_TOKENS_RE",
@@ -56,7 +58,8 @@ def _load_funcs():
         def __getattr__(self, _):
             return lambda *a, **k: None
 
-    ns = {"os": os, "json": json, "re": re, "threading": threading, "logger": _L()}
+    ns = {"os": os, "json": json, "re": re, "threading": threading,
+          "base64": base64, "logger": _L()}
     exec("\n\n".join(segs), ns)
     ns["_captured_errors"] = captured_errors
     return ns

--- a/test_review_file_fetch.py
+++ b/test_review_file_fetch.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Self-test for the reviewer's repo-file fetch path (fix_engine).
+
+Run:  python3 ab/test_review_file_fetch.py
+
+WHAT BROKE (lm#444, and every other attempt to fix a big file)
+-------------------------------------------------------------
+GitHub's Contents API REFUSES to inline any file over 1MB: it answers with
+``encoding: "none"`` and an empty ``content``, so PyGithub's decoded_content
+raises. lm's ``WebUI/main.js`` is 1.99MB / 30,323 lines, so every reviewer
+fetch of it returned "no fetchable content". The model therefore never saw the
+file and invented search anchors that could not possibly match — the observed
+failure was three rounds of "search snippet not found", naming a parameter
+(``setTenant(tenantName)``) that does not exist; the real signature is
+``setTenant(tenant)``.
+
+Two independent defects, so two independent guards below:
+
+  1. FETCH — the file could not be read at all. Fixed by reading from the local
+     checkout when AppBuilder already has one, and otherwise falling back to the
+     Git Blobs API (100MB limit) when the Contents API declines to inline.
+
+  2. RETRIEVAL — even with the bytes in hand, the reply is capped at
+     _REVIEW_FILE_MAX_CHARS (20,000). On a 1.99MB file that is the first ~1%,
+     so a symbol at line 1669 is still invisible. Fixed by the ``pattern``
+     argument, which returns windows AROUND matches instead of the head.
+
+Fixing only (1) would have left the tool still useless on exactly the file that
+motivated it, so the "without pattern the symbol is absent / with pattern it is
+present" pair below is the real regression guard.
+
+fix_engine.py cannot be imported (its ``from main import …`` triggers a
+circular FastAPI init), so the pure helpers are extracted via ast and exec'd —
+this exercises the real code text, not a copy.
+"""
+import ast
+import base64
+import json
+import os
+import re
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIX_ENGINE = os.path.join(HERE, "fix_engine.py")
+
+
+def _load():
+    src = open(FIX_ENGINE).read()
+    tree = ast.parse(src)
+    want = {"_safe_repo_target", "_repo_file_text", "_fetch_repo_file_for_review",
+            "_targeted_file_context"}
+    segs = [ast.get_source_segment(src, n) for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name in want]
+
+    def _trunc(s, n):
+        if s is None:
+            return ""
+        s = str(s)
+        return s if len(s) <= n else s[:n] + " …[truncated]"
+
+    class _L:
+        def __getattr__(self, _):
+            return lambda *a, **k: None
+
+    ns = {"os": os, "json": json, "re": re, "base64": base64, "logger": _L(),
+          "_trunc": _trunc, "_REVIEW_FILE_MAX_CHARS": 20000}
+    exec("\n\n".join(segs), ns)
+    return ns
+
+
+def _check(label, cond):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
+    return bool(cond)
+
+
+# ---------------------------------------------------------------- fakes
+
+
+class _Oversized:
+    """A ContentFile for a >1MB file: the Contents API gave us no content, so
+    decoded_content raises exactly as PyGithub's does."""
+
+    def __init__(self, sha="abc123"):
+        self.sha = sha
+
+    @property
+    def decoded_content(self):
+        raise AssertionError("unsupported encoding: none")
+
+
+class _Blob:
+    def __init__(self, text):
+        self.content = base64.b64encode(text.encode()).decode()
+
+
+class _Repo:
+    """Records access so a test can prove the API was never consulted."""
+
+    def __init__(self, blob_text=None, content_file=None, blob_raises=False):
+        self._blob_text = blob_text
+        self._content_file = content_file if content_file is not None else _Oversized()
+        self._blob_raises = blob_raises
+        self.contents_calls = 0
+        self.blob_calls = 0
+
+    def get_contents(self, path, ref=None):
+        self.contents_calls += 1
+        return self._content_file
+
+    def get_git_blob(self, sha):
+        self.blob_calls += 1
+        if self._blob_raises:
+            raise RuntimeError("blob boom")
+        return _Blob(self._blob_text or "")
+
+
+def _big_js():
+    """A stand-in for lm's WebUI/main.js: >1MB, with the real signature far past
+    any head-truncation cutoff."""
+    filler = "// padding line that exists only to push the symbol out of reach\n"
+    head = filler * 1668
+    body = ("async function setTenant(tenant) {\n"
+            "    currentTenant = tenant;\n"
+            "    localStorage.setItem('lm_tenant', tenant);\n"
+            "}\n")
+    tail = filler * 15000
+    return head + body + tail
+
+
+def main():
+    ns = _load()
+    fetch = ns["_fetch_repo_file_for_review"]
+    read = ns["_repo_file_text"]
+    ok = True
+
+    # ---------------------------------------------------------- 1. FETCH
+    big = _big_js()
+    ok &= _check("test fixture really is >1MB (the Contents API refusal threshold)",
+                 len(big) > 1_000_000)
+
+    repo = _Repo(blob_text=big)
+    text, err = read(repo, "deadbeef", "WebUI/main.js")
+    ok &= _check("a >1MB file is recovered via the Git Blobs API, not lost",
+                 err is None and text == big)
+    ok &= _check("the blob fallback is only reached after the Contents API declines",
+                 repo.contents_calls == 1 and repo.blob_calls == 1)
+
+    # Local checkout must win outright — no API call at all.
+    with tempfile.TemporaryDirectory() as d:
+        os.makedirs(os.path.join(d, "WebUI"))
+        with open(os.path.join(d, "WebUI", "main.js"), "w") as fh:
+            fh.write(big)
+        repo2 = _Repo(blob_text="WRONG")
+        text2, err2 = read(repo2, "deadbeef", "WebUI/main.js", checkout_path=d)
+        ok &= _check("an existing local checkout is used instead of streaming from GitHub",
+                     err2 is None and text2 == big)
+        ok &= _check("using the checkout costs ZERO GitHub API calls",
+                     repo2.contents_calls == 0 and repo2.blob_calls == 0)
+
+        # Path containment still enforced on the read path. The escape target
+        # must genuinely EXIST outside the checkout, otherwise dropping the
+        # guard merely fails the isfile() check and falls through to the API,
+        # and the test passes for the wrong reason.
+        outside = os.path.join(os.path.dirname(d), "ab-secret-probe.txt")
+        with open(outside, "w") as fh:
+            fh.write("TOP-SECRET-OUTSIDE-THE-REPO")
+        try:
+            rel = os.path.relpath(outside, d)  # e.g. ../ab-secret-probe.txt
+            repo_t = _Repo(blob_text="from-api")
+            bad, bad_err = read(repo_t, "deadbeef", rel, checkout_path=d)
+            ok &= _check("a traversal path cannot read a file outside the checkout",
+                         bad != "TOP-SECRET-OUTSIDE-THE-REPO")
+        finally:
+            os.remove(outside)
+
+        # A path absent from the checkout must fall through to the API, not fail.
+        repo3 = _Repo(blob_text="from-api")
+        t3, e3 = read(repo3, "deadbeef", "not/here.js", checkout_path=d)
+        ok &= _check("a file missing from the checkout falls back to the API",
+                     e3 is None and t3 == "from-api" and repo3.contents_calls == 1)
+
+    # Failure modes stay soft — the contract is "never raises".
+    t4, e4 = read(_Repo(blob_text=None, blob_raises=True), "deadbeef", "big.js")
+    ok &= _check("a blob-API failure degrades to an error, not an exception",
+                 t4 is None and e4 and "no fetchable content" in e4)
+
+    class _NoSha:
+        @property
+        def decoded_content(self):
+            raise AssertionError("unsupported encoding: none")
+
+    t5, e5 = read(_Repo(content_file=_NoSha()), "deadbeef", "big.js")
+    ok &= _check("a content object with no sha degrades to an error",
+                 t5 is None and bool(e5))
+
+    class _Binary:
+        sha = "s"
+        decoded_content = b"\xff\xfe\x00binary"
+
+    t6, e6 = read(_Repo(content_file=_Binary()), "deadbeef", "x.bin")
+    ok &= _check("non-UTF-8 content is reported as binary, not crashed on",
+                 t6 is None and "not valid UTF-8" in (e6 or ""))
+
+    out_err = fetch(_Repo(content_file=_NoSha()), "deadbeef", "big.js")
+    ok &= _check("the tool executor still returns an error DICT (never raises)",
+                 isinstance(out_err, dict) and "error" in out_err)
+
+    # ------------------------------------------------------ 2. RETRIEVAL
+    # The heart of lm#444: fetching the bytes is not enough.
+    repo4 = _Repo(blob_text=big)
+    plain = fetch(repo4, "deadbeef", "WebUI/main.js")
+    ok &= _check("without a pattern the reply is truncated (head only)",
+                 plain.get("truncated") is True)
+    ok &= _check("without a pattern the real signature is NOT visible "
+                 "— this is precisely why the model invented an anchor",
+                 "async function setTenant(tenant)" not in plain.get("content", ""))
+    ok &= _check("the reply reports total_lines so the model can tell it saw a fraction",
+                 plain.get("total_lines", 0) > 16000)
+
+    windowed = fetch(repo4, "deadbeef", "WebUI/main.js", pattern="function setTenant")
+    ok &= _check("WITH a pattern the real signature IS visible",
+                 "async function setTenant(tenant) {" in windowed.get("content", ""))
+    ok &= _check("the windowed reply is flagged as windowed, not silently partial",
+                 windowed.get("windowed") is True)
+    ok &= _check("the windowed reply still respects the char budget",
+                 len(windowed.get("content", "")) <= 20000 + 200)
+    ok &= _check("the hallucinated signature is absent (it never existed)",
+                 "setTenant(tenantName)" not in windowed.get("content", ""))
+
+    missing = fetch(repo4, "deadbeef", "WebUI/main.js", pattern="setTenant(tenantName)")
+    ok &= _check("a pattern that does not exist is reported as not-found, "
+                 "not as an empty file",
+                 "error" in missing and "not found" in missing["error"])
+    ok &= _check("the not-found reply still reports total_lines",
+                 missing.get("total_lines", 0) > 16000)
+
+    # ------------------------------------------------- 3. CALL-SITE WIRING
+    # Everything above would still pass if the production caller never passed
+    # the checkout or the pattern — so pin the real call site.
+    src = open(FIX_ENGINE).read()
+    tree = ast.parse(src)
+    turn = [n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "_run_reviewer_turn"][0]
+    call = None
+    for node in ast.walk(turn):
+        if (isinstance(node, ast.Call)
+                and getattr(node.func, "id", "") == "_fetch_repo_file_for_review"):
+            call = node
+    kw = {k.arg for k in call.keywords} if call else set()
+    ok &= _check("the reviewer call site passes checkout_path=", "checkout_path" in kw)
+    ok &= _check("the reviewer call site passes pattern=", "pattern" in kw)
+    ok &= _check("checkout_path is wired to the turn's repo_checkout_path arg",
+                 any(k.arg == "checkout_path"
+                     and getattr(k.value, "id", "") == "repo_checkout_path"
+                     for k in (call.keywords if call else [])))
+    # Presence of the keyword is not enough: `pattern=None` would satisfy it
+    # while silently disabling windowing, which is the whole fix. Pin that the
+    # value is actually derived from the model's tool arguments.
+    _pat_kw = next((k for k in (call.keywords if call else []) if k.arg == "pattern"), None)
+    _pat_src = ast.get_source_segment(src, _pat_kw.value) if _pat_kw else ""
+    ok &= _check("pattern= is derived from the reviewer's tool args, not hard-coded",
+                 "args" in (_pat_src or ""))
+
+    ok &= _check("the tool schema advertises the pattern argument",
+                 '"pattern"' in src and "pattern" in src.split("_REVIEW_TOOLS")[1][:2000])
+
+    review = [n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef) and n.name == "review_fix"][0]
+    review_src = ast.get_source_segment(src, review)
+    ok &= _check("an already-existing checkout is reused (not cloned) for reviewers",
+                 "_wants_clone or (repo_path and os.path.isdir(repo_path))" in review_src)
+
+    print("\n" + ("ALL CASES PASSED" if ok else "SOME CASES FAILED"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
AppBuilder could not fix ANY file larger than 1MB. GitHub's Contents API
refuses to inline them -- it returns `encoding: "none"` with empty content,
so PyGithub's decoded_content raises and the reviewer's fetch_repo_file tool
answered "no fetchable content". The model then never saw the file and
invented search anchors that could not match, producing repeated
"search snippet not found" failures (lm#444, on WebUI/main.js: 1.99MB /
30,323 lines, where it guessed `setTenant(tenantName)` for the real
`setTenant(tenant)`).

Two independent defects, so two fixes:

1. FETCH. _repo_file_text() resolves content local-first:
   the on-disk checkout AppBuilder already has -> Contents API ->
   Git Blobs API (100MB limit) when the Contents API declines to inline.
   Reading from the checkout has no size ceiling and costs no API call.

2. RETRIEVAL. Fetching the bytes is not enough: replies are capped at
   _REVIEW_FILE_MAX_CHARS (20,000), which on a 1.99MB file is the first ~1%,
   so a symbol at line 1669 stayed invisible. fetch_repo_file now takes an
   optional `pattern` and returns the windows AROUND matches (reusing
   _targeted_file_context) instead of the head, plus `total_lines` so the
   model can tell how much it was shown.

The checkout is reused only when one already exists. _ensure_review_checkout
does a FULL clone when it has to make one, which is far too costly to pay on
every PR pre-review, so a fresh clone is still made only for claude_cli.
Correctness does not depend on it -- the Blobs fallback handles >1MB on the
API path too.

_safe_repo_target gained a `what` label so a refused READ no longer logs
"Refusing to apply fix ...": log_scan.py harvests those ERROR lines verbatim
and would file a write-failure bug for a reviewer asking for a bad path.

test_review_file_fetch.py (25 checks) covers blob recovery, checkout
preference with a zero-API-call assertion, traversal containment against a
file that genuinely exists outside the root, binary/no-sha/blob-failure
degradation, the without-pattern-invisible / with-pattern-visible pair that
is the actual lm#444 regression, and call-site wiring. Seven mutations were
each caught, including two that initially escaped and forced stronger
assertions.