### PR TITLE
UI: fix issue-table header layout (ID clipping + Status whitespace)

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -539,20 +539,20 @@
             <table class="w-full text-left text-sm table-fixed">
                 <thead class="bg-slate-50 text-slate-500 uppercase text-xs">
                     <tr class="border-b border-slate-200">
-                        <th class="px-3 py-3 font-medium w-[20%]">Issue ID</th>
-                        <th class="px-3 py-3 font-medium text-right w-[30%]">Status</th>
-                        <th class="px-3 py-3 font-medium text-right w-[50%]">Actions</th>
+                        <th class="px-4 py-3 font-medium w-[30%]">Issue ID</th>
+                        <th class="px-4 py-3 font-medium w-[16%]">Status</th>
+                        <th class="px-4 py-3 font-medium w-[54%]">Actions</th>
                     </tr>
                 </thead>
                 <tbody class="divide-y divide-slate-200">
                     {% for issue_id, info in state.processed.items() %}
                     <tr class="hover:bg-slate-50 transition-colors" data-status="{{ info.status }}">
-                        <td class="px-6 py-3 font-mono text-[#01A982] align-middle">{{ issue_id }}</td>
-                        <td class="px-6 py-3 text-right align-middle">
+                        <td class="px-4 py-3 font-mono text-[#01A982] align-middle truncate" title="{{ issue_id }}">{{ issue_id }}</td>
+                        <td class="px-4 py-3 align-middle">
                             <span class="px-2 py-1 rounded text-xs font-bold whitespace-nowrap {% if info.status == 'closed' %}text-slate-600 bg-slate-200{% elif info.status == 'failed' %}text-red-700 bg-red-100{% elif info.status == 'non-actionable' %}text-orange-700 bg-orange-100{% elif info.status == 'pending_verification' %}text-amber-700 bg-amber-100{% elif info.status == 'processing' %}text-blue-700 bg-blue-100{% elif info.status == 'feature_flagged' %}text-purple-700 bg-purple-100{% elif info.status == 'feature_needs_info' %}text-sky-700 bg-sky-100{% elif info.status == 'feature_built' %}text-teal-700 bg-teal-100{% else %}text-green-700 bg-green-100{% endif %}">{{ info.status.upper() }}</span>
                         </td>
-                        <td class="px-6 py-3 align-middle">
-                            <div class="flex flex-wrap gap-1.5 justify-end items-center">
+                        <td class="px-4 py-3 align-middle">
+                            <div class="flex flex-wrap gap-1.5 justify-start items-center">
                                 {% if info.status in ('feature_flagged', 'feature_needs_info') %}
                                 <!-- No Retry/Claude/Reopen here — those trigger a code fix attempt,
                                      but a boundary-flag or a clarify request has no code to fix; the


### PR DESCRIPTION
Fixes two layout problems in the Issue ID / Status / Actions table on the dashboard.

## Problems
- **Issue ID cut off** — the column was `w-[20%]` with `px-6` padding while the header used `px-3` (misaligned), so longer IDs like `lbockenstedt/lm:452` clipped.
- **Whitespace to the right of Status** — Status was `text-right w-[30%]` and Actions was `justify-end`, so the badge sat mid-row while the buttons hugged the far right, leaving a large empty gap between them.

## Fix
- Rebalance columns to **30% / 16% / 54%** and unify padding to `px-4` (header + body aligned).
- Issue ID cell gets `truncate` + a `title="{{ issue_id }}"` tooltip so it never clips abruptly and the full ID is available on hover.
- Status is left-aligned and Actions pack left (`justify-start`) so the buttons follow the badge with no gap.

Template-only change; Jinja2 parses clean. No logic touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
