### PR TITLE
fix: replay why the last run failed into a retried issue

### DIFF
--- a/fix_engine.py
+++ b/fix_engine.py
@@ -295,6 +295,65 @@ def _regression_triage_context(repo_git, issue, prior_commit=None, prior_files=N
     )
 
 
+# Terminal failure kinds worth replaying to the builder. "review_rejected" and
+# "no_edits" both mean the previous RUN produced something concrete that was
+# judged wrong — that judgement is the single most useful input a retry can have.
+_REPLAYABLE_FAILURE_KINDS = ("review_rejected", "no_edits", "qa_failed", "error")
+
+
+def _prior_failure_context(issue_info):
+    """For an issue being re-run after a terminal failure: tell the builder WHY
+    the last run failed, so a retry does not repeat it.
+
+    error_context (the attempt-to-attempt feedback loop) is reset to None at the
+    start of every run, and the stored failure_detail was written to the record
+    for the UI but never read back. So a retry began completely blind: the model
+    re-derived the same wrong fix and the reviewers re-rejected it for the same
+    reason, burning all attempts again.
+
+    Observed on lbockenstedt/lm#452 and #487 — both rejected 3/3 because the fix
+    edited the wrong file/function, with the reviewer stating exactly where the
+    bug actually lived. That critique is sitting in the record; this feeds it
+    back.
+
+    Returns "" for anything not worth replaying (no prior failure, no detail, or
+    a failure kind that says nothing about the code), so the prompt is unchanged
+    on a first run."""
+    if not isinstance(issue_info, dict):
+        return ""
+    if (issue_info.get("status") or "") != "failed":
+        return ""
+    detail = str(issue_info.get("failure_detail") or "").strip()
+    kind = str(issue_info.get("failure_kind") or "").strip()
+    if not detail or kind not in _REPLAYABLE_FAILURE_KINDS:
+        return ""
+    attempts = issue_info.get("attempts")
+    try:
+        attempts = int(attempts)
+    except (TypeError, ValueError):
+        attempts = 0
+    conf = issue_info.get("failure_confidence")
+    try:
+        conf_txt = " (reviewer confidence %.0f%%)" % (float(conf) * 100)
+    except (TypeError, ValueError):
+        conf_txt = ""
+    lead = {
+        "review_rejected": "the skeptical reviewer panel REJECTED the fix",
+        "no_edits": "the builder returned JSON containing no applicable edits",
+        "qa_failed": "the fix failed QA verification",
+        "error": "the run errored out",
+    }.get(kind, "the run failed")
+    return (
+        "\n\n--- WHY THE PREVIOUS RUN FAILED (read this before proposing a fix) ---\n"
+        f"A previous AppBuilder run on this issue used {attempts or 'several'} attempt(s) "
+        f"and ended because {lead}{conf_txt}:\n"
+        f"{detail[:1000]}\n\n"
+        "Treat the above as a verified finding about the CODE, not as style feedback. "
+        "If it says the wrong file or function was changed, locate the one it names "
+        "before editing anything. Do not re-propose the same change."
+    )
+
+
 def _notify_bug_fixed(issue):
     """If a GitHub issue came from an LM 'File a Bug' report (hidden bug-report-id
     marker in the body), tell the hub the issue is fixed so the LM bug-reports UI
@@ -2431,6 +2490,17 @@ def process_single_issue(repo_name, issue_num, llm_preference=None):
                         logger.info(f"Added regression-triage context for reopened {issue_id}.")
                 except Exception as _re:  # noqa: BLE001
                     logger.debug(f"regression triage context skipped for {issue_id}: {_re}")
+
+            # Re-run after a terminal failure → replay the reason so the builder
+            # does not blindly re-derive the fix that was already rejected.
+            try:
+                _pf = _prior_failure_context(issue_info)
+                if _pf:
+                    fix_body += _pf
+                    logger.info("Added prior-failure context (%s) for retried %s.",
+                                issue_info.get("failure_kind"), issue_id)
+            except Exception as _pe:  # noqa: BLE001
+                logger.debug(f"prior failure context skipped for {issue_id}: {_pe}")
 
             for attempt in range(1, max_attempts + 1):
                 try:

--- a/test_prior_failure_context.py
+++ b/test_prior_failure_context.py
@@ -1,0 +1,125 @@
+"""Selftest for fix_engine._prior_failure_context.
+
+WHY: error_context (the attempt-to-attempt feedback inside one run) is reset to
+None at the start of every run, and the stored failure_detail was written to the
+record for the UI but never read back. A retry of a terminally-failed issue
+therefore began completely blind — the builder re-derived the same wrong fix and
+the reviewers re-rejected it for the same reason, burning all attempts again.
+
+Observed on lbockenstedt/lm#452 and #487: both rejected 3/3 because the fix
+edited the wrong file/function, with the reviewer stating exactly where the bug
+actually lived.
+
+fix_engine imports the app (circular at import time), so the pure helper is
+extracted with ast — the same harness pattern the other selftests use.
+"""
+import ast
+import re
+
+_WANT_FUNCS = {"_prior_failure_context"}
+_WANT_ASSIGNS = {"_REPLAYABLE_FAILURE_KINDS"}
+
+
+def _load():
+    tree = ast.parse(open("fix_engine.py").read())
+    ns = {"re": re}
+    mod = ast.Module(body=[], type_ignores=[])
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in _WANT_FUNCS:
+            mod.body.append(node)
+        elif isinstance(node, ast.Assign) and any(
+                getattr(t, "id", None) in _WANT_ASSIGNS for t in node.targets):
+            mod.body.append(node)
+    exec(compile(mod, "fix_engine_extract", "exec"), ns)
+    missing = sorted((_WANT_FUNCS | _WANT_ASSIGNS) - set(ns))
+    if missing:
+        raise AssertionError("extraction incomplete, missing: %s" % ", ".join(missing))
+    return ns
+
+
+def _check(label, cond):
+    print(("  PASS  " if cond else "  FAIL  ") + label)
+    return bool(cond)
+
+
+def main():
+    ns = _load()
+    ctx = ns["_prior_failure_context"]
+    ok = True
+    print("prior-failure replay into retries:")
+
+    # ── the real lm#487 record ─────────────────────────────────────────────
+    rec487 = {
+        "status": "failed",
+        "attempts": 3,
+        "failure_kind": "review_rejected",
+        "failure_confidence": 0.08333333333333333,
+        "failure_detail": ("[Reviewer (copilot)] The issue specifically occurs on the "
+                           "credvault view ('currentView: credvault') when clicking 'edit'. "
+                           "The proposed fix modifies the z-index in securityEventDetail(i)."),
+    }
+    out = ctx(rec487)
+    ok &= _check("a rejected run produces context", bool(out))
+    ok &= _check("the reviewer's finding is replayed verbatim",
+                 "securityEventDetail(i)" in out and "credvault" in out)
+    ok &= _check("attempt count is stated", "3 attempt(s)" in out)
+    ok &= _check("confidence is rendered as a percentage", "8%" in out)
+    ok &= _check("names the reviewer panel as the cause", "REJECTED" in out)
+    ok &= _check("instructs against repeating the change",
+                 "Do not re-propose the same change" in out)
+
+    # ── the real lm#486 record (a different failure kind) ───────────────────
+    rec486 = {
+        "status": "failed", "attempts": 3, "failure_kind": "no_edits",
+        "failure_detail": "The JSON parsed but contained no applicable changes.",
+    }
+    out486 = ctx(rec486)
+    ok &= _check("a no_edits run produces context", bool(out486))
+    ok &= _check("no_edits gets its own explanation",
+                 "no applicable edits" in out486)
+
+    # ── first runs and non-replayable states produce NOTHING ────────────────
+    ok &= _check("a fresh issue (no record) is unchanged", ctx({}) == "")
+    ok &= _check("None is handled", ctx(None) == "")
+    ok &= _check("a non-dict is handled", ctx("failed") == "")
+    ok &= _check("a fixed issue is unchanged",
+                 ctx({"status": "fixed", "failure_kind": "review_rejected",
+                      "failure_detail": "x"}) == "")
+    ok &= _check("awaiting_review is not replayed (the fix is still pending)",
+                 ctx({"status": "awaiting_review", "failure_kind": "review_rejected",
+                      "failure_detail": "x"}) == "")
+    ok &= _check("a failure with no detail is unchanged",
+                 ctx({"status": "failed", "failure_kind": "review_rejected",
+                      "failure_detail": ""}) == "")
+    ok &= _check("a whitespace-only detail is unchanged",
+                 ctx({"status": "failed", "failure_kind": "review_rejected",
+                      "failure_detail": "   \n "}) == "")
+    ok &= _check("an unknown failure kind is not replayed",
+                 ctx({"status": "failed", "failure_kind": "mystery",
+                      "failure_detail": "something"}) == "")
+
+    # ── robustness on malformed values ─────────────────────────────────────
+    weird = {"status": "failed", "failure_kind": "review_rejected",
+             "failure_detail": "d", "attempts": "lots", "failure_confidence": "nope"}
+    out_w = ctx(weird)
+    ok &= _check("non-numeric attempts/confidence do not raise", bool(out_w))
+    ok &= _check("non-numeric confidence is omitted rather than printed raw",
+                 "nope" not in out_w)
+    ok &= _check("non-numeric attempts falls back to prose", "several attempt(s)" in out_w)
+
+    # ── detail is bounded (records store up to 1000 chars) ─────────────────
+    big = {"status": "failed", "failure_kind": "review_rejected", "attempts": 1,
+           "failure_detail": "z" * 5000}
+    ok &= _check("an over-long detail is truncated", ctx(big).count("z") == 1000)
+
+    print()
+    if ok:
+        print("ALL CASES PASSED")
+        return 0
+    print("ONE OR MORE CASES FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
Retrying a terminally-failed issue started **completely blind**.

`error_context` — the attempt-to-attempt feedback loop — is reset to `None` at the start of every run, and the stored `failure_detail` was written to the record for the UI but **never read back**. So a retry re-derived the same wrong fix and the reviewers re-rejected it for the same reason, burning all three attempts again.

## The evidence (live records on LM-AB)

| issue | kind | confidence | reviewer said |
|---|---|---|---|
| `lm#452` | `review_rejected` | 21% (3/3) | "the bug report explicitly originates from `lm.self_update` in the LM Agent, but the proposed fix modifies `install_all.sh`" |
| `lm#487` | `review_rejected` | 8% (3/3) | "the issue specifically occurs on the credvault view when clicking edit; the proposed fix modifies the z-index in `securityEventDetail(i)`" |
| `lm#486` | `no_edits` | — (3/3) | "the JSON parsed but contained no applicable changes" |

In both rejections the reviewer had **already located the real bug** — and that finding was sitting unused in the record while the retry guessed again from zero.

## The change

`_prior_failure_context` feeds that finding back into the builder prompt, following the existing `_regression_triage_context` precedent for reopened issues (same placement, same fail-soft wrapper, same "do not re-solve from scratch" framing).

Deliberately narrow, so it cannot perturb a normal run:

- only for `status == "failed"` — `awaiting_review` still has a pending fix, and replaying a critique there would fight the normal review loop
- only for failure kinds that say something about the **code** (`review_rejected` / `no_edits` / `qa_failed` / `error`)
- returns `""` on anything else, so a **first runs prompt is byte-identical**
- detail bounded to the 1000 chars the record actually stores
- malformed `attempts`/`failure_confidence` degrade to prose instead of raising

## Verification

- `test_prior_failure_context.py` — 20 assertions, built from the **real** lm#452/#486/#487 records
- **5/5 mutations caught** (status guard removed; kind filter removed; truncation widened; empty-detail guard removed; confidence coercion unguarded)
- Full suite **357 passed**