### PR TITLE
fix: exclude a model the endpoint refuses to serve on the first failure (reviewer panel kept re-picking it)

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -2091,6 +2091,36 @@ _ENTRY_UNHEALTHY_THRESHOLD = 2
 # (wrong model name) needs an operator anyway, and a real outage is rare
 # enough that checking hourly costs nothing.
 _ENTRY_UNHEALTHY_RETRY_SECONDS = 3600
+# A 400 that names the MODEL as the problem ("model X is not accessible via
+# the /chat/completions endpoint", code unsupported_api_for_model) is not a
+# transient failure and not a guess: the provider has told us this exact
+# (provider, base_url, model) pairing can never serve this request. Retrying
+# it hourly cannot succeed, and each retry costs a failed panel plus an ERROR
+# that the self-log scan files as a NEW issue — which is how one mis-set
+# reviewer model produced ab#119, #121, #125 and #135, all the same fact.
+# Excluded on the FIRST such failure (no threshold: one is conclusive) and for
+# far longer, since only an operator changing the entry can fix it.
+#
+# Safe against permanently stranding an entry, because health is keyed by
+# _model_key(provider, base_url, model): correcting the model in Settings
+# produces a DIFFERENT key that carries none of this state. The cooldown is
+# long rather than infinite only so a provider that later starts serving the
+# model recovers on its own.
+_ENTRY_UNSUPPORTED_RETRY_SECONDS = 86400
+#: Substrings that mark a 4xx as "this endpoint will never serve this model".
+#: Deliberately narrow — a rejection we cannot attribute to the model itself
+#: must keep the ordinary transient-failure path, not get locked out for a day.
+_UNSUPPORTED_MODEL_MARKERS = (
+    "unsupported_api_for_model",
+    "is not accessible via the",
+    "model_not_supported",
+)
+
+
+def _is_unsupported_model_error(err_str):
+    """True when the provider blamed the model itself, not the request."""
+    low = (err_str or "").lower()
+    return any(m in low for m in _UNSUPPORTED_MODEL_MARKERS)
 
 
 def _record_llm_success(key):
@@ -2106,7 +2136,22 @@ def _record_llm_failure(key, exc):
         entry["consecutive_failures"] = entry.get("consecutive_failures", 0) + 1
         entry["last_error"] = str(exc)[:300]
         entry["last_error_at"] = datetime.now().isoformat()
-        if entry["consecutive_failures"] >= _ENTRY_UNHEALTHY_THRESHOLD:
+        if _is_unsupported_model_error(str(exc)):
+            # Conclusive on the first occurrence — see
+            # _ENTRY_UNSUPPORTED_RETRY_SECONDS. Force the count to the
+            # threshold so _entry_is_unhealthy (shared with the Settings
+            # badge) agrees immediately instead of waiting for a second
+            # failure that can only repeat the same rejection.
+            was_excluded = entry.get("unsupported_model")
+            entry["retry_after"] = time.time() + _ENTRY_UNSUPPORTED_RETRY_SECONDS
+            entry["unsupported_model"] = True
+            if not was_excluded:
+                logger.error(
+                    "LLM entry %s rejected its own model (%s). Excluding it from routing for %dh — "
+                    "no retry can fix this. Change the model for this entry in "
+                    "Settings -> Model Registry.",
+                    key, entry["last_error"], _ENTRY_UNSUPPORTED_RETRY_SECONDS // 3600)
+        elif entry["consecutive_failures"] >= _ENTRY_UNHEALTHY_THRESHOLD:
             entry["retry_after"] = time.time() + _ENTRY_UNHEALTHY_RETRY_SECONDS
         _ENTRY_HEALTH[key] = entry
 
@@ -2130,7 +2175,14 @@ def _entry_is_unhealthy(key):
     through; if it fails again, _record_llm_failure extends the cooldown."""
     with _ENTRY_HEALTH_LOCK:
         entry = _ENTRY_HEALTH.get(key)
-    if not entry or entry.get("consecutive_failures", 0) < _ENTRY_UNHEALTHY_THRESHOLD:
+    if not entry:
+        return False
+    # A model the endpoint refuses to serve needs no blip tolerance: one
+    # rejection is the provider stating a fact, so this bypasses the
+    # consecutive-failure threshold (the count stays truthful for the badge).
+    if entry.get("unsupported_model"):
+        return time.time() < entry.get("retry_after", 0.0)
+    if entry.get("consecutive_failures", 0) < _ENTRY_UNHEALTHY_THRESHOLD:
         return False
     return time.time() < entry.get("retry_after", 0.0)
 

--- a/test_llm_client_entry_health.py
+++ b/test_llm_client_entry_health.py
@@ -16,6 +16,7 @@ was broken. _record_llm_success/_record_llm_failure/get_llm_entry_health are
 wired into _call_provider_timed (every LLM call in the app routes through
 it) so a hard-failing entry becomes visible without reading ab.log."""
 import ast
+import logging
 import threading
 import time
 from datetime import datetime
@@ -25,15 +26,19 @@ def _load_ns():
     src = open("llm_client.py").read()
     tree = ast.parse(src)
     names = {"_model_key", "_record_llm_success", "_record_llm_failure",
-              "get_llm_entry_health", "_entry_is_unhealthy"}
-    ns = {"threading": threading, "datetime": datetime, "time": time}
+              "get_llm_entry_health", "_entry_is_unhealthy",
+              "_is_unsupported_model_error"}
+    ns = {"threading": threading, "datetime": datetime, "time": time,
+          "logger": logging.getLogger("entry-health-selftest")}
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name in names:
             exec(ast.get_source_segment(src, node), ns)
         elif isinstance(node, ast.Assign) and any(
             isinstance(t, ast.Name) and t.id in ("_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH",
                                                   "_ENTRY_UNHEALTHY_THRESHOLD",
-                                                  "_ENTRY_UNHEALTHY_RETRY_SECONDS")
+                                                  "_ENTRY_UNHEALTHY_RETRY_SECONDS",
+                                                  "_ENTRY_UNSUPPORTED_RETRY_SECONDS",
+                                                  "_UNSUPPORTED_MODEL_MARKERS")
             for t in node.targets
         ):
             exec(ast.get_source_segment(src, node), ns)
@@ -60,23 +65,57 @@ def main():
     ok &= _check("an entry with no recorded calls is healthy (silence != failure)",
                 h["unhealthy"] is False and h["consecutive_failures"] == 0)
 
-    # ── the actual regression: a model an API rejects on EVERY call ─────────
+    # ── the actual regression: an entry failing on EVERY call ───────────────
+    # Uses a GENERIC error on purpose: this block guards the blip-tolerance
+    # threshold, which must stay >1 for failures we cannot attribute to a
+    # permanent cause. The model-rejection fast path is asserted separately
+    # below (it deliberately does NOT wait for a second failure).
     key = ("copilot", "", "grok-4.6")
     ok &= _check("a single failure does not yet flag the entry (avoids one-off blips)",
                 not get_health(*key)["unhealthy"])
-    record_failure(key, Exception('400 unsupported_api_for_model: model "grok-4.6" is not '
-                                  "accessible via the /chat/completions endpoint"))
+    record_failure(key, Exception("500 Internal Server Error from the provider"))
     h1 = get_health(*key)
     ok &= _check("after 1 failure: still not flagged (threshold is >1)",
                 not h1["unhealthy"] and h1["consecutive_failures"] == 1)
-    record_failure(key, Exception("400 unsupported_api_for_model (again)"))
+    record_failure(key, Exception("500 Internal Server Error (again)"))
     h2 = get_health(*key)
     ok &= _check("after 2 consecutive failures: flagged unhealthy",
                 h2["unhealthy"] and h2["consecutive_failures"] == 2)
     ok &= _check("the last error message is captured for the badge tooltip",
-                "unsupported_api_for_model" in (h2["last_error"] or ""))
+                "Internal Server Error" in (h2["last_error"] or ""))
     ok &= _check("last_error_at is stamped",
                 bool(h2["last_error_at"]))
+
+    # ── a model the endpoint REFUSES to serve is conclusive on the first
+    # failure. Waiting for a second (and then retrying hourly forever) is what
+    # let one mis-set reviewer model keep being re-picked, failing the panel
+    # and filing a duplicate log-alert issue every hour — ab#119/#121/#125/#135
+    # are all the same fact. No retry can change the provider's answer. ──────
+    unsup = ("copilot", "", "grok-4.5")
+    record_failure(unsup, Exception('400 unsupported_api_for_model: model "grok-4.5" is not '
+                                    "accessible via the /chat/completions endpoint"))
+    hu = get_health(*unsup)
+    ok &= _check("model rejection flags the entry on the FIRST failure",
+                hu["unhealthy"] and hu["consecutive_failures"] == 1)
+    with ns["_ENTRY_HEALTH_LOCK"]:
+        _entry = ns["_ENTRY_HEALTH"][unsup]
+    ok &= _check("marked as a model-rejection, not a generic failure",
+                _entry.get("unsupported_model") is True)
+    ok &= _check("excluded far longer than the ordinary hourly retry",
+                _entry["retry_after"] - time.time()
+                > ns["_ENTRY_UNHEALTHY_RETRY_SECONDS"])
+    ok &= _check("cooldown matches the unsupported-model constant",
+                abs((_entry["retry_after"] - time.time())
+                    - ns["_ENTRY_UNSUPPORTED_RETRY_SECONDS"]) < 5)
+    # An operator correcting the model yields a DIFFERENT key, which carries
+    # none of this state — that is what stops the block being a dead end.
+    fixed = get_health("copilot", "", "gpt-5.5-corrected")
+    ok &= _check("correcting the model produces a clean, routable entry",
+                not fixed["unhealthy"] and fixed["consecutive_failures"] == 0)
+    # ...and a genuine success still clears it outright.
+    record_success(unsup)
+    ok &= _check("a later success clears the model-rejection block",
+                not get_health(*unsup)["unhealthy"])
 
     # ── a success resets the streak — a since-fixed entry stops being flagged
     record_success(key)

--- a/test_llm_client_instrumentation.py
+++ b/test_llm_client_instrumentation.py
@@ -88,16 +88,18 @@ def _load_timed_ns(perf_path):
     names = {"_LLM_PERF_STORE", "_LLM_PERF_LOCK", "_llm_perf_last_save", "_LLM_PERF_SAVE_INTERVAL",
               # per-entry health globals (_call_provider_timed records against these
               # on every call — see llm_client.get_llm_entry_health's docstring)
-              "_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH", "_ENTRY_UNHEALTHY_THRESHOLD"}
+              "_ENTRY_HEALTH_LOCK", "_ENTRY_HEALTH", "_ENTRY_UNHEALTHY_THRESHOLD",
+              "_ENTRY_UNSUPPORTED_RETRY_SECONDS", "_UNSUPPORTED_MODEL_MARKERS"}
     fn_names = {"_get_llm_perf_store", "get_llm_perf_snapshot", "_model_key", "_call_provider_timed",
-                "_call_provider_wrapper", "_record_llm_success", "_record_llm_failure"}
+                "_call_provider_wrapper", "_record_llm_success", "_record_llm_failure",
+                "_is_unsupported_model_error"}
     segs = []
     for node in tree.body:
         if isinstance(node, ast.Assign) and any(getattr(t, "id", "") in names for t in node.targets):
             segs.append(ast.get_source_segment(src, node))
         elif isinstance(node, ast.FunctionDef) and node.name in fn_names:
             segs.append(ast.get_source_segment(src, node))
-    assert len(segs) == 7 + 7, f"expected 7 globals + 7 functions, found {len(segs)} segments"
+    assert len(segs) == 9 + 8, f"expected 9 globals + 8 functions, found {len(segs)} segments"
 
     calls = {"provider_calls": []}
 

--- a/test_llm_client_requirements_path.py
+++ b/test_llm_client_requirements_path.py
@@ -35,9 +35,11 @@ def _load_ns():
         # EXCLUDED from the picker's pool, not just visible in Settings —
         # see _entry_is_unhealthy's docstring in llm_client.py)
         "_record_llm_failure", "_record_llm_success", "_entry_is_unhealthy",
+        "_is_unsupported_model_error",
     }
     want_assign = {
         "_ALL_SLOTS", "_CODE_SLOTS", "_LOG_SLOTS", "_REVIEW_SLOTS", "_TOOL_400_MARKERS",
+        "_UNSUPPORTED_MODEL_MARKERS", "_ENTRY_UNSUPPORTED_RETRY_SECONDS",
         "_ENDPOINT_CB_LOCK", "_ENDPOINT_CREDIT_CB", "_MODEL_RATE_CB",
         "_MODEL_LOCKS_LOCK", "_MODEL_LOCKS",
         "_LLM_PERF_STORE", "_LLM_PERF_LOCK",
@@ -175,11 +177,14 @@ def main():
     ok &= _check("before any failure, the entry is a normal available candidate",
                 len(hard_candidates_before) == 1 and hard_candidates_before[0]["available"] is True)
 
-    ns["_record_llm_failure"](hard_key, Exception('400 unsupported_api_for_model'))
+    # Generic error on purpose: blip tolerance applies to failures we cannot
+    # attribute to a permanent cause. A model the endpoint REFUSES to serve is
+    # asserted separately below and excludes on the first failure.
+    ns["_record_llm_failure"](hard_key, Exception('503 Service Unavailable'))
     ok &= _check("one failure alone does not exclude the candidate (avoids a one-off blip)",
                 ns["_enumerate_candidates"](hard_cfg)[0]["available"] is True)
 
-    ns["_record_llm_failure"](hard_key, Exception('400 unsupported_api_for_model (again)'))
+    ns["_record_llm_failure"](hard_key, Exception('503 Service Unavailable (again)'))
     hard_candidates_after = ns["_enumerate_candidates"](hard_cfg)
     ok &= _check("after 2 consecutive failures, the SAME entry that keeps 400ing is excluded "
                 "from the pool — the actual fix for lm#452/#469/#444 (a broken reviewer no "
@@ -191,6 +196,20 @@ def main():
     ok &= _check("a success (e.g. after an operator fixes the model name) clears the exclusion "
                 "immediately — no need to wait out the hourly retry window",
                 ns["_enumerate_candidates"](hard_cfg)[0]["available"] is True)
+
+    # --- a model the endpoint refuses to serve: excluded on the FIRST failure
+    # Retrying it hourly cannot succeed and re-breaks the reviewer panel every
+    # cycle (ab#119/#121/#125/#135 are the same fact, filed four times).
+    unsup_cfg = {"llm_entries": [_entry("e2", "copilot", "grok-4.5", base_url="")]}
+    unsup_key = ns["_model_key"]("copilot", "", "grok-4.5")
+    ns["_record_llm_failure"](unsup_key, Exception(
+        '400 unsupported_api_for_model: model "grok-4.5" is not accessible '
+        'via the /chat/completions endpoint'))
+    unsup_after = ns["_enumerate_candidates"](unsup_cfg)
+    ok &= _check("a model-rejection 400 excludes the candidate immediately, with no "
+                "second failure and no hourly re-pick",
+                len(unsup_after) == 1 and unsup_after[0]["available"] is False
+                and unsup_after[0]["unavailable_reason"] == "hard_failing")
 
     # Timed recovery: re-trip it, then simulate the retry window elapsing —
     # this is what lets the picker try it again on its own even if nobody


### PR DESCRIPTION
Answers "if one reviewer LLM is unavailable, another should be picked — why is this not working?"

## Why substitution was not happening

Reviewers are **pinned by design**. `_select_review_panel` picks N distinct models up front, and `_run_reviewer_turn` dispatches each directly with **no call-time failover** — its docstring is explicit: *"a reviewer IS that specific model for this turn."*

So the only thing that can stop a broken model being used is the **picker refusing to select it**, via `_enumerate_candidates` → `_entry_is_unhealthy`. That path existed and was correct in principle — but its thresholds made it ineffective for a permanently-broken model:

- it required **2 consecutive failures**, so the first pick always burned a panel slot
- the exclusion then **expired after 1 hour** (`_ENTRY_UNHEALTHY_RETRY_SECONDS`)

Result is a loop: picked → 400 → picked → 400 → excluded 1h → picked again. Every pass burns a reviewer slot and logs an ERROR that the self-log scan files as a **new** issue — which is why **#119, #121, #125 and #135 are four copies of one fact**, hours apart. When the second reviewer was independently 429-rate-limited, the panel returned `all_reviewers_failed` and produced no verdict at all (visible on #133).

## The change

A 400 carrying `unsupported_api_for_model` (or `"is not accessible via the <endpoint>"`) is categorically different from a transient failure: the provider has stated this exact `(provider, base_url, model)` pairing **cannot** serve the request. Blip tolerance is meaningless and no retry can change the answer. It is now:

- excluded on the **first** such failure, by bypassing the threshold inside `_entry_is_unhealthy` rather than inflating `consecutive_failures` — so the Settings badge keeps reporting the true count
- excluded for **24h** (`_ENTRY_UNSUPPORTED_RETRY_SECONDS`) instead of 1h
- logged **once**, naming the entry and pointing at Settings → Model Registry, instead of an identical ERROR hourly

With the bad entry out of the pool, the picker selects a working model for that slot — which is the substitution behaviour expected in the first place.

### Why this cannot strand an entry

Health is keyed by `_model_key(provider, base_url, model)`. Correcting the model in Settings produces a **different key** carrying none of this state, and a success clears it outright. The cooldown is long rather than infinite only so a provider that later starts serving the model recovers unattended.

The marker list is deliberately narrow — a rejection that cannot be attributed to the model itself keeps the ordinary transient path.

## Tests

Two existing assertions encoded the old policy. They were **updated, not removed**: both now use a generic error to guard blip tolerance (unchanged for ordinary failures), and each gained a case for the new fast path. The three source-extraction harnesses also needed the new helper, constants and a logger.

- **4/4 mutations caught**: disable the branch, neuter the detector, drop the threshold bypass, shorten the cooldown to hourly.
- Full suite: **354 passed**.

Note this is defence-in-depth for the *next* mis-set model — the immediate outage was cleared by removing the Grok entry.