### PR TITLE
Fix AB so it can fix wrong-file bugs: retry re-targeting + guaranteed second reviewer

### DIFF
--- a/fix_engine.py
+++ b/fix_engine.py
@@ -875,7 +875,67 @@ def _extract_error_symbols(issue_body):
     return out
 
 
-def identify_files_to_fix(repo_path, issue_body):
+def _extract_cited_paths(feedback, all_files):
+    """On a RETRY, pull the file paths a reviewer explicitly named out of the
+    previous attempt's feedback and map them to REAL repo files.
+
+    A skeptical reviewer that rejects a fix as "wrong file" almost always names
+    the correct location (e.g. "the real path is core/src/messaging/self_update.py:733"
+    or "target `self_update.py`"). That is the single strongest signal available on
+    a retry — stronger than re-deriving from the (unchanged) issue body, which is
+    exactly what produced the rejected guess in the first place. Without this the
+    next attempt re-identifies the identical wrong file every time and burns every
+    attempt on the same decoy (see AppBuilder's own lm#452 failure).
+
+    Matches full repo-relative paths (…/foo/bar.py, with an optional ':<line>'
+    suffix stripped) and, for a UNIQUE basename, bare filenames in prose/backticks
+    ("target `self_update.py`"). Returns an ordered, de-duplicated list of real
+    repo-relative paths; [] when nothing matches or feedback is empty."""
+    import re
+    if not feedback:
+        return []
+    text = str(feedback)
+    rel_set = set(all_files)
+    by_base = {}
+    for f in all_files:
+        by_base.setdefault(os.path.basename(f), []).append(f)
+
+    ordered = []
+    def _add(rel):
+        if rel and rel not in ordered:
+            ordered.append(rel)
+
+    # Full path-shaped tokens ('/'-containing, ending in a file extension); the
+    # ':<line>[:<col>]' a reviewer appends ("self_update.py:733") is not part of
+    # the regex-captured extension, so it is naturally excluded.
+    for m in re.finditer(r"([A-Za-z0-9_][\w./-]*/[\w./-]+\.[A-Za-z0-9]+)", text):
+        cand = m.group(1)
+        if cand in rel_set:
+            _add(cand)
+        else:
+            # Path cited relative to a subdir (or with an extra prefix) still
+            # resolves via a UNIQUE basename, so a full "core/src/messaging/
+            # self_update.py" maps to wherever the repo actually stores it.
+            hits = by_base.get(os.path.basename(cand), [])
+            if len(hits) == 1:
+                _add(hits[0])
+
+    # Bare filenames in prose or backticks — only when the basename is UNIQUE in
+    # the repo, so we never guess between two same-named files.
+    for m in re.finditer(r"[`'\"]?([A-Za-z0-9_][\w.-]*\.[A-Za-z0-9]+)[`'\"]?", text):
+        hits = by_base.get(os.path.basename(m.group(1)), [])
+        if len(hits) == 1:
+            _add(hits[0])
+    return ordered
+
+
+def identify_files_to_fix(repo_path, issue_body, error_context=None):
+    """error_context: the previous attempt's failure feedback (e.g. a reviewer's
+    "you edited the wrong file — the real path is X"). On a retry this both
+    ANCHORS the candidate list on any real repo file the reviewer cited (put
+    first, so the builder re-targets instead of re-editing the rejected decoy)
+    and is handed to the LLM guesser so even an uncited retry re-locates with the
+    reviewer's reasoning rather than re-deriving the same wrong guess."""
     logger.info("Identifying relevant files for fix...")
     all_files = []
     for root, _, files in os.walk(repo_path):
@@ -885,6 +945,21 @@ def identify_files_to_fix(repo_path, issue_body):
             if any(x in rel_path for x in [".git", "node_modules", "__pycache__", "venv", ".env"]):
                 continue
             all_files.append(rel_path)
+
+    # Reviewer-cited files lead on a retry (see _extract_cited_paths). Merged in
+    # front of every return path below via _lead(), de-duped, order preserved.
+    cited = _extract_cited_paths(error_context, all_files)
+    if cited:
+        logger.info("File identification: previous-attempt feedback cited existing file(s) "
+                    "→ re-targeting the fix, prioritising %s", ", ".join(cited[:5]))
+
+    def _lead(*groups):
+        out = []
+        for g in groups:
+            for f in (g or []):
+                if isinstance(f, str) and f not in out:
+                    out.append(f)
+        return out
 
     # Deterministic anchor: grep the repo for the exact symbols named in the issue
     # (e.g. "Can't find variable: ensureLDAPTennants") and rank those files FIRST —
@@ -908,12 +983,27 @@ def identify_files_to_fix(repo_path, issue_body):
         focused = symbol_hits[:3]
         logger.info("File identification: error symbol(s) %s → focusing the fix on %s",
                     error_symbols[:3], ", ".join(focused))
-        return focused
+        # cited leads even here: on a retry the error-symbol focus is the SAME
+        # guess the reviewer just rejected, so the reviewer-named file must win.
+        return _lead(cited, focused)
 
     file_list_str = "\n".join(all_files)
+    retry_hint = ""
+    if error_context:
+        # An uncited retry still benefits from the reviewer's reasoning: tell the
+        # guesser the last attempt was rejected and to locate the CORRECT file.
+        # Cap it — this is the SMALL file-id prompt, and a multi-reviewer critique
+        # can run to thousands of chars; the precise signal is already captured by
+        # _extract_cited_paths above, so a bounded excerpt is enough here.
+        retry_hint = (
+            "\nA previous fix attempt was REJECTED. Reviewer feedback follows — use it to "
+            "locate the CORRECT file to change; the last attempt very likely edited the "
+            f"WRONG file:\n{str(error_context)[:2000]}\n"
+        )
     prompt = (
         f"Issue Description: {issue_body}\n\n"
-        f"Repository File List:\n{file_list_str}\n\n"
+        f"Repository File List:\n{file_list_str}\n"
+        f"{retry_hint}\n"
         "Identify which files are most likely relevant to fixing this issue. "
         "Return ONLY a JSON array of file paths: [\"path/to/file1\", \"path/to/file2\"]"
     )
@@ -931,11 +1021,12 @@ def identify_files_to_fix(repo_path, issue_body):
         else:
             logger.error(f"Error identifying files: {e}")
         # A grep hit alone is still a usable answer even if the LLM leg failed.
-        return grep_hits
+        return _lead(cited, grep_hits)
 
-    # Merge: grep hits first (literal symbol location beats a guess), then any
-    # LLM-suggested files not already covered. De-duped, order preserved.
-    merged = list(grep_hits)
+    # Merge: reviewer-cited files first (retry re-targeting), then grep hits
+    # (literal symbol location beats a guess), then any LLM-suggested files not
+    # already covered. De-duped, order preserved.
+    merged = _lead(cited, grep_hits)
     for f in (llm_files or []):
         if isinstance(f, str) and f not in merged:
             merged.append(f)
@@ -1371,6 +1462,7 @@ def _ensure_review_checkout(repo_path, repo, head_sha, config):
 
 
 _REVIEW_PANEL_MAX = 4  # bounded like the largest configured pool this replaces (4 code slots)
+_REVIEW_PANEL_MIN = 2  # a lone reviewer is a single opinion; get a second whenever one exists
 
 
 def _select_review_panel(config, builder_n=None, builder_key=None, max_reviewers=_REVIEW_PANEL_MAX):
@@ -1381,6 +1473,13 @@ def _select_review_panel(config, builder_n=None, builder_key=None, max_reviewers
     excludes every prior pick (an accumulating exclude_models set), so the
     panel is naturally made of distinct models rather than requiring an
     operator to have configured a dedicated review pool.
+
+    Strong models (large-capability floor) are chosen first. If fewer than
+    _REVIEW_PANEL_MIN of them exist, the remaining slots are backfilled with
+    distinct models at a relaxed floor (medium, then any) so the panel still
+    delivers MULTIPLE opinions whenever more than one model is configured —
+    a lone reviewer's verdict would otherwise gate the fix unchecked. The
+    builder and already-picked models are never re-added.
 
     builder_key: the builder's already-resolved ModelKey (e.g. from
     apply_ai_fix's used_model_out=), excluded up front so the builder never
@@ -1430,6 +1529,31 @@ def _select_review_panel(config, builder_n=None, builder_key=None, max_reviewers
             break
         panel.append(matched)
         excluded.add(sel.key)
+
+    # Multiple opinions whenever possible: a single reviewer is one opinion, and
+    # the whole point of the panel is cross-checking — a lone strong model gives
+    # no second opinion and its verdict alone gates the fix. When fewer than
+    # _REVIEW_PANEL_MIN strong models exist but OTHER distinct (non-builder,
+    # not-yet-picked) models are configured, backfill the remaining slots at a
+    # relaxed capability floor (medium, then any) so at least a second reviewer
+    # weighs in. Strong models are always chosen FIRST above; this only ADDS
+    # weaker distinct reviewers to reach a second opinion, never displaces a
+    # strong one, and never re-adds the builder or a model already on the panel.
+    for fallback_complexity in ("medium", "small"):
+        while len(panel) < _REVIEW_PANEL_MIN:
+            reqs = LlmRequirements(complexity=fallback_complexity, needs_structured_output=True,
+                                   exclude_models=tuple(excluded))
+            sel = select_model(reqs, candidates, perf)
+            if sel is None:
+                break
+            matched = next((c for c in candidates if c["key"] == sel.key), None)
+            if matched is None:
+                break
+            logger.info("review panel: backfilling a second opinion at relaxed floor "
+                        "'%s' with %s (only %d strong reviewer(s) available)",
+                        fallback_complexity, sel.key, len(panel))
+            panel.append(matched)
+            excluded.add(sel.key)
     return panel
 
 
@@ -1902,7 +2026,7 @@ def apply_ai_fix(repo_path, issue_body, error_context=None, task_id=None, files_
     max_files = int(config.get("FIX_MAX_FILES", CHAT_CONFIG_DEFAULTS["FIX_MAX_FILES"]) or CHAT_CONFIG_DEFAULTS["FIX_MAX_FILES"])
     max_file_chars = int(config.get("FIX_MAX_FILE_CHARS", CHAT_CONFIG_DEFAULTS["FIX_MAX_FILE_CHARS"]) or CHAT_CONFIG_DEFAULTS["FIX_MAX_FILE_CHARS"])
     max_ctx_chars = int(config.get("FIX_MAX_CONTEXT_CHARS", CHAT_CONFIG_DEFAULTS["FIX_MAX_CONTEXT_CHARS"]) or CHAT_CONFIG_DEFAULTS["FIX_MAX_CONTEXT_CHARS"])
-    relevant_files = list(files_override) if files_override else identify_files_to_fix(repo_path, issue_body)
+    relevant_files = list(files_override) if files_override else identify_files_to_fix(repo_path, issue_body, error_context)
     if not relevant_files:
         logger.warning(f"No specific files identified for issue. Attempting general fix.")
     # Bound the prompt: cap file count, per-file chars, and total chars so the

--- a/test_fix_engine_reviewer_panel.py
+++ b/test_fix_engine_reviewer_panel.py
@@ -59,7 +59,7 @@ def _load_ns(want_funcs, extra_ns=None):
     want_assigns = {
         "_REVIEW_TOOLS", "_REVIEW_TOOL_MAX_ITER", "_REVIEW_TOOL_MAX_FILES",
         "_REVIEW_FILE_MAX_CHARS", "_REVIEWER_JSON_SCHEMA", "_DIFF_FILE_HEADER_RE",
-        "_REVIEW_PANEL_MAX",
+        "_REVIEW_PANEL_MAX", "_REVIEW_PANEL_MIN",
     }
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name in want_funcs:
@@ -148,6 +148,67 @@ def main():
     )
     ok &= _check("_select_review_panel: nothing configured -> []",
                 ns_panel_empty["_select_review_panel"]({}, builder_n=1) == [])
+
+    # ---- 1b. multiple opinions whenever possible (backfill at relaxed floor) ----
+    # Only ONE strong (large) non-builder model exists, but weaker distinct models
+    # are configured. The panel must still reach _REVIEW_PANEL_MIN by backfilling
+    # the weaker distinct models, so a lone reviewer never gates a fix unchecked.
+    def _cap_of(provider, model, max_complexity):
+        c = _candidate(provider, model)
+        c["caps"]["max_complexity"] = max_complexity
+        c["caps"]["cost_tier"] = "cheap"
+        return c
+
+    mixed = [
+        _cap_of("groq", "llama-70b", "large"),     # builder (slot 1) — excluded
+        _cap_of("anthropic", "claude-sonnet", "large"),  # the ONE strong reviewer
+        _cap_of("ollama", "qwen-7b", "medium"),    # weaker distinct model
+        _cap_of("local", "phi", "small"),          # weaker distinct model
+    ]
+
+    class _MixedLlmClient:
+        def _enumerate_candidates(self, config):
+            return list(mixed)
+        def get_llm_perf_snapshot(self):
+            return {}
+        def _model_key(self, provider, base_url, model):
+            return (provider, base_url, model)
+
+    ns_mixed = _load_ns(
+        {"_select_review_panel"},
+        {"llm_client": _MixedLlmClient(), "_get_provider_config": _get_provider_config,
+         "load_config": lambda: {}},
+    )
+    mixed_panel = ns_mixed["_select_review_panel"]({}, builder_n=1)
+    ok &= _check("_select_review_panel: backfills to >= _REVIEW_PANEL_MIN when only one strong model exists",
+                len(mixed_panel) >= ns_mixed["_REVIEW_PANEL_MIN"] >= 2)
+    ok &= _check("_select_review_panel: strong model is still chosen first",
+                bool(mixed_panel) and mixed_panel[0]["provider"] == "anthropic")
+    ok &= _check("_select_review_panel: backfill uses a distinct weaker model (not the builder, not a repeat)",
+                all(c["provider"] != "groq" for c in mixed_panel)
+                and len({c["provider"] for c in mixed_panel}) == len(mixed_panel))
+
+    # Genuinely only one non-builder model configured -> panel of 1 (backfill must
+    # NOT fabricate a second reviewer that doesn't exist).
+    solo = [_cap_of("groq", "llama-70b", "large"), _cap_of("anthropic", "claude-sonnet", "large")]
+
+    class _SoloLlmClient:
+        def _enumerate_candidates(self, config):
+            return list(solo)
+        def get_llm_perf_snapshot(self):
+            return {}
+        def _model_key(self, provider, base_url, model):
+            return (provider, base_url, model)
+
+    ns_solo = _load_ns(
+        {"_select_review_panel"},
+        {"llm_client": _SoloLlmClient(), "_get_provider_config": _get_provider_config,
+         "load_config": lambda: {}},
+    )
+    solo_panel = ns_solo["_select_review_panel"]({}, builder_n=1)
+    ok &= _check("_select_review_panel: only one non-builder model -> panel of 1 (no fabricated reviewer)",
+                len(solo_panel) == 1 and solo_panel[0]["provider"] == "anthropic")
+
 
     # ---- 2-6. _run_reviewer_turn ----
     def _make_turn_ns(try_candidate_stub, call_llm_stub):

--- a/test_fix_engine_triage_identify_requirements.py
+++ b/test_fix_engine_triage_identify_requirements.py
@@ -124,7 +124,9 @@ def main():
         # The real array extractor is pulled in rather than stubbed: it is the
         # thing that replaced the old greedy `\[.*\]` match, so stubbing it here
         # would hide a regression in exactly the code this test exercises.
-        {"identify_files_to_fix", "_first_json_array_of_strings", "_json_string_spans"},
+        # _extract_cited_paths is the retry re-targeting helper (case 3 below).
+        {"identify_files_to_fix", "_first_json_array_of_strings", "_json_string_spans",
+         "_extract_cited_paths"},
         {
             "call_llm": _capturing_call_llm2,
             "_robust_json_loads": json.loads,
@@ -155,6 +157,40 @@ def main():
                  reqs2 is not None and reqs2.min_context_tokens == len(captured3["prompt"]) // 4 > 0)
     ok &= _check("identify_files_to_fix: existing JSON-array parsing still returns the LLM's file list",
                  files == ["src/a.py", "src/b.py"])
+
+    # ---- 3. identify_files_to_fix RETRY re-targeting (site #2, error_context) ----
+    # On a retry, a reviewer's "wrong file — the real path is core/.../self_update.py"
+    # feedback must LEAD the candidate list so the next attempt re-targets instead of
+    # re-editing the rejected decoy. Reproduces the AppBuilder lm#452 failure mode.
+    ns3 = _load_fix_engine_ns(
+        {"identify_files_to_fix", "_first_json_array_of_strings", "_json_string_spans",
+         "_extract_cited_paths"},
+        {
+            # LLM still "guesses" the decoy the previous attempt already edited.
+            "call_llm": lambda *a, **k: '["install_all.sh"]',
+            "_robust_json_loads": json.loads,
+            "_extract_issue_identifiers": lambda body: [],
+            "_grep_files_for_identifiers": lambda repo_path, all_files, identifiers: [],
+            "_extract_error_symbols": lambda body: [],
+            "is_llm_cooldown_error": lambda e: False,
+        },
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        os.makedirs(os.path.join(tmp, "core", "src", "messaging"), exist_ok=True)
+        real = os.path.join("core", "src", "messaging", "self_update.py")
+        with open(os.path.join(tmp, real), "w") as f:
+            f.write("pass\n")
+        with open(os.path.join(tmp, "install_all.sh"), "w") as f:
+            f.write("echo hi\n")
+        critique = ("Reviewer rejected the fix: the patch edits install_all.sh but the real "
+                    "path is core/src/messaging/self_update.py:733 — target self_update.py.")
+        retry_files = ns3["identify_files_to_fix"](
+            tmp, "self-update git lock error", error_context=critique)
+
+    ok &= _check("identify_files_to_fix: reviewer-cited file LEADS on a retry (re-targeting)",
+                 bool(retry_files) and retry_files[0] == real)
+    ok &= _check("identify_files_to_fix: no error_context anchors nothing (unchanged behavior)",
+                 ns3["_extract_cited_paths"](None, [real]) == [])
 
     print()
     if ok:


### PR DESCRIPTION
## Problem

AppBuilder repeatedly failed to fix issues whose obvious-looking file is the **wrong** one. Concrete case: **lm#452** — the log names `lm.self_update` (`/opt/lm/.git/HEAD.lock`), but the fix runs kept patching `install_all.sh`. All 3 fix runs failed (2× "wrong file" rejections at ~21% confidence, then "AI returned no edits").

Two root causes:

### 1. File localization never self-corrected
`apply_ai_fix` re-ran `identify_files_to_fix(repo_path, issue_body)` on every retry, keyed off the **issue body only**. The reviewer critique ("wrong file — the real path is `core/src/messaging/self_update.py`") reached the *edit-generation* prompt but never the *file-identification* step — so each retry re-derived the identical wrong file and burned every attempt on the same decoy.

- **New `_extract_cited_paths()`** — pulls file paths a reviewer explicitly named out of the previous attempt's feedback and maps them to **real** repo files (full paths with `:line` stripped, plus unique basenames in prose/backticks).
- **`identify_files_to_fix()` now takes `error_context`** — reviewer-cited files **lead** the candidate list on a retry; the critique is also handed to the LLM guesser (capped at 2000 chars) so an uncited retry re-locates with the reviewer's reasoning. Attempt 1 (no context) is unchanged.
- **`apply_ai_fix()`** threads `error_context` through.

### 2. A single reviewer could gate a fix
`_select_review_panel` stopped as soon as strong (`large`) models ran out, so a repo with one strong model got a single opinion.

- Added **`_REVIEW_PANEL_MIN = 2`**. Strong models are still chosen first; remaining slots backfill with **distinct** models at a relaxed floor (`medium`, then any). Never displaces a strong model, re-adds the builder, or fabricates a reviewer that doesn't exist.

## Tests

Extended the two `fix_engine` self-tests (all cases pass):
- `identify_files_to_fix`: reviewer-cited file **leads** on a retry; no `error_context` anchors nothing (unchanged behavior).
- `_select_review_panel`: backfills to ≥ min when only one strong model exists; strong-first ordering preserved; solo non-builder model → panel of 1 (no fabrication).

## Scope / notes

- One repo (`ab`) only. No behavior change on the first attempt.
- Does **not** modify `self_update.py` — this makes AB *capable* of generating that fix; the fix to lm#452 itself is a separate PR AB (or a human) opens. Self-update remains a hard boundary, so any such fix still requires human merge, not auto-merge.
