### PR TITLE
Gate retry re-targeting on a wrong-file signal + pr_review_score self-improvement module

### DIFF
--- a/fix_engine.py
+++ b/fix_engine.py
@@ -875,7 +875,7 @@ def _extract_error_symbols(issue_body):
     return out
 
 
-def _extract_cited_paths(feedback, all_files):
+def _extract_cited_paths(feedback, all_files, avoid=None):
     """On a RETRY, pull the file paths a reviewer explicitly named out of the
     previous attempt's feedback and map them to REAL repo files.
 
@@ -887,6 +887,13 @@ def _extract_cited_paths(feedback, all_files):
     next attempt re-identifies the identical wrong file every time and burns every
     attempt on the same decoy (see AppBuilder's own lm#452 failure).
 
+    Reviewer text almost always names BOTH the rejected decoy and the correct
+    target ("edits install_all.sh but the real path is …/self_update.py"), and we
+    cannot reliably tell them apart by prose polarity. `avoid` is the set of files
+    the previous attempt ACTUALLY modified — i.e. the decoy(s) the reviewer just
+    rejected — and is excluded from the result, so a named-but-rejected file can
+    never lead the next attempt regardless of the phrasing order.
+
     Matches full repo-relative paths (…/foo/bar.py, with an optional ':<line>'
     suffix stripped) and, for a UNIQUE basename, bare filenames in prose/backticks
     ("target `self_update.py`"). Returns an ordered, de-duplicated list of real
@@ -896,13 +903,16 @@ def _extract_cited_paths(feedback, all_files):
         return []
     text = str(feedback)
     rel_set = set(all_files)
+    avoid_set = set(avoid or ())
     by_base = {}
     for f in all_files:
         by_base.setdefault(os.path.basename(f), []).append(f)
 
     ordered = []
     def _add(rel):
-        if rel and rel not in ordered:
+        # Never re-lead a file the previous attempt already modified: that is the
+        # decoy the reviewer rejected, and re-targeting it reintroduces the loop.
+        if rel and rel not in ordered and rel not in avoid_set:
             ordered.append(rel)
 
     # Full path-shaped tokens ('/'-containing, ending in a file extension); the
@@ -929,13 +939,22 @@ def _extract_cited_paths(feedback, all_files):
     return ordered
 
 
-def identify_files_to_fix(repo_path, issue_body, error_context=None):
-    """error_context: the previous attempt's failure feedback (e.g. a reviewer's
-    "you edited the wrong file — the real path is X"). On a retry this both
-    ANCHORS the candidate list on any real repo file the reviewer cited (put
-    first, so the builder re-targets instead of re-editing the rejected decoy)
-    and is handed to the LLM guesser so even an uncited retry re-locates with the
-    reviewer's reasoning rather than re-deriving the same wrong guess."""
+def identify_files_to_fix(repo_path, issue_body, error_context=None, retarget=False, avoid_paths=None):
+    """error_context: the previous attempt's failure feedback, handed to the LLM
+    guesser so a retry re-locates with the reviewer's reasoning rather than
+    re-deriving the same wrong guess.
+
+    retarget: an EXPLICIT wrong-file signal — True only when the previous attempt
+    was rejected by REVIEW (the sole failure state whose feedback can name a
+    different correct location). Every other retry kind (invalid/truncated JSON,
+    missed edit anchors, no edits, failed tests, low confidence) failed while the
+    TARGET file was correct, so re-targeting would steer AWAY from it. When
+    retarget is False we neither anchor on cited paths nor tell the guesser to
+    relocate — the file the last attempt aimed at is kept.
+
+    avoid_paths: files the previous attempt ACTUALLY modified (the rejected
+    decoys). Excluded from the reviewer-cited anchor so a named-but-rejected file
+    can never lead the retry."""
     logger.info("Identifying relevant files for fix...")
     all_files = []
     for root, _, files in os.walk(repo_path):
@@ -946,11 +965,14 @@ def identify_files_to_fix(repo_path, issue_body, error_context=None):
                 continue
             all_files.append(rel_path)
 
-    # Reviewer-cited files lead on a retry (see _extract_cited_paths). Merged in
-    # front of every return path below via _lead(), de-duped, order preserved.
-    cited = _extract_cited_paths(error_context, all_files)
+    # Reviewer-cited files lead ONLY on an explicit wrong-file signal (retarget) —
+    # a review rejection. For all other failure kinds the last target was correct,
+    # so cited stays empty and the existing candidate ordering is preserved. Any
+    # file the previous attempt modified (avoid_paths) is excluded so a rejected
+    # decoy can never lead. Merged in front of every return path below via _lead().
+    cited = _extract_cited_paths(error_context, all_files, avoid=avoid_paths) if retarget else []
     if cited:
-        logger.info("File identification: previous-attempt feedback cited existing file(s) "
+        logger.info("File identification: review rejection cited existing file(s) "
                     "→ re-targeting the fix, prioritising %s", ", ".join(cited[:5]))
 
     def _lead(*groups):
@@ -989,16 +1011,27 @@ def identify_files_to_fix(repo_path, issue_body, error_context=None):
 
     file_list_str = "\n".join(all_files)
     retry_hint = ""
-    if error_context:
-        # An uncited retry still benefits from the reviewer's reasoning: tell the
-        # guesser the last attempt was rejected and to locate the CORRECT file.
-        # Cap it — this is the SMALL file-id prompt, and a multi-reviewer critique
-        # can run to thousands of chars; the precise signal is already captured by
-        # _extract_cited_paths above, so a bounded excerpt is enough here.
+    if error_context and retarget:
+        # Wrong-file signal (review rejection): the reviewer MAY name a different
+        # correct location. Ask the guesser to prefer a cited file if present, but
+        # do NOT assert the last file was wrong — a rejection is often about the
+        # edit's content, not its location — so it can legitimately keep the same
+        # target. Cap it: this is the SMALL file-id prompt and the precise signal
+        # is already captured by _extract_cited_paths above.
         retry_hint = (
-            "\nA previous fix attempt was REJECTED. Reviewer feedback follows — use it to "
-            "locate the CORRECT file to change; the last attempt very likely edited the "
-            f"WRONG file:\n{str(error_context)[:2000]}\n"
+            "\nA previous fix attempt was REJECTED BY REVIEW. Reviewer feedback follows. If it "
+            "names a specific file as the correct location, target THAT file; otherwise keep the "
+            "same target file and address the critique — do NOT relocate to an unrelated file:\n"
+            f"{str(error_context)[:2000]}\n"
+        )
+    elif error_context:
+        # Non-review failure (bad/truncated JSON, missed anchors, no edits, failed
+        # tests, low confidence): the target file was NOT wrong. Keep the same
+        # file(s); the fault was in the edit, not its location.
+        retry_hint = (
+            "\nA previous fix attempt for the SAME file(s) failed for the reason below. The target "
+            "file was NOT wrong — do not switch files; produce a corrected fix for the same "
+            f"location:\n{str(error_context)[:2000]}\n"
         )
     prompt = (
         f"Issue Description: {issue_body}\n\n"
@@ -2008,7 +2041,7 @@ def _targeted_file_context(content, identifiers, max_chars, window=60, max_hits_
     return "\n".join(parts) if parts else None
 
 
-def apply_ai_fix(repo_path, issue_body, error_context=None, task_id=None, files_override=None, requirements=None, used_model_out=None):
+def apply_ai_fix(repo_path, issue_body, error_context=None, task_id=None, files_override=None, requirements=None, used_model_out=None, retarget=False, avoid_paths=None):
     """files_override: skip the identify_files_to_fix guess and target exactly
     these repo-relative paths instead — for callers (pr_review's fix_one_pr)
     that already know precisely which files are at issue (a PR's own changed-
@@ -2026,7 +2059,7 @@ def apply_ai_fix(repo_path, issue_body, error_context=None, task_id=None, files_
     max_files = int(config.get("FIX_MAX_FILES", CHAT_CONFIG_DEFAULTS["FIX_MAX_FILES"]) or CHAT_CONFIG_DEFAULTS["FIX_MAX_FILES"])
     max_file_chars = int(config.get("FIX_MAX_FILE_CHARS", CHAT_CONFIG_DEFAULTS["FIX_MAX_FILE_CHARS"]) or CHAT_CONFIG_DEFAULTS["FIX_MAX_FILE_CHARS"])
     max_ctx_chars = int(config.get("FIX_MAX_CONTEXT_CHARS", CHAT_CONFIG_DEFAULTS["FIX_MAX_CONTEXT_CHARS"]) or CHAT_CONFIG_DEFAULTS["FIX_MAX_CONTEXT_CHARS"])
-    relevant_files = list(files_override) if files_override else identify_files_to_fix(repo_path, issue_body, error_context)
+    relevant_files = list(files_override) if files_override else identify_files_to_fix(repo_path, issue_body, error_context, retarget=retarget, avoid_paths=avoid_paths)
     if not relevant_files:
         logger.warning(f"No specific files identified for issue. Attempting general fix.")
     # Bound the prompt: cap file count, per-file chars, and total chars so the
@@ -2790,6 +2823,10 @@ def process_single_issue(repo_name, issue_num, llm_preference=None):
             built_key = None
             success = False
             error_context = None
+            # Files the previous attempt actually modified — the decoys a review
+            # rejection may re-name. Passed as avoid_paths so a rejected file can
+            # never lead the re-targeted retry.
+            modified_paths = set()
             # WHY the last attempt failed, structured. error_context is written for
             # the NEXT builder prompt, so it is phrased as instructions to a model
             # and gets buried behind boilerplate by the time it reaches the UI.
@@ -2866,7 +2903,9 @@ def process_single_issue(repo_name, issue_num, llm_preference=None):
                             processed[issue_id]["status"] = "processing"
                             save_processed(processed)
                     elif not pending_fix:
-                        fix_code = apply_ai_fix(path, fix_body, error_context, task_id=issue_id, requirements=reqs, used_model_out=used_model_out)
+                        fix_code = apply_ai_fix(path, fix_body, error_context, task_id=issue_id, requirements=reqs, used_model_out=used_model_out,
+                                                retarget=(last_failure.get("kind") == "review_rejected"),
+                                                avoid_paths=sorted(modified_paths))
                         success_applied, fixes, confidence = parse_and_apply(fix_code, path)
                     built_key = used_model_out.get("key")
 
@@ -2957,6 +2996,14 @@ def process_single_issue(repo_name, issue_num, llm_preference=None):
                             if review_verdict == "Reject":
                                 logger.warning(f"Reviewer REJECTED fix for {issue_id}: {critique}")
                                 error_context = f"Reviewer rejected the fix: {critique}"
+                                # Record the files this rejected attempt modified so
+                                # the re-targeted retry excludes them (never re-lead
+                                # a decoy the reviewer just rejected).
+                                try:
+                                    if isinstance(fixes, dict):
+                                        modified_paths.update(fixes.keys())
+                                except Exception:  # noqa: BLE001
+                                    pass
                                 last_failure = {
                                     "kind": "review_rejected",
                                     "detail": str(critique or "").strip(),

--- a/pr_review.py
+++ b/pr_review.py
@@ -1389,7 +1389,20 @@ def fix_one_pr(repo_full_name, number, config=None):
 
         rec = (state.get("pr_reviews") or {}).get("%s#%s" % (repo_full_name, number)) or {}
         panel_critique = (rec.get("panel_critique") or "").strip()
-        if not findings and not panel_critique:
+
+        # Self-improvement: also read the pre-review AB actually POSTED on this PR
+        # and fold every below-target panel's dissent into the fix prompt. This
+        # survives a restart (where in-memory `state` lost panel_critique) and
+        # targets exactly the panels that lowered the score. See pr_review_score.
+        score_feedback = ""
+        try:
+            import pr_review_score
+            _report, _body = pr_review_score.read_pr_review(pr)
+            score_feedback = pr_review_score.dissent_feedback(_report, _body).strip()
+        except Exception as e:  # noqa: BLE001
+            logger.debug("fix_one_pr: pre-review score read skipped: %s", e)
+
+        if not findings and not panel_critique and not score_feedback:
             return False, "No findings to fix — this PR has a clean pre-review."
 
         lines = ["PR #%s: %s" % (pr.number, pr.title or "")]
@@ -1402,6 +1415,8 @@ def fix_one_pr(repo_full_name, number, config=None):
                     (f.get("level") or "advisory").upper(), f.get("title") or "", f.get("detail") or ""))
         if panel_critique:
             lines.append("\nSkeptical reviewer critique (from the last panel pass):\n" + panel_critique)
+        if score_feedback:
+            lines.append("\n" + score_feedback)
         fix_body = "\n".join(lines)
 
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/pr_review_score.py
+++ b/pr_review_score.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Read, score, and act on AppBuilder's own PR pre-review comment.
+
+AppBuilder posts an automated skeptical-panel pre-review on every PR (see
+pr_review.py, marker ``<!-- ab-pr-review -->``). Each advisory panel — the
+general "Skeptical review" and the narrow "State-logic / control-flow review" —
+reports a ``panel confidence`` and per-reviewer verdicts. The composite score a
+human reads is only as good as the WEAKEST panel, and the actionable signal is
+the set of reviewers that did NOT approve.
+
+This module is the repeatable driver for the "improve the review score" loop. It
+is used two ways:
+
+1. **Programmatically, so AppBuilder can improve ITSELF.** `read_pr_review(pr)`
+   parses the pre-review AB posted on its own PR, and `dissent_feedback(...)`
+   turns every below-target panel and dissenting reviewer into concise, actionable
+   retry guidance. `pr_review.fix_one_pr` folds that back into the next fix
+   attempt's prompt, so a low score on AB's own PR drives AB's own next revision.
+
+2. **From the CLI, for a human running the loop by hand** — see `main()` /
+   ``python3 pr_review_score.py 152``: report every panel's confidence and every
+   dissenting concern so the next change targets exactly what lowered the score.
+
+CLI usage:
+    python3 pr_review_score.py 152                 # report latest review on PR 152
+    python3 pr_review_score.py 152 --json          # machine-readable
+    python3 pr_review_score.py 152 --watch         # wait for a review of the CURRENT head, then report
+    python3 pr_review_score.py 152 --min 90        # exit non-zero if any panel < 90%
+
+CLI exit code is 0 when every panel is >= --min (default 90) AND no reviewer
+dissents; 1 otherwise (2 on operational error) — so it slots into a CI gate or a
+scripted iterate-until-green loop. The CLI depends only on the `gh` CLI (already
+required by this repo); the programmatic API takes a PyGithub PR and needs no gh.
+"""
+import argparse
+import json
+import logging
+import re
+import subprocess
+import sys
+import time
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REPO = "lbockenstedt/ab"
+# Mirrors pr_review.PR_REVIEW_MARKER — resolved lazily via _marker() to stay in
+# lockstep without a top-level import cycle (pr_review imports this module).
+_MARKER_FALLBACK = "<!-- ab-pr-review -->"
+
+# Anchors kept in sync with pr_review.py's renderer (_render_* / _PANEL_HEADER).
+_HEAD_RE = re.compile(r"<!--\s*head:\s*([0-9a-f]{7,40})\s*-->")
+_PANEL_HEADER_RE = re.compile(r"^###\s+.*review \(panel\)\s*$", re.MULTILINE)
+_RECO_RE = re.compile(
+    r"\*\*Recommendation:\s*(?P<verdict>[A-Z]+)\*\*\s*·\s*panel confidence\s*\*\*(?P<pct>\d+)%\*\*")
+_REVIEWER_RE = re.compile(
+    r"\*\*(?P<name>[^*]+?)\*\*\s*—\s*\S+\s*(?P<verdict>Approve|Reject|Deny)\s*·\s*confidence\s*(?P<pct>\d+)%",
+    re.IGNORECASE)
+
+
+def _marker():
+    """The pre-review marker, sourced from pr_review when importable."""
+    try:
+        from pr_review import PR_REVIEW_MARKER
+        return PR_REVIEW_MARKER
+    except Exception:  # noqa: BLE001 — CLI/standalone use without the full app
+        return _MARKER_FALLBACK
+
+
+def _gh_json(repo, pr, fields):
+    """Return `gh pr view` JSON for the given fields, or raise RuntimeError."""
+    try:
+        out = subprocess.run(
+            ["gh", "pr", "view", str(pr), "--repo", repo, "--json", fields],
+            capture_output=True, text=True, check=True).stdout
+    except FileNotFoundError:
+        raise RuntimeError("gh CLI not found on PATH")
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError((e.stderr or e.stdout or "gh pr view failed").strip())
+    return json.loads(out)
+
+
+def _latest_review_comment(comments):
+    """The most recent AppBuilder pre-review comment body, or None.
+
+    `comments` is an iterable of objects/dicts exposing a comment body — either
+    `gh` JSON dicts ({"body": ...}) or PyGithub IssueComment objects (.body).
+    """
+    marker = _marker()
+    hits = []
+    for c in comments:
+        body = c.get("body") if isinstance(c, dict) else getattr(c, "body", None)
+        if body and marker in body:
+            hits.append(body)
+    # oldest-first from both gh and PyGithub; the last marker comment is current.
+    return hits[-1] if hits else None
+
+
+def _section_bounds(body):
+    """Yield (title_line, start, end) for each panel section in the comment."""
+    starts = [m.start() for m in _PANEL_HEADER_RE.finditer(body)]
+    for i, s in enumerate(starts):
+        end = starts[i + 1] if i + 1 < len(starts) else len(body)
+        title = body[s:body.find("\n", s) if body.find("\n", s) != -1 else len(body)].strip("# ").strip()
+        yield title, s, end
+
+
+def parse_review(body):
+    """Parse a pre-review comment body into a structured score report."""
+    head = None
+    m = _HEAD_RE.search(body)
+    if m:
+        head = m.group(1)
+
+    panels = []
+    for title, s, e in _section_bounds(body):
+        seg = body[s:e]
+        reco = _RECO_RE.search(seg)
+        reviewers = []
+        for rm in _REVIEWER_RE.finditer(seg):
+            verdict = rm.group("verdict").title()
+            reviewers.append({
+                "name": rm.group("name").strip(),
+                "verdict": "Reject" if verdict in ("Reject", "Deny") else "Approve",
+                "confidence": int(rm.group("pct")),
+            })
+        panels.append({
+            "panel": title,
+            "verdict": (reco.group("verdict") if reco else None),
+            "confidence": (int(reco.group("pct")) if reco else None),
+            "reviewers": reviewers,
+            "dissenting": [r for r in reviewers if r["verdict"] != "Approve"],
+        })
+
+    scored = [p["confidence"] for p in panels if p["confidence"] is not None]
+    return {
+        "head": head,
+        "panels": panels,
+        "composite": (min(scored) if scored else None),
+        "any_dissent": any(p["dissenting"] for p in panels),
+    }
+
+
+def _concern_snippets(body, panel_title):
+    """Pull the dissenting-reviewer critique bullets for a panel (for humans)."""
+    for title, s, e in _section_bounds(body):
+        if title != panel_title:
+            continue
+        seg = body[s:e]
+        # Everything under a "Reviewer (…) — 🔴 Reject" block, first ~600 chars.
+        out = []
+        for rm in _REVIEWER_RE.finditer(seg):
+            if rm.group("verdict").title() in ("Reject", "Deny"):
+                tail = seg[rm.end():]
+                nxt = _REVIEWER_RE.search(tail)
+                block = tail[:nxt.start()] if nxt else tail
+                block = block.strip().strip("-").strip()
+                if block:
+                    out.append(block[:600].rstrip())
+        return out
+    return []
+
+
+# ── programmatic API: let AppBuilder read + act on its own review ──────────────
+
+def read_pr_review(pr):
+    """Parse the pre-review AppBuilder posted on a PyGithub PR.
+
+    Returns (report, body) where report is the parse_review() dict and body is
+    the raw comment markdown (needed by dissent_feedback for the critique text),
+    or (None, None) when AB has not posted a pre-review on this PR yet.
+    """
+    try:
+        comments = list(pr.get_issue_comments())
+    except Exception as e:  # noqa: BLE001
+        logger.debug("read_pr_review: could not list comments: %s", e)
+        return None, None
+    body = _latest_review_comment(comments)
+    if not body:
+        return None, None
+    return parse_review(body), body
+
+
+def dissent_feedback(report, body, min_pct=90):
+    """Turn a parsed review into actionable retry guidance for the fix engine.
+
+    Emits one bullet per panel that fell below `min_pct` OR carried a dissenting
+    reviewer, quoting that reviewer's concern. This is what closes AppBuilder's
+    self-improvement loop: fed back into the next fix attempt's prompt (see
+    pr_review.fix_one_pr), it points the builder at exactly what lowered the
+    score. Returns "" when every panel is at/above target with no dissent.
+    """
+    if not report:
+        return ""
+    lines = []
+    for p in report.get("panels", []):
+        conf = p.get("confidence")
+        below = conf is not None and conf < min_pct
+        if not below and not p.get("dissenting"):
+            continue
+        head = "%s — panel confidence %s%s" % (
+            p.get("panel") or "panel",
+            ("%d%%" % conf) if conf is not None else "n/a",
+            " (below %d%% target)" % min_pct if below else "")
+        lines.append("- " + head)
+        for snip in (_concern_snippets(body, p.get("panel")) if body else []):
+            first = " ".join(snip.split())
+            lines.append("    • " + first[:500])
+    if not lines:
+        return ""
+    return ("The AppBuilder pre-review scored below target. Address these panel "
+            "concerns so the next revision raises the score:\n" + "\n".join(lines))
+
+
+def render_human(report, body, min_pct):
+    lines = []
+    comp = report["composite"]
+    comp_s = f"{comp}%" if comp is not None else "n/a"
+    head_s = (report["head"] or "?")[:12]
+    lines.append(f"Composite (weakest panel): {comp_s}   head={head_s}")
+    lines.append("")
+    for p in report["panels"]:
+        conf = f"{p['confidence']}%" if p["confidence"] is not None else "n/a"
+        flag = ""
+        if p["confidence"] is not None and p["confidence"] < min_pct:
+            flag = "  ⬇ below threshold"
+        elif p["dissenting"]:
+            flag = "  ⚠ dissent"
+        lines.append(f"• {p['panel']}: {conf} ({p['verdict'] or '?'}){flag}")
+        for r in p["reviewers"]:
+            mark = "✓" if r["verdict"] == "Approve" else "✗"
+            lines.append(f"    {mark} {r['name']}: {r['verdict']} {r['confidence']}%")
+        for snip in _concern_snippets(body, p["panel"]):
+            first = snip.splitlines()[0]
+            lines.append(f"      ↳ {first[:200]}")
+    return "\n".join(lines)
+
+
+def fetch_report(repo, pr, want_head=None, watch=False, timeout=600, interval=20):
+    """Fetch (optionally waiting for a review of `want_head`) and parse the review."""
+    deadline = time.time() + timeout
+    while True:
+        data = _gh_json(repo, pr, "comments,headRefOid")
+        head_oid = data.get("headRefOid")
+        target = want_head or head_oid
+        body = _latest_review_comment(data.get("comments") or [])
+        if body:
+            report = parse_review(body)
+            fresh = (not watch) or (report.get("head") and target
+                                    and report["head"].startswith(target[:len(report["head"])]) or
+                                    (target and report.get("head") and target.startswith(report["head"])))
+            if fresh:
+                return report, body, head_oid
+        if not watch or time.time() >= deadline:
+            if body:
+                return parse_review(body), body, head_oid
+            return None, None, head_oid
+        print(f"… waiting for AppBuilder review of {(target or '')[:12]} "
+              f"({int(deadline - time.time())}s left)", file=sys.stderr)
+        time.sleep(interval)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("pr", help="PR number")
+    ap.add_argument("--repo", default=DEFAULT_REPO, help=f"owner/name (default {DEFAULT_REPO})")
+    ap.add_argument("--min", type=int, default=90, help="min per-panel confidence to pass (default 90)")
+    ap.add_argument("--json", action="store_true", dest="as_json", help="machine-readable output")
+    ap.add_argument("--watch", action="store_true",
+                    help="wait for a review of the PR's CURRENT head, then report")
+    ap.add_argument("--timeout", type=int, default=600, help="--watch timeout seconds (default 600)")
+    args = ap.parse_args(argv)
+
+    try:
+        report, body, head_oid = fetch_report(
+            args.repo, args.pr, watch=args.watch, timeout=args.timeout)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    if report is None:
+        print(f"error: no AppBuilder pre-review comment found on {args.repo}#{args.pr}",
+              file=sys.stderr)
+        return 2
+
+    stale = bool(head_oid and report.get("head")
+                 and not (head_oid.startswith(report["head"]) or report["head"].startswith(head_oid)))
+
+    if args.as_json:
+        print(json.dumps({**report, "repo": args.repo, "pr": args.pr,
+                          "current_head": head_oid, "stale": stale, "min": args.min}, indent=2))
+    else:
+        print(render_human(report, body, args.min))
+        if stale:
+            print(f"\n⚠ review is for {report['head'][:12]}, PR head is now "
+                  f"{(head_oid or '')[:12]} — push landed, re-review pending.")
+
+    comp = report["composite"]
+    passed = (comp is not None and comp >= args.min
+              and all((p["confidence"] or 0) >= args.min for p in report["panels"])
+              and not report["any_dissent"])
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_fix_engine_triage_identify_requirements.py
+++ b/test_fix_engine_triage_identify_requirements.py
@@ -159,9 +159,13 @@ def main():
                  files == ["src/a.py", "src/b.py"])
 
     # ---- 3. identify_files_to_fix RETRY re-targeting (site #2, error_context) ----
-    # On a retry, a reviewer's "wrong file — the real path is core/.../self_update.py"
-    # feedback must LEAD the candidate list so the next attempt re-targets instead of
-    # re-editing the rejected decoy. Reproduces the AppBuilder lm#452 failure mode.
+    # On a REVIEW-REJECTION retry (retarget=True), a reviewer's "wrong file — the
+    # real path is core/.../self_update.py" feedback must LEAD the candidate list
+    # so the next attempt re-targets instead of re-editing the rejected decoy.
+    # Reproduces the AppBuilder lm#452 failure mode. Non-review failures must NOT
+    # re-target (the target file was correct), and a decoy the previous attempt
+    # actually modified (avoid_paths) must never lead even when the reviewer names
+    # it — this is the state-conflation fix from PR #152's review.
     ns3 = _load_fix_engine_ns(
         {"identify_files_to_fix", "_first_json_array_of_strings", "_json_string_spans",
          "_extract_cited_paths"},
@@ -184,13 +188,34 @@ def main():
             f.write("echo hi\n")
         critique = ("Reviewer rejected the fix: the patch edits install_all.sh but the real "
                     "path is core/src/messaging/self_update.py:733 — target self_update.py.")
+        # (a) review rejection → re-target: cited correct file leads.
         retry_files = ns3["identify_files_to_fix"](
-            tmp, "self-update git lock error", error_context=critique)
+            tmp, "self-update git lock error", error_context=critique, retarget=True)
+        # (b) non-review failure (retarget=False, the default) → do NOT re-target:
+        # the target file was correct, so cited is suppressed and the LLM's same
+        # guess is kept (no relocation to the reviewer-named file).
+        nonreview = ns3["identify_files_to_fix"](
+            tmp, "self-update git lock error",
+            error_context="AI generated invalid JSON format")
+        # (c) bare-name phrasing names the decoy FIRST; excluding the file the
+        # previous attempt modified (avoid_paths) still makes the correct file lead.
+        bare = ("Reviewer rejected the fix: install_all.sh is not where the bug is; "
+                "edit self_update.py instead.")
+        retarget_avoided = ns3["identify_files_to_fix"](
+            tmp, "self-update git lock error", error_context=bare,
+            retarget=True, avoid_paths=["install_all.sh"])
 
-    ok &= _check("identify_files_to_fix: reviewer-cited file LEADS on a retry (re-targeting)",
+    ok &= _check("identify_files_to_fix: reviewer-cited file LEADS on a review-rejection retry",
                  bool(retry_files) and retry_files[0] == real)
+    ok &= _check("identify_files_to_fix: non-review failure does NOT re-target (keeps target file)",
+                 bool(nonreview) and nonreview[0] == "install_all.sh" and real not in nonreview[:1])
+    ok &= _check("identify_files_to_fix: avoid_paths keeps a rejected decoy from leading",
+                 bool(retarget_avoided) and retarget_avoided[0] == real)
     ok &= _check("identify_files_to_fix: no error_context anchors nothing (unchanged behavior)",
                  ns3["_extract_cited_paths"](None, [real]) == [])
+    ok &= _check("_extract_cited_paths: avoid= excludes a previously-modified decoy",
+                 "install_all.sh" not in ns3["_extract_cited_paths"](
+                     critique, [real, "install_all.sh"], avoid=["install_all.sh"]))
 
     print()
     if ok:

--- a/test_pr_review_score.py
+++ b/test_pr_review_score.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Self-test for pr_review_score — the module AppBuilder uses to read and act on
+its own PR pre-review.
+
+Unlike most fix_engine self-tests, pr_review_score imports cleanly (no circular
+main.py chain), so this imports it directly. Covers the pure parser and the
+self-improvement feeder (dissent_feedback) against a rendered pre-review body in
+the exact shape pr_review.py emits — including the mixed panel where one panel is
+strong (APPROVE, high confidence) and the other carries a dissenting reviewer.
+Run: python3 test_pr_review_score.py
+"""
+import sys
+
+import pr_review_score as prs
+
+# A trimmed but format-faithful pre-review body (see pr_review._render_panel /
+# _render_state_panel). Panel 1 is clean; panel 2 has a 40% Reject → dissent.
+SAMPLE = """<!-- ab-pr-review -->
+<!-- head: 9f0d19f88196c460595c4434ec1b737a1d16b166 -->
+## 🤖 AppBuilder PR pre-review
+
+### 🧠 Skeptical review (panel)
+
+🟢 **Recommendation: APPROVE** · panel confidence **94%**
+
+#### Reviewer detail
+
+**Reviewer (copilot)** — 🟢 Approve · confidence 95%
+
+The changes correctly and safely address both issues.
+
+**Reviewer (copilot)** — 🟢 Approve · confidence 92%
+
+Logic is sound; tests are thorough.
+
+### 🔀 State-logic / control-flow review (panel)
+
+🟢 **Recommendation: APPROVE** · panel confidence **77%**
+
+#### ⚠️ Concerns (1 of 3 reviewers did not approve)
+
+- 🔴 **Reviewer (copilot)** (40%) — STATE CONFLATION in error_context.
+
+#### Reviewer detail
+
+**Reviewer (copilot)** — 🟢 Approve · confidence 98%
+
+No state/status coverage defects found.
+
+**Reviewer (copilot)** — 🔴 Reject · confidence 40%
+
+STATE CONFLATION — error_context conflates five distinct failure states and
+unconditionally asserts the last attempt edited the WRONG file.
+
+**Reviewer (copilot)** — 🟢 Approve · confidence 92%
+
+Well-scoped defensive change.
+"""
+
+
+def _check(name, cond):
+    print("  [%s] %s" % ("PASS" if cond else "FAIL", name))
+    return bool(cond)
+
+
+class _FakeComment:
+    def __init__(self, body):
+        self.body = body
+
+
+class _FakePR:
+    def __init__(self, comments):
+        self._c = comments
+
+    def get_issue_comments(self):
+        return list(self._c)
+
+
+def main():
+    ok = True
+    report = prs.parse_review(SAMPLE)
+
+    ok &= _check("parse: head sha captured",
+                 report["head"] == "9f0d19f88196c460595c4434ec1b737a1d16b166")
+    ok &= _check("parse: two panels found", len(report["panels"]) == 2)
+    ok &= _check("parse: composite is the WEAKEST panel (77)", report["composite"] == 77)
+    ok &= _check("parse: general panel 94% / APPROVE",
+                 report["panels"][0]["confidence"] == 94 and report["panels"][0]["verdict"] == "APPROVE")
+    ok &= _check("parse: state-logic panel has one dissenting reviewer (40%)",
+                 len(report["panels"][1]["dissenting"]) == 1
+                 and report["panels"][1]["dissenting"][0]["confidence"] == 40)
+    ok &= _check("parse: any_dissent True", report["any_dissent"] is True)
+
+    fb = prs.dissent_feedback(report, SAMPLE, min_pct=90)
+    ok &= _check("dissent_feedback: names the below-target state-logic panel",
+                 "State-logic" in fb and "77%" in fb)
+    ok &= _check("dissent_feedback: quotes the dissenting reviewer's concern",
+                 "STATE CONFLATION" in fb)
+    ok &= _check("dissent_feedback: omits the clean 94% panel from the ask",
+                 "Skeptical review (panel) — panel confidence 94%" not in fb)
+
+    # A clean review yields no feedback (nothing to fix → loop terminates).
+    clean = SAMPLE.replace("**77%**", "**96%**").replace(
+        "**Reviewer (copilot)** — 🔴 Reject · confidence 40%", "**Reviewer (copilot)** — 🟢 Approve · confidence 96%")
+    clean_report = prs.parse_review(clean)
+    ok &= _check("dissent_feedback: empty when every panel is at/above target",
+                 prs.dissent_feedback(clean_report, clean, min_pct=90) == "")
+
+    # Programmatic reader over a PyGithub-shaped PR (latest marker comment wins).
+    pr = _FakePR([_FakeComment("unrelated"), _FakeComment(SAMPLE)])
+    r2, b2 = prs.read_pr_review(pr)
+    ok &= _check("read_pr_review: returns the posted pre-review report+body",
+                 r2 is not None and r2["composite"] == 77 and prs._marker() in (b2 or ""))
+    none_pr = _FakePR([_FakeComment("no review here")])
+    ok &= _check("read_pr_review: (None, None) when AB has not posted a review",
+                 prs.read_pr_review(none_pr) == (None, None))
+
+    print()
+    if ok:
+        print("ALL CASES PASSED")
+        return 0
+    print("ONE OR MORE CASES FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #152 (already merged). Addresses the **state-logic panel dissent** on #152 (the 42% Reject: *state conflation*), and makes AppBuilder able to read and act on its own review score.

## Why
#152's retry re-targeting fired on **every** failure kind. A frontier model reads the nuance, but the weaker models that run automated fixes take `error_context` literally — so on non-wrong-file retries (bad JSON, missed anchors, no edits, failed tests, low confidence) the "you edited the WRONG file, relocate" hint steered them **away** from the already-correct file. And `_extract_cited_paths` couldn't tell the reviewer's *correct target* from the *rejected decoy*, so bare-name phrasing could re-target the just-rejected file — reintroducing the lm#452 loop.

## Changes
**`fix_engine.py` — gate re-targeting on an explicit wrong-file signal**
- `identify_files_to_fix(..., retarget=False, avoid_paths=None)`: reviewer-cited files lead **only** when `retarget` is True (a review rejection — the sole state whose feedback names a location). Other kinds keep the same target.
- Retry hint no longer asserts "very likely edited the WRONG file": review rejections get conditional language (prefer a cited file if named, else keep the target + fix the critique); non-review failures are told the target was **not** wrong.
- `_extract_cited_paths(..., avoid=...)`: excludes files the previous attempt actually modified, so a rejected decoy can never lead regardless of phrasing order.
- `apply_ai_fix` and the retry loop thread the failure kind + modified-file set.

**`pr_review_score.py` — new AB module (also a CLI) so AB can improve itself**
- Parses AB's own posted pre-review, scores every panel (composite = weakest), extracts dissent.
- `pr_review.fix_one_pr` folds `dissent_feedback()` into the next fix attempt's prompt — a low score on AB's own PR now drives AB's own next revision.
- CLI: `python3 pr_review_score.py <PR> [--watch] [--json] [--min N]` — the repeatable driver for the improve-the-score loop; exit non-zero until every panel is at or above threshold with no dissent.

## Tests
- Extended `test_fix_engine_triage_identify_requirements.py`: gated re-targeting (review vs non-review), `avoid_paths` decoy exclusion.
- New `test_pr_review_score.py`: parser, `dissent_feedback`, PyGithub reader.
- All affected self-tests pass; changed modules parse; pytest collection safe.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
