### PR TITLE
fix: stop discarding reviews over a quoted code snippet; show PR target branch

### DIFF
--- a/fix_engine.py
+++ b/fix_engine.py
@@ -136,9 +136,17 @@ _JSON_NEXT_MEMBER_RE = re.compile(r'\s*,\s*"[^"\\]{0,80}"\s*:')
 # Only these values are repaired leniently; every other byte of the response is
 # copied verbatim, so already-valid JSON is passed through untouched.
 _FIX_CODE_KEY_RE = re.compile(r'"(?:search|replace|code)"\s*:\s*"')
+# The reviewer schema's one free-text value. A critique quotes the code it is
+# reviewing (settings["KEY"], logger.error("…")), so it breaks in exactly the
+# same way a fix's code value does — see _review_one's use below.
+_REVIEW_TEXT_KEY_RE = re.compile(r'"critique"\s*:\s*"')
+# Reviewer objects only ever have these three members, so the "next member"
+# anchor can be exact rather than the fix path's generic <=80-char key match.
+_REVIEW_NEXT_MEMBER_RE = re.compile(r'\s*,\s*"(?:confidence|verdict|critique)"\s*:')
 
 
-def _relax_json_fix_strings(raw):
+def _relax_json_fix_strings(raw, key_re=None, next_member_re=None,
+                            bracket_closes=True):
     """Repair the single most destructive way an LLM's fix JSON breaks: a
     "search"/"replace"/"code" value holds a real code snippet whose OWN string
     literals contain unescaped double-quotes (e.g. logger.error("…")) — and
@@ -155,12 +163,23 @@ def _relax_json_fix_strings(raw):
     byte-for-byte, so this is a no-op on already-valid input and never corrupts
     unrelated fields (other keys, arrays of short strings, etc.). The result is
     only ever used if json.loads accepts it, so a mis-guessed boundary degrades
-    to the existing fallbacks rather than to a bad parse."""
+    to the existing fallbacks rather than to a bad parse.
+
+    key_re/next_member_re/bracket_closes parameterise the schema so the SAME
+    repair serves the reviewer's "critique" value (see _review_one), which
+    breaks identically because a critique quotes the code it reviews. Defaults
+    reproduce the fix-path behaviour exactly. bracket_closes=False is required
+    for prose values: a critique legitimately contains `settings["KEY"]`, and
+    the `"` before `]` there is an INNER quote, not a structural close — the
+    fix path's `]` anchor would mis-cut the value mid-sentence."""
+    key_re = key_re or _FIX_CODE_KEY_RE
+    next_member_re = next_member_re or _JSON_NEXT_MEMBER_RE
+    closers = ('}', ']', '') if bracket_closes else ('}', '')
     out = []
     pos = 0
     n = len(raw)
     while True:
-        m = _FIX_CODE_KEY_RE.search(raw, pos)
+        m = key_re.search(raw, pos)
         if not m:
             out.append(raw[pos:])
             break
@@ -182,13 +201,43 @@ def _relax_json_fix_strings(raw):
             if ch == '"':
                 rest = raw[j + 1:]
                 nxt = rest.lstrip()[:1]
-                if nxt in ('}', ']', '') or _JSON_NEXT_MEMBER_RE.match(rest):
+                if nxt in closers or next_member_re.match(rest):
                     break                      # structural close of the value
                 out.append('\\"'); j += 1; continue   # inner code quote
             out.append(ch); j += 1
         out.append('"')                        # emit the closing quote
         pos = j + 1
     return ''.join(out)
+
+
+def _parse_reviewer_json(raw):
+    """Parse a reviewer's {confidence, verdict, critique} object, applying the
+    same escalating repairs parse_and_apply already uses for fix JSON.
+
+    A reviewer's critique quotes the code under review, so it hits the exact
+    same failure the fix path was hardened against years ago — but the reviewer
+    path only ever called _robust_json_loads, so a single unescaped quote threw
+    the WHOLE review away (the reviewer was counted as failed, burning a panel
+    slot). Confirmed in production: a copilot review of settings["GITHUB_TOKEN_
+    configured"] died with "Expecting ',' delimiter: line 1 column 248" despite
+    a complete, well-formed answer (confidence 0.93, verdict Approve).
+
+    Raises the ORIGINAL JSONDecodeError if every repair fails, so the caller's
+    existing diagnostic logging is unchanged."""
+    try:
+        return _robust_json_loads(raw)
+    except json.JSONDecodeError as first:
+        for candidate in (
+            _sanitize_json_string_newlines(raw),
+            _relax_json_fix_strings(raw, key_re=_REVIEW_TEXT_KEY_RE,
+                                    next_member_re=_REVIEW_NEXT_MEMBER_RE,
+                                    bracket_closes=False),
+        ):
+            try:
+                return _robust_json_loads(candidate)
+            except json.JSONDecodeError:
+                continue
+        raise first
 
 
 def _regression_triage_context(repo_git, issue, prior_commit=None, prior_files=None):
@@ -1267,7 +1316,7 @@ def review_fix(repo_path, issue_body, proposed_fixes, force_cloud=None, task_id=
             )
             match = re.search(r'\{.*\}', res, re.DOTALL)
             if match:
-                _v = _robust_json_loads(match.group())
+                _v = _parse_reviewer_json(match.group())
                 _v["confidence"] = _norm_confidence(_v.get("confidence"))
                 return ({**_v, "reviewer": r["name"]}, None)
             # Parseable-JSON-less but non-erroring response: neither a vote nor a

--- a/pr_review.py
+++ b/pr_review.py
@@ -1513,10 +1513,59 @@ def scan_open_prs(gh, config):
                                        getattr(pr, "number", "?"), repo_name, e)
             except Exception as e:  # noqa: BLE001
                 logger.warning("pr_review: repo %s failed: %s", repo_name, e)
-        # Self-heal listed PRs that are no longer open (merged elsewhere or closed).
+        # Backfill the target-branch badge on older records (see below), then
+        # self-heal listed PRs that are no longer open (merged elsewhere or closed).
+        _backfill_pr_review_refs(gh)
         _reconcile_closed_prs(gh, seen_open)
     finally:
         update_task_state("PRReview", action="end")
+
+
+# Records written before base_ref/head_ref existed have neither, so the PR list
+# renders no target-branch badge for them — in a dev -> qa -> main workflow that
+# is the single most useful fact about a PR, and it was missing from the large
+# majority of rows (67 of 72 on the production host). New reviews store the refs;
+# this fills in the history so the column is uniformly populated.
+#
+# Deliberately bounded per scan cycle: a full backfill is one GET per affected
+# record, and the scan cycle also has real review work to do. The work is
+# idempotent and self-terminating — each cycle re-computes what is still missing
+# and stops costing anything once nothing is (an in-memory dict scan).
+_REFS_BACKFILL_PER_CYCLE = 25
+
+
+def _backfill_pr_review_refs(gh, limit=_REFS_BACKFILL_PER_CYCLE):
+    """Fill in base_ref/head_ref on reviewed-PR records that predate those
+    fields. Never raises out — a backfill is cosmetic and must not break a scan.
+
+    Returns the number of records updated (for tests/logging)."""
+    try:
+        reviews = dict(state.get("pr_reviews") or {})
+    except Exception:  # noqa: BLE001
+        return 0
+    pending = [(k, r) for k, r in reviews.items()
+               if r and not r.get("base_ref") and r.get("repo") and r.get("number")]
+    if not pending:
+        return 0
+    filled = 0
+    for _key, rec in pending[:max(0, int(limit or 0))]:
+        repo_name, number = rec.get("repo"), rec.get("number")
+        try:
+            pr = gh.get_repo(repo_name).get_pull(int(number))
+            base_ref = getattr(getattr(pr, "base", None), "ref", "") or ""
+            head_ref = getattr(getattr(pr, "head", None), "ref", "") or ""
+        except Exception as e:  # noqa: BLE001
+            logger.debug("pr_review backfill: %s#%s fetch failed: %s", repo_name, number, e)
+            continue
+        if not base_ref:
+            continue
+        if update_pr_review(repo_name, number,
+                            base_ref=str(base_ref)[:120], head_ref=str(head_ref)[:120]):
+            filled += 1
+    if filled:
+        logger.info("pr_review: backfilled target branch on %d record(s); %d still missing",
+                    filled, max(0, len(pending) - filled))
+    return filled
 
 
 def _reconcile_closed_prs(gh, seen_open):

--- a/test_pr_review_ref_backfill.py
+++ b/test_pr_review_ref_backfill.py
@@ -1,0 +1,189 @@
+"""Selftest for pr_review._backfill_pr_review_refs.
+
+WHY: the PR list renders a target-branch badge only when a record carries
+base_ref. Records written before that field existed have neither base_ref nor
+head_ref, so the badge was missing from the large majority of rows (67 of 72 on
+the production host) — in a dev -> qa -> main workflow the target branch is the
+most useful fact about a PR. New reviews store it; this backfills the history.
+
+pr_review imports the app (circular at import time), so the function is
+extracted with ast and exec'd against fakes — the same harness pattern the
+test_llm_client_* selftests use.
+"""
+import ast
+import re
+
+
+class _FakeRef:
+    def __init__(self, ref):
+        self.ref = ref
+
+
+class _FakePR:
+    def __init__(self, base, head):
+        self.base = _FakeRef(base)
+        self.head = _FakeRef(head)
+
+
+class _FakeRepo:
+    def __init__(self, gh, name):
+        self._gh, self._name = gh, name
+
+    def get_pull(self, number):
+        self._gh.fetches.append((self._name, number))
+        pr = self._gh.prs.get((self._name, number))
+        if pr is None:
+            raise RuntimeError("404 not found")
+        return pr
+
+
+class _FakeGH:
+    def __init__(self, prs):
+        self.prs = prs
+        self.fetches = []
+
+    def get_repo(self, name):
+        return _FakeRepo(self, name)
+
+
+class _Logger:
+    def debug(self, *a, **k):
+        pass
+
+    def info(self, *a, **k):
+        pass
+
+    def warning(self, *a, **k):
+        pass
+
+
+def _load(state, updates):
+    """Extract the backfill function + its constant against injected fakes."""
+    tree = ast.parse(open("pr_review.py").read())
+    ns = {"re": re, "state": state, "logger": _Logger()}
+
+    def _update_pr_review(repo, number, **fields):
+        key = "%s#%s" % (repo, number)
+        rec = state["pr_reviews"].get(key)
+        if not rec:
+            return False
+        rec.update(fields)
+        updates.append((key, dict(fields)))
+        return True
+
+    ns["update_pr_review"] = _update_pr_review
+    mod = ast.Module(body=[], type_ignores=[])
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_backfill_pr_review_refs":
+            mod.body.append(node)
+        elif isinstance(node, ast.Assign) and any(
+                getattr(t, "id", None) == "_REFS_BACKFILL_PER_CYCLE" for t in node.targets):
+            mod.body.append(node)
+    exec(compile(mod, "pr_review_extract", "exec"), ns)
+    for name in ("_backfill_pr_review_refs", "_REFS_BACKFILL_PER_CYCLE"):
+        if name not in ns:
+            raise AssertionError("extraction incomplete, missing: %s" % name)
+    return ns
+
+
+def _check(label, cond):
+    print(("  PASS  " if cond else "  FAIL  ") + label)
+    return bool(cond)
+
+
+def _rec(repo, number, **extra):
+    r = {"repo": repo, "number": number}
+    r.update(extra)
+    return r
+
+
+def main():
+    ok = True
+    print("pr_review target-branch backfill:")
+
+    # ── fills a record that predates base_ref, leaves a populated one alone ──
+    state = {"pr_reviews": {
+        "o/r#1": _rec("o/r", 1),                              # missing -> fill
+        "o/r#2": _rec("o/r", 2, base_ref="qa", head_ref="x"),  # already set
+    }}
+    updates = []
+    ns = _load(state, updates)
+    backfill = ns["_backfill_pr_review_refs"]
+    gh = _FakeGH({("o/r", 1): _FakePR("dev", "fix/thing"),
+                  ("o/r", 2): _FakePR("main", "other")})
+    n = backfill(gh)
+    ok &= _check("returns the number filled", n == 1)
+    ok &= _check("missing record gets base_ref", state["pr_reviews"]["o/r#1"]["base_ref"] == "dev")
+    ok &= _check("missing record gets head_ref",
+                 state["pr_reviews"]["o/r#1"]["head_ref"] == "fix/thing")
+    ok &= _check("already-populated record untouched",
+                 state["pr_reviews"]["o/r#2"]["base_ref"] == "qa")
+    ok &= _check("no wasted API call for a populated record", gh.fetches == [("o/r", 1)])
+
+    # ── idempotent: a second pass does nothing and costs no API calls ───────
+    gh2 = _FakeGH({("o/r", 1): _FakePR("dev", "fix/thing")})
+    ok &= _check("second pass is a no-op", backfill(gh2) == 0)
+    ok &= _check("second pass makes no API calls", gh2.fetches == [])
+
+    # ── bounded per cycle ──────────────────────────────────────────────────
+    many = {"o/r#%d" % i: _rec("o/r", i) for i in range(1, 11)}
+    state2 = {"pr_reviews": many}
+    ns2 = _load(state2, [])
+    gh3 = _FakeGH({("o/r", i): _FakePR("dev", "h%d" % i) for i in range(1, 11)})
+    n2 = ns2["_backfill_pr_review_refs"](gh3, limit=4)
+    ok &= _check("respects the per-cycle limit", n2 == 4 and len(gh3.fetches) == 4)
+    remaining = [k for k, v in state2["pr_reviews"].items() if not v.get("base_ref")]
+    ok &= _check("the rest are left for the next cycle", len(remaining) == 6)
+    ok &= _check("default per-cycle bound is sane",
+                 isinstance(ns2["_REFS_BACKFILL_PER_CYCLE"], int)
+                 and 0 < ns2["_REFS_BACKFILL_PER_CYCLE"] <= 100)
+
+    # ── failure isolation ──────────────────────────────────────────────────
+    state3 = {"pr_reviews": {"o/r#7": _rec("o/r", 7), "o/r#8": _rec("o/r", 8)}}
+    ns3 = _load(state3, [])
+    gh4 = _FakeGH({("o/r", 8): _FakePR("main", "h8")})  # #7 will raise 404
+    try:
+        n3 = ns3["_backfill_pr_review_refs"](gh4)
+        raised = False
+    except Exception:
+        n3, raised = -1, True
+    ok &= _check("a failed fetch does not raise", not raised)
+    ok &= _check("a failed fetch does not block the others", n3 == 1)
+    ok &= _check("unfetchable record left unset", not state3["pr_reviews"]["o/r#7"].get("base_ref"))
+
+    # ── an empty base_ref is never written (would render a blank badge) ─────
+    state4 = {"pr_reviews": {"o/r#9": _rec("o/r", 9)}}
+    ns4 = _load(state4, [])
+    gh5 = _FakeGH({("o/r", 9): _FakePR("", "")})
+    ok &= _check("empty base_ref is not written", ns4["_backfill_pr_review_refs"](gh5) == 0)
+    ok &= _check("record stays unset rather than blank",
+                 not state4["pr_reviews"]["o/r#9"].get("base_ref"))
+
+    # ── records without repo/number are skipped, not crashed on ────────────
+    state5 = {"pr_reviews": {"bad": {"findings": 1}, "o/r#3": _rec("o/r", 3)}}
+    ns5 = _load(state5, [])
+    gh6 = _FakeGH({("o/r", 3): _FakePR("dev", "h3")})
+    ok &= _check("malformed record skipped, valid one still filled",
+                 ns5["_backfill_pr_review_refs"](gh6) == 1)
+
+    # ── over-long ref names are truncated (matches record_pr_review) ────────
+    state6 = {"pr_reviews": {"o/r#4": _rec("o/r", 4)}}
+    ns6 = _load(state6, [])
+    gh7 = _FakeGH({("o/r", 4): _FakePR("b" * 300, "h" * 300)})
+    ns6["_backfill_pr_review_refs"](gh7)
+    ok &= _check("base_ref truncated to 120",
+                 len(state6["pr_reviews"]["o/r#4"]["base_ref"]) == 120)
+    ok &= _check("head_ref truncated to 120",
+                 len(state6["pr_reviews"]["o/r#4"]["head_ref"]) == 120)
+
+    print()
+    if ok:
+        print("ALL CASES PASSED")
+        return 0
+    print("ONE OR MORE CASES FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/test_reviewer_json_repair.py
+++ b/test_reviewer_json_repair.py
@@ -1,0 +1,141 @@
+"""Selftest for _parse_reviewer_json — the reviewer-side JSON repair ladder.
+
+WHY: a reviewer's "critique" quotes the code it is reviewing, so it contains
+unescaped double-quotes (settings["KEY"], logger.error("…")). The reviewer path
+only ever called _robust_json_loads, so ONE such quote discarded an otherwise
+complete review and counted the reviewer as failed — burning a panel slot.
+Confirmed in production 2026-08-30 00:47:34 (copilot, confidence 0.93/Approve,
+killed by "Expecting ',' delimiter: line 1 column 248").
+
+fix_engine imports the app (circular at import time), so — like the other
+test_llm_client_* harnesses — the pure helpers are extracted with ast and
+exec'd into a synthetic namespace.
+"""
+import ast
+import json
+import re
+
+_WANT_FUNCS = {"_relax_json_fix_strings", "_parse_reviewer_json",
+               "_robust_json_loads", "_sanitize_json_string_newlines"}
+_WANT_ASSIGNS = {"_JSON_NEXT_MEMBER_RE", "_FIX_CODE_KEY_RE", "_REVIEW_TEXT_KEY_RE",
+                 "_REVIEW_NEXT_MEMBER_RE", "_JSON_BAD_ESCAPE_RE"}
+
+
+def _load():
+    tree = ast.parse(open("fix_engine.py").read())
+    ns = {"re": re, "json": json}
+    mod = ast.Module(body=[], type_ignores=[])
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in _WANT_FUNCS:
+            mod.body.append(node)
+        elif isinstance(node, ast.Assign) and any(
+                getattr(t, "id", None) in _WANT_ASSIGNS for t in node.targets):
+            mod.body.append(node)
+    exec(compile(mod, "fix_engine_extract", "exec"), ns)
+    missing = sorted((_WANT_FUNCS | _WANT_ASSIGNS) - set(ns))
+    if missing:
+        raise AssertionError("extraction incomplete, missing: %s" % ", ".join(missing))
+    return ns
+
+
+def _check(label, cond):
+    print(("  PASS  " if cond else "  FAIL  ") + label)
+    return bool(cond)
+
+
+def main():
+    ns = _load()
+    parse = ns["_parse_reviewer_json"]
+    relax = ns["_relax_json_fix_strings"]
+    ok = True
+
+    print("reviewer JSON repair:")
+
+    # ── the exact production failure ────────────────────────────────────────
+    prod = ('{"confidence": 0.93, "verdict": "Approve", "critique": "Reachability: '
+            'the settings["GITHUB_TOKEN_configured"]/from_env lines are computed."}')
+    try:
+        json.loads(prod)
+        ok &= _check("production sample really is invalid JSON (guards the premise)", False)
+    except json.JSONDecodeError:
+        ok &= _check("production sample really is invalid JSON (guards the premise)", True)
+    v = parse(prod)
+    ok &= _check("production sample now parses", isinstance(v, dict))
+    ok &= _check("verdict recovered", v.get("verdict") == "Approve")
+    ok &= _check("confidence recovered", v.get("confidence") == 0.93)
+    ok &= _check("critique text preserved verbatim, inner quotes intact",
+                 'settings["GITHUB_TOKEN_configured"]' in v.get("critique", ""))
+
+    # ── the `]` trap: why bracket_closes=False is required ───────────────────
+    # The fix path treats a quote followed by `]` as a structural close. In prose
+    # that is an inner quote, and honouring it truncates the critique mid-word.
+    bracketed = relax(prod, key_re=ns["_REVIEW_TEXT_KEY_RE"],
+                      next_member_re=ns["_REVIEW_NEXT_MEMBER_RE"], bracket_closes=True)
+    bad = True
+    try:
+        json.loads(bracketed)
+        bad = False
+    except json.JSONDecodeError:
+        pass
+    ok &= _check("bracket_closes=True would still fail (proves the param is load-bearing)", bad)
+
+    # ── other real critique shapes ──────────────────────────────────────────
+    quoted_call = ('{"confidence": 0.8, "verdict": "Reject", "critique": '
+                   '"logger.error("boom") should be logger.warning("boom")."}')
+    v2 = parse(quoted_call)
+    ok &= _check("critique containing a quoted call parses", v2.get("verdict") == "Reject")
+    ok &= _check("quoted call preserved", 'logger.error("boom")' in v2.get("critique", ""))
+
+    multiline = ('{"confidence": 0.5, "verdict": "Reject", "critique": "line one\n'
+                 'line two with "quoted" text"}')
+    v3 = parse(multiline)
+    ok &= _check("critique with literal newlines parses", v3.get("verdict") == "Reject")
+
+    # critique is NOT the last member -> the next-member anchor must be used
+    reordered = ('{"critique": "uses settings["A"] here", "confidence": 0.7, '
+                 '"verdict": "Approve"}')
+    v4 = parse(reordered)
+    ok &= _check("critique before other members still parses", v4.get("verdict") == "Approve")
+    ok &= _check("reordered critique preserved", 'settings["A"]' in v4.get("critique", ""))
+
+    # ── no-ops and non-regression ───────────────────────────────────────────
+    clean = '{"confidence": 1.0, "verdict": "Approve", "critique": "All good."}'
+    ok &= _check("already-valid JSON is unchanged", parse(clean)["critique"] == "All good.")
+    ok &= _check("relax() is a no-op on valid JSON",
+                 relax(clean, key_re=ns["_REVIEW_TEXT_KEY_RE"],
+                       next_member_re=ns["_REVIEW_NEXT_MEMBER_RE"],
+                       bracket_closes=False) == clean)
+
+    esc = '{"confidence": 0.9, "verdict": "Approve", "critique": "he said \\"hi\\" ok"}'
+    ok &= _check("correctly-escaped quotes survive",
+                 parse(esc)["critique"] == 'he said "hi" ok')
+
+    # the fix path must be untouched by the new parameters
+    fix_raw = '{"search": "logger.error("x")", "replace": "logger.warning("x")"}'
+    fixed = relax(fix_raw)
+    try:
+        fv = json.loads(fixed)
+        ok &= _check("fix-path default behaviour unchanged (search/replace repaired)",
+                     fv.get("search") == 'logger.error("x")')
+    except json.JSONDecodeError as e:
+        ok &= _check("fix-path default behaviour unchanged (search/replace repaired): %s" % e,
+                     False)
+
+    # unrepairable input must raise the ORIGINAL error for the caller's logging
+    try:
+        parse('{"confidence": 0.5, "verdict": ')
+        ok &= _check("unrepairable input raises JSONDecodeError", False)
+    except json.JSONDecodeError:
+        ok &= _check("unrepairable input raises JSONDecodeError", True)
+
+    print()
+    if ok:
+        print("ALL CASES PASSED")
+        return 0
+    print("ONE OR MORE CASES FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
Two independent defects, both found by reading the live logs and state on `LM-AB`.

## 1. One unescaped quote threw away an entire review

A critique quotes the code it is reviewing, so it contains raw double quotes (`settings["KEY"]`, `logger.error("...")`). `json.loads` ends the string at the first inner quote and fails. The reviewer path only ever called `_robust_json_loads`, so the reviewer was counted as **failed** and its panel slot burned — despite a complete, well-formed answer.

Confirmed in production (`/var/log/ab.log`, 2026-08-30 00:47:34) — a review that had already reached a verdict:

```
ERROR Reviewer (copilot) JSON parse failed (Expecting ',' delimiter: line 1 column 248)
raw: {"confidence": 0.93, "verdict": "Approve", "critique": "... the settings["GITHUB_TOKEN_configured"]/from_env lines are computed
```

Note this is **not** truncation and not a token limit — `max_tokens` is already 8192 on that path. The response was complete; char 247 is the `"` in `settings["`.

The fix path was hardened against exactly this (`_relax_json_fix_strings`); the reviewer path never got it. Rather than duplicate the logic it is parameterised by schema and reused through a new `_parse_reviewer_json`.

`bracket_closes=False` is load-bearing: the fix path treats a quote followed by `]` as a structural close, but in prose `settings["KEY"]` that is an inner quote and honouring it truncates the critique mid-word. A test asserts the fix-path default still fails on this input, so the parameter cannot be quietly dropped.

Unrepairable input still raises the **original** `JSONDecodeError`, so existing diagnostic logging is unchanged.

## 2. The PR list showed no target branch on 67 of 72 records

The badge renders only when a record carries `base_ref`. New reviews store it, but older records have neither `base_ref` nor `head_ref` — so a routine `dev` PR looked identical to one aimed at `main`.

`_backfill_pr_review_refs` fills the history from GitHub during the scan cycle:

- **bounded** to 25 records per cycle (one GET each) so it cannot starve real review work
- **idempotent and self-terminating** — once nothing is missing it costs an in-memory dict scan
- an **empty** `base_ref` is never written, so a record never renders a blank badge
- a failed fetch is skipped, not raised — a cosmetic backfill must not break a scan

No template change was needed; the badge already existed and was starved of data.

## Verification

- `test_reviewer_json_repair.py` — 16 assertions, incl. the exact production payload
- `test_pr_review_ref_backfill.py` — 18 assertions
- **6/6 mutations caught** (repair scoped to nothing; `]` treated as a close; empty-ref guard removed; limit ignored; filled records re-fetched; truncation dropped)
- Full suite **356 passed**