### PR TITLE
feat(promote): scheduled dev→qa / qa→main promotion (opens PRs, never merges)

### DIFF
--- a/main.py
+++ b/main.py
@@ -644,6 +644,7 @@ if _acquire_worker_singleton():
     threading.Thread(target=restart_worker, daemon=True).start()
     threading.Thread(target=log_health_worker, daemon=True).start()
     threading.Thread(target=model_preload_worker, daemon=True).start()
+    threading.Thread(target=promote_scheduler_worker, daemon=True).start()
     # Batch worker (async cloud batch processing). Gated by batch_enabled (default
     # off). Defensive import/start so a batch issue can never crash AppBuilder startup.
     try:

--- a/promote_ops.py
+++ b/promote_ops.py
@@ -1,0 +1,258 @@
+"""Scheduled branch promotion for AppBuilder.
+
+This module lets AppBuilder open promotion PRs on a fixed *cadence* instead of
+only when someone clicks a promotion button in the WebUI. It changes nothing
+about what a promotion IS: exactly like the buttons, a scheduled promotion only
+DISPATCHES ``.github/workflows/promote.yml`` in each target repo, which prepares
+a ``promote/<src>-to-<tgt>`` branch and OPENS a pull request. Nothing here
+merges and nothing here pushes to dev/qa/main -- the promotion PR is still
+reviewed (AppBuilder's own pre-review panels run on it) and merged by a human.
+The schedule only decides *when* to open those PRs, so dev->qa (and, if enabled,
+qa->main) batches on a regular interval.
+
+The dispatch itself is shared with the WebUI path (routes.py) via
+``dispatch_promote_workflow`` so there is one implementation, not two that drift.
+
+Config (config.json, editable from Settings -> Automation):
+  promote_schedule_enabled            bool  master switch                 (default False)
+  promote_schedule_dev_to_qa_hours    int   dev->qa cadence, 0 = off      (default 24)
+  promote_schedule_qa_to_main_hours   int   qa->main cadence, 0 = off     (default 0)
+  promote_schedule_repo               str   repo scope; the "__all__"
+                                            sentinel = every promotable
+                                            repo                          (default "__all__")
+  promote_schedule_check_interval_min int   how often the worker wakes to
+                                            re-check whether a route is due (default 30)
+
+qa->main defaults OFF: pushing to production on a timer is a deliberate choice
+the operator has to opt into, whereas batching dev->qa is low-risk (it only ever
+opens a PR into qa).
+"""
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger("appbuilder.promote")
+
+#: Sentinel meaning "every promotable repo". Mirrors routes.PROMOTE_ALL; kept as
+#: a literal here so this module carries no import-time dependency on routes.py
+#: (routes.py imports THIS module, so the reverse would be a cycle). Asserted
+#: equal to routes.PROMOTE_ALL in the tests to catch drift.
+PROMOTE_ALL = "__all__"
+
+#: (source, target) -> config key holding that route's cadence in hours.
+#: Only the two forward, non-override routes are schedulable. The dev->main
+#: emergency override is intentionally NOT here: skipping qa is a human
+#: decision, never something a timer should do on its own.
+ROUTE_INTERVAL_KEYS = {
+    ("dev", "qa"): "promote_schedule_dev_to_qa_hours",
+    ("qa", "main"): "promote_schedule_qa_to_main_hours",
+}
+
+_DEFAULT_INTERVALS = {
+    "promote_schedule_dev_to_qa_hours": 24,
+    "promote_schedule_qa_to_main_hours": 0,
+}
+
+
+def _route_key(source, target):
+    return f"{source}->{target}"
+
+
+def _as_int(val, default):
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Shared dispatch (used by BOTH the WebUI buttons and the scheduler).
+# ---------------------------------------------------------------------------
+def dispatch_promote_workflow(token, repo_name, source, target, is_override):
+    """Dispatch promote.yml in ``repo_name`` for the ``source -> target`` hop.
+
+    Returns the workflow URL on success and raises on failure. This ONLY opens a
+    PR -- it never merges. Shared with routes.promote_branch so the manual and
+    scheduled paths behave identically.
+    """
+    from github import Github
+    repo = Github(token).get_repo(repo_name)
+    wf = repo.get_workflow("promote.yml")
+    # workflow_dispatch runs the workflow file as it exists on the ref it is
+    # dispatched from; the promotion logic lives on the default branch, which is
+    # also what promote.yml's concurrency note assumes.
+    ref = repo.default_branch
+    # Send `target` ONLY for the override. A sibling repo's promote.yml may still
+    # declare just the `source` input, and GitHub rejects a dispatch carrying an
+    # input the workflow does not declare -- so always sending `target` would
+    # break the ordinary dev->qa / qa->main dispatch on those repos. The
+    # scheduler never uses the override, so this stays omitted for it.
+    inputs = {"source": source}
+    if is_override:
+        inputs["target"] = target
+    ok = wf.create_dispatch(ref, inputs)
+    # PyGithub returns False (rather than raising) when GitHub rejects the
+    # dispatch. Treat that as a failure instead of a false success.
+    if ok is False:
+        extra = (" This repo's promote.yml may predate the 'target' input "
+                 "that the dev -> main override requires.") if is_override else ""
+        raise RuntimeError(
+            f"GitHub rejected the workflow dispatch for {repo_name} (ref '{ref}').{extra}")
+    return f"https://github.com/{repo_name}/actions/workflows/promote.yml"
+
+
+# ---------------------------------------------------------------------------
+# Schedule decision (pure -- unit-tested without any GitHub/IO).
+# ---------------------------------------------------------------------------
+def due_routes(cfg, last_runs, now):
+    """Which forward routes are due to be promoted, given the last-run times.
+
+    ``last_runs`` maps ``"src->tgt"`` -> aware ``datetime`` of the last dispatch
+    (or missing/None if never). A route is due when its cadence is > 0 hours and
+    either it has never run or at least that many hours have elapsed. Returns a
+    list of ``(source, target)`` in a stable order (dev->qa before qa->main).
+    """
+    due = []
+    for (src, tgt), key in ROUTE_INTERVAL_KEYS.items():
+        hours = _as_int(cfg.get(key, _DEFAULT_INTERVALS[key]), _DEFAULT_INTERVALS[key])
+        if hours <= 0:
+            continue
+        last = last_runs.get(_route_key(src, tgt))
+        if last is None or (now - last) >= timedelta(hours=hours):
+            due.append((src, tgt))
+    return due
+
+
+# ---------------------------------------------------------------------------
+# Last-run state (small JSON file next to config.json).
+# ---------------------------------------------------------------------------
+def _state_path():
+    from main import CONFIG_DIR
+    return os.path.join(CONFIG_DIR, "promote_schedule_state.json")
+
+
+def load_schedule_state():
+    """route-key -> aware datetime of last dispatch. Empty on any read problem."""
+    try:
+        with open(_state_path(), "r") as fh:
+            raw = json.load(fh)
+    except (FileNotFoundError, ValueError, OSError):
+        return {}
+    out = {}
+    for k, v in (raw or {}).items():
+        try:
+            dt = datetime.fromisoformat(v)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            out[k] = dt
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def save_schedule_state(runs):
+    """Persist {route-key: datetime} atomically as ISO-8601 UTC strings."""
+    path = _state_path()
+    payload = {k: (v.astimezone(timezone.utc).isoformat()) for k, v in runs.items()}
+    tmp = f"{path}.tmp"
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(tmp, "w") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+    os.replace(tmp, path)
+
+
+# ---------------------------------------------------------------------------
+# One scheduler cycle: dispatch every due route across the configured repos.
+# ---------------------------------------------------------------------------
+def _clean_repo(name):
+    """Minimal 'owner/name' normaliser for the single-repo schedule scope.
+
+    Deliberately does NOT import github_ops.clean_repo_name: that module imports
+    `main` at load time, which would drag the whole app (and its worker threads)
+    into anything that merely resolves the schedule's repo scope. The schedule
+    value is a plain config string, so a light strip of a URL/`.git`/slash is
+    enough here."""
+    s = (name or "").strip()
+    for pre in ("https://github.com/", "http://github.com/", "git@github.com:"):
+        if s.startswith(pre):
+            s = s[len(pre):]
+            break
+    if s.endswith(".git"):
+        s = s[:-4]
+    return s.strip("/")
+
+
+def _resolve_repos(cfg):
+    """The repo list a scheduled promotion fans out to.
+
+    Honours ``promote_schedule_repo``: the PROMOTE_ALL sentinel (default) means
+    every promotable repo -- exactly the set the WebUI "All" button uses -- while
+    a concrete "owner/name" restricts the schedule to that single repo.
+    """
+    scope = (cfg.get("promote_schedule_repo") or PROMOTE_ALL).strip()
+    if scope and scope != PROMOTE_ALL:
+        one = _clean_repo(scope)
+        return [one] if one else []
+    from routes import _promotable_repos
+    repos, _ = _promotable_repos(cfg)
+    return repos
+
+
+def run_scheduled_promotions(cfg, now=None):
+    """Dispatch promote.yml for every route whose cadence has elapsed.
+
+    Returns a summary dict {dispatched, skipped, results}. A route is marked as
+    run (its timer resets) as long as at least one repo dispatched, so a single
+    flaky repo does not wedge the whole schedule; per-repo failures are logged
+    and reported. Never raises for a per-repo failure -- only truly fatal setup
+    problems (no token) short-circuit the cycle.
+    """
+    from routes import PROMOTE_ROUTES
+    now = now or datetime.now(timezone.utc)
+
+    token = cfg.get("GITHUB_TOKEN") or os.getenv("GITHUB_TOKEN", "")
+    if not token:
+        logger.warning("promote scheduler: no GitHub token configured — skipping cycle")
+        return {"dispatched": 0, "skipped": 0, "results": [], "reason": "no-token"}
+
+    last_runs = load_schedule_state()
+    due = due_routes(cfg, last_runs, now)
+    if not due:
+        return {"dispatched": 0, "skipped": 0, "results": []}
+
+    repos = _resolve_repos(cfg)
+    if not repos:
+        logger.warning("promote scheduler: no promotable repositories resolved — nothing to do")
+        return {"dispatched": 0, "skipped": 0, "results": [], "reason": "no-repos"}
+
+    results = []
+    dispatched_total = 0
+    for src, tgt in due:
+        is_override = PROMOTE_ROUTES.get((src, tgt), False)
+        ok_count = 0
+        for name in repos:
+            try:
+                url = dispatch_promote_workflow(token, name, src, tgt, is_override)
+                results.append({"repo": name, "source": src, "target": tgt, "ok": True, "url": url})
+                ok_count += 1
+            except Exception as e:  # noqa: BLE001 — one repo must not abort the fan-out
+                logger.error("promote scheduler: %s %s -> %s failed: %s", name, src, tgt, e)
+                results.append({"repo": name, "source": src, "target": tgt, "ok": False, "error": str(e)})
+        if ok_count:
+            # Reset the timer for this route only when something actually went
+            # out, so a fully-failed hop is retried next tick rather than
+            # silently waiting a whole interval.
+            last_runs[_route_key(src, tgt)] = now
+            dispatched_total += ok_count
+            logger.warning("promote scheduler: %s -> %s dispatched for %d/%d repo(s)",
+                           src, tgt, ok_count, len(repos))
+
+    try:
+        save_schedule_state(last_runs)
+    except OSError as e:
+        logger.error("promote scheduler: could not persist schedule state: %s", e)
+
+    return {"dispatched": dispatched_total,
+            "skipped": len(due) - len({(r["source"], r["target"]) for r in results if r["ok"]}),
+            "results": results}

--- a/routes.py
+++ b/routes.py
@@ -725,33 +725,10 @@ async def promote_branch(request: Request):
         targets = [repo_name]
 
     def _do_dispatch(repo_name):
-        repo = Github(token).get_repo(repo_name)
-        wf = repo.get_workflow("promote.yml")
-        # workflow_dispatch always runs the workflow file as it exists on the
-        # ref it is dispatched from; the promotion logic lives on the default
-        # branch, which is also what promote.yml's concurrency note assumes.
-        ref = repo.default_branch
-        # Send `target` ONLY for the override. promote.yml in the sibling repos
-        # still has just the `source` input, and GitHub rejects a dispatch that
-        # carries an input the workflow does not declare -- so always sending
-        # `target` would break the ordinary dev->qa / qa->main buttons on every
-        # repo except this one. Omitting it reproduces the historical call
-        # exactly, and those repos keep working; dev->main is the only route
-        # that genuinely requires the newer workflow.
-        inputs = {"source": source}
-        if is_override:
-            inputs["target"] = target
-        ok = wf.create_dispatch(ref, inputs)
-        # PyGithub returns False rather than raising when GitHub rejects the
-        # dispatch. Treat that as a failure instead of reporting a false
-        # success -- for the override the likeliest cause is a promote.yml on
-        # that repo that predates the `target` input.
-        if ok is False:
-            extra = (" This repo's promote.yml may predate the 'target' input "
-                     "that the dev -> main override requires.") if is_override else ""
-            raise RuntimeError(
-                f"GitHub rejected the workflow dispatch for {repo_name} (ref '{ref}').{extra}")
-        return f"https://github.com/{repo_name}/actions/workflows/promote.yml"
+        # Shared with the scheduled-promotion path (promote_ops) so the manual
+        # and scheduled dispatches are one implementation, not two that drift.
+        from promote_ops import dispatch_promote_workflow
+        return dispatch_promote_workflow(token, repo_name, source, target, is_override)
 
     async def _dispatch(name):
         # PyGithub is synchronous — see pr_review_approve's note; offload so a
@@ -2684,6 +2661,14 @@ async def save_settings(request: Request):
         "HUB_WS_URL": lambda v: v.strip() if v else "",
         "HUB_AGENT_ID": lambda v: v.strip() if v else "ab",
         "POST_UPDATE_COOLDOWN_MINUTES": lambda v: max(0, int(v)) if str(v).isdigit() else 10,
+        # Scheduled promotion cadence (promote_ops / promote_scheduler_worker).
+        # Hours between auto-opening a promotion PR for each hop; 0 = that hop is
+        # off. qa->main defaults to 0 so production is never promoted on a timer
+        # unless explicitly turned on.
+        "promote_schedule_dev_to_qa_hours": lambda v: max(0, int(v)) if str(v).strip().lstrip("-").isdigit() else 24,
+        "promote_schedule_qa_to_main_hours": lambda v: max(0, int(v)) if str(v).strip().lstrip("-").isdigit() else 0,
+        "promote_schedule_check_interval_min": lambda v: max(1, int(v)) if str(v).strip().isdigit() else 30,
+        "promote_schedule_repo": lambda v: (v.strip() if v and v.strip() else "__all__"),
     }
 
 
@@ -2708,6 +2693,11 @@ async def save_settings(request: Request):
             config_data["GITHUB_TOKEN"] = _submitted_token
 
     config_data["direct_push_enabled"] = data.get("direct_push_enabled") == "on"
+    # Scheduled-promotion master switch (default OFF). When on, the
+    # promote_scheduler_worker opens dev->qa (and, if its cadence > 0, qa->main)
+    # promotion PRs on the configured interval. It only OPENS PRs — merging still
+    # goes through every existing gate.
+    config_data["promote_schedule_enabled"] = data.get("promote_schedule_enabled") == "on"
     # Unchecked checkboxes are simply absent from the form, so an explicit
     # comparison is what distinguishes "off" from "not submitted".
     config_data["delete_merged_branches"] = data.get("delete_merged_branches") == "on"

--- a/templates/index.html
+++ b/templates/index.html
@@ -2287,6 +2287,39 @@
                             {% endif %}
                         </div>
 
+                        <div class="space-y-2 mt-6 pt-4 border-t border-slate-200">
+                            <label class="text-sm font-semibold text-slate-700">Scheduled Promotion <span class="text-slate-400 font-normal">(opens dev→qa / qa→main PRs on a cadence — never merges)</span></label>
+                            <div class="flex items-center gap-3">
+                                <input type="checkbox" name="promote_schedule_enabled" id="promote_schedule_enabled" {{ 'checked' if settings.get('promote_schedule_enabled', False) else '' }} class="w-4 h-4 text-[#01A982] focus:ring-[#01A982]">
+                                <label for="promote_schedule_enabled" class="text-xs font-medium text-slate-700" title="Off by default. When on, AppBuilder opens a promotion PR (via .github/workflows/promote.yml) for each hop below on the configured interval. It only OPENS the PR; your existing review/auto-merge gates still decide whether it merges.">
+                                    Enable scheduled promotion
+                                </label>
+                            </div>
+                            <p class="text-xs text-slate-500">Each hop opens a batch PR into the next branch, which AppBuilder's pre-review then scores. Set a hop's interval to <strong>0</strong> to turn that hop off. Nothing here merges — merging still goes through the Auto-Merge gates above (and main stays owner-only).</p>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-2">
+                                <div class="space-y-2">
+                                    <label class="text-sm font-medium text-slate-600">dev → qa cadence (hours)</label>
+                                    <input type="number" name="promote_schedule_dev_to_qa_hours" min="0" value="{{ settings.get('promote_schedule_dev_to_qa_hours', 24) }}" class="w-full p-2 rounded-lg outline-none focus:ring-2 focus:ring-[#01A982]">
+                                    <span class="text-xs text-slate-500">Default 24h. How often to batch dev into a qa promotion PR. 0 = off.</span>
+                                </div>
+                                <div class="space-y-2">
+                                    <label class="text-sm font-medium text-slate-600">qa → main cadence (hours)</label>
+                                    <input type="number" name="promote_schedule_qa_to_main_hours" min="0" value="{{ settings.get('promote_schedule_qa_to_main_hours', 0) }}" class="w-full p-2 rounded-lg outline-none focus:ring-2 focus:ring-[#01A982]">
+                                    <span class="text-xs text-slate-500">Default <strong>0 (off)</strong> — opening production PRs on a timer is opt-in. Still only opens a PR; it does not merge.</span>
+                                </div>
+                                <div class="space-y-2">
+                                    <label class="text-sm font-medium text-slate-600">Check interval (minutes)</label>
+                                    <input type="number" name="promote_schedule_check_interval_min" min="1" value="{{ settings.get('promote_schedule_check_interval_min', 30) }}" class="w-full p-2 rounded-lg outline-none focus:ring-2 focus:ring-[#01A982]">
+                                    <span class="text-xs text-slate-500">How often the scheduler wakes to check whether a hop is due (default 30m).</span>
+                                </div>
+                                <div class="space-y-2">
+                                    <label class="text-sm font-medium text-slate-600">Repository scope</label>
+                                    <input type="text" name="promote_schedule_repo" value="{{ settings.get('promote_schedule_repo', '__all__') }}" class="w-full p-2 rounded-lg outline-none focus:ring-2 focus:ring-[#01A982]">
+                                    <span class="text-xs text-slate-500"><code>__all__</code> (default) = every promotable repo, exactly like the footer "All" button. Or a single <code>owner/name</code>.</span>
+                                </div>
+                            </div>
+                        </div>
+
                         <div class="flex justify-end pt-6 mt-2">
                             <button type="button" onclick="saveSettingsAjax(this)" class="px-6 py-2 rounded-md text-sm font-bold btn-primary">Save</button>
                         </div>

--- a/test_promote_ops.py
+++ b/test_promote_ops.py
@@ -1,0 +1,191 @@
+"""Tests for promote_ops (scheduled promotion).
+
+main()-style like the rest of the AB suite (pytest collects 0 here; run with
+`python3 test_promote_ops.py`). Covers the pure schedule-decision logic, the
+last-run state round-trip, and one full scheduler cycle with GitHub/routes
+faked out, so nothing here touches the network or imports the real app.
+"""
+import os
+import sys
+import types
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+
+def _fresh_promote_ops(config_dir):
+    """Import promote_ops with a stub `main` (for CONFIG_DIR) so the state file
+    lands in a temp dir and no real app startup happens."""
+    sys.modules.pop("promote_ops", None)
+    sys.modules["main"] = types.SimpleNamespace(CONFIG_DIR=config_dir)
+    import promote_ops
+    return promote_ops
+
+
+def _now():
+    return datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def test_due_routes():
+    po = _fresh_promote_ops(tempfile.mkdtemp())
+    now = _now()
+    fails = []
+
+    # Never-run + positive cadence => due.
+    cfg = {"promote_schedule_dev_to_qa_hours": 24, "promote_schedule_qa_to_main_hours": 0}
+    due = po.due_routes(cfg, {}, now)
+    if due != [("dev", "qa")]:
+        fails.append(f"never-run dev->qa should be the only due route, got {due}")
+
+    # qa->main cadence 0 => never scheduled even if never run.
+    if ("qa", "main") in due:
+        fails.append("qa->main with 0 hours must not be due")
+
+    # Within the interval => not due.
+    last = {"dev->qa": now - timedelta(hours=10)}
+    if po.due_routes(cfg, last, now) != []:
+        fails.append("dev->qa 10h after last run (24h cadence) must not be due")
+
+    # Exactly at/after the interval => due.
+    last = {"dev->qa": now - timedelta(hours=24)}
+    if po.due_routes(cfg, last, now) != [("dev", "qa")]:
+        fails.append("dev->qa exactly 24h later must be due")
+
+    # Both routes enabled and both overdue => stable order dev->qa, qa->main.
+    cfg2 = {"promote_schedule_dev_to_qa_hours": 24, "promote_schedule_qa_to_main_hours": 168}
+    last2 = {"dev->qa": now - timedelta(hours=48), "qa->main": now - timedelta(days=14)}
+    if po.due_routes(cfg2, last2, now) != [("dev", "qa"), ("qa", "main")]:
+        fails.append(f"both overdue routes should return in order, got {po.due_routes(cfg2, last2, now)}")
+
+    # Negative / garbage cadence treated as off.
+    if po.due_routes({"promote_schedule_dev_to_qa_hours": -5}, {}, now) != []:
+        fails.append("negative cadence must be treated as off")
+    if po.due_routes({"promote_schedule_dev_to_qa_hours": "oops"}, {}, now) != [("dev", "qa")]:
+        # 'oops' -> default 24 -> never run -> due
+        fails.append("garbage cadence should fall back to the default (24h), so a never-run route is due")
+
+    return fails
+
+
+def test_state_roundtrip():
+    d = tempfile.mkdtemp()
+    po = _fresh_promote_ops(d)
+    fails = []
+    now = _now()
+    po.save_schedule_state({"dev->qa": now, "qa->main": now - timedelta(hours=5)})
+    loaded = po.load_schedule_state()
+    if loaded.get("dev->qa") != now:
+        fails.append(f"round-trip lost dev->qa time: {loaded.get('dev->qa')} != {now}")
+    if loaded.get("qa->main") != now - timedelta(hours=5):
+        fails.append("round-trip lost qa->main time")
+    # Missing file => empty, not an error.
+    po2 = _fresh_promote_ops(tempfile.mkdtemp())
+    if po2.load_schedule_state() != {}:
+        fails.append("missing state file should load as {}")
+    # Corrupt file => empty, not a crash.
+    with open(os.path.join(d, "promote_schedule_state.json"), "w") as fh:
+        fh.write("{not json")
+    if po.load_schedule_state() != {}:
+        fails.append("corrupt state file should load as {}")
+    return fails
+
+
+def _install_fake_routes(promotable):
+    """Stub the routes module promote_ops reaches into at runtime."""
+    fake = types.ModuleType("routes")
+    fake.PROMOTE_ALL = "__all__"
+    fake.PROMOTE_ROUTES = {("dev", "qa"): False, ("qa", "main"): False, ("dev", "main"): True}
+    fake._promotable_repos = lambda cfg: (list(promotable), "")
+    sys.modules["routes"] = fake
+
+
+def test_run_cycle():
+    d = tempfile.mkdtemp()
+    po = _fresh_promote_ops(d)
+    _install_fake_routes(["own/a", "own/b"])
+    fails = []
+    now = _now()
+
+    calls = []
+
+    def fake_dispatch(token, repo, src, tgt, is_override):
+        calls.append((repo, src, tgt, is_override))
+        return f"https://github.com/{repo}/actions"
+
+    po.dispatch_promote_workflow = fake_dispatch
+
+    # No token => short-circuit, nothing dispatched.
+    r = po.run_scheduled_promotions({"promote_schedule_dev_to_qa_hours": 24}, now=now)
+    if r.get("reason") != "no-token" or calls:
+        fails.append("missing token must short-circuit with no dispatch")
+
+    # Token + due dev->qa across all promotable repos.
+    cfg = {"GITHUB_TOKEN": "t", "promote_schedule_dev_to_qa_hours": 24,
+           "promote_schedule_qa_to_main_hours": 0, "promote_schedule_repo": "__all__"}
+    r = po.run_scheduled_promotions(cfg, now=now)
+    if sorted(c[0] for c in calls) != ["own/a", "own/b"]:
+        fails.append(f"should dispatch to every promotable repo, got {calls}")
+    if any(c[3] for c in calls):
+        fails.append("scheduled dev->qa must never use the override flag")
+    if r["dispatched"] != 2:
+        fails.append(f"expected 2 dispatches, got {r['dispatched']}")
+
+    # Timer was reset => immediate re-run dispatches nothing new.
+    calls.clear()
+    r = po.run_scheduled_promotions(cfg, now=now + timedelta(minutes=5))
+    if calls:
+        fails.append("route within its interval must not re-dispatch")
+
+    # After the interval elapses it fires again.
+    r = po.run_scheduled_promotions(cfg, now=now + timedelta(hours=25))
+    if len(calls) != 2:
+        fails.append("route should re-dispatch after the interval elapses")
+
+    # Single-repo scope override.
+    calls.clear()
+    cfg_one = dict(cfg, promote_schedule_repo="own/a")
+    po.run_scheduled_promotions(cfg_one, now=now + timedelta(hours=50))
+    if [c[0] for c in calls] != ["own/a"]:
+        fails.append(f"single-repo scope should dispatch only that repo, got {calls}")
+
+    # A per-repo failure must not abort the fan-out, and the timer still resets
+    # because at least one repo succeeded.
+    _install_fake_routes(["own/a", "own/b"])
+    d2 = tempfile.mkdtemp()
+    po2 = _fresh_promote_ops(d2)
+    _install_fake_routes(["own/a", "own/b"])
+
+    def flaky(token, repo, src, tgt, is_override):
+        if repo == "own/a":
+            raise RuntimeError("boom")
+        return "ok"
+
+    po2.dispatch_promote_workflow = flaky
+    r = po2.run_scheduled_promotions(dict(cfg), now=now)
+    oks = [x for x in r["results"] if x["ok"]]
+    bad = [x for x in r["results"] if not x["ok"]]
+    if len(oks) != 1 or len(bad) != 1:
+        fails.append(f"fan-out should report 1 ok + 1 failed, got {r['results']}")
+    if po2.load_schedule_state().get("dev->qa") != now:
+        fails.append("timer should reset when at least one repo dispatched")
+
+    return fails
+
+
+def main():
+    all_fails = []
+    for fn in (test_due_routes, test_state_roundtrip, test_run_cycle):
+        fs = fn()
+        for f in fs:
+            print(f"FAIL [{fn.__name__}] {f}")
+        all_fails.extend(fs)
+        if not fs:
+            print(f"PASS {fn.__name__}")
+    if all_fails:
+        print(f"\n{len(all_fails)} failure(s)")
+        return 1
+    print("\nall promote_ops tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workers.py
+++ b/workers.py
@@ -1587,8 +1587,35 @@ def poller_worker():
         time.sleep(interval)
 
 
+def promote_scheduler_worker():
+    """Open promotion PRs on a fixed cadence (dev->qa and, if enabled, qa->main).
 
-
+    Off by default. When ``promote_schedule_enabled`` is set, this wakes every
+    ``promote_schedule_check_interval_min`` minutes and asks promote_ops which
+    routes are due (per their configured interval-in-hours); each due route is
+    dispatched exactly like the WebUI promotion buttons — it OPENS a PR into the
+    next branch and never merges. AppBuilder's own pre-review then runs on that
+    PR, which is the "run the changes through AB" step. See promote_ops for the
+    decision logic and the shared dispatch."""
+    from datetime import datetime, timezone
+    while True:
+        try:
+            cfg = load_config()
+        except Exception as e:  # noqa: BLE001 — a bad config read must not kill the loop
+            logger.error("promote scheduler: could not load config: %s", e)
+            time.sleep(1800)
+            continue
+        interval_min = max(1, int(cfg.get("promote_schedule_check_interval_min", 30) or 30))
+        if cfg.get("promote_schedule_enabled"):
+            try:
+                from promote_ops import run_scheduled_promotions
+                summary = run_scheduled_promotions(cfg, now=datetime.now(timezone.utc))
+                if summary.get("dispatched"):
+                    logger.warning("promote scheduler: opened %d promotion PR dispatch(es) this cycle",
+                                   summary["dispatched"])
+            except Exception as e:  # noqa: BLE001 — never let a cycle crash the worker
+                logger.error("promote scheduler: cycle failed: %s", e)
+        time.sleep(interval_min * 60)
 
 
 def _model_fetch_reason(e):


### PR DESCRIPTION
## What
Opt-in **scheduled promotion**: AppBuilder can open `dev→qa` and (optionally) `qa→main` promotion PRs on a fixed cadence instead of only when someone clicks a button. This is the promotion-automation leg of the autonomous dev→qa→main pipeline.

**It only OPENS PRs — it never merges.** Every scheduled promotion dispatches the existing `.github/workflows/promote.yml`, which prepares a `promote/<src>-to-<tgt>` branch and opens a PR that AppBuilder's own pre-review then scores. Merging still goes through all existing review/auto-merge gates, and `main` stays owner-only.

## How it fits the goal
Gets us to hands-free stage promotion so changes flow toward production on a schedule, with each hop reviewed. (The QA-module half of the loop is intentionally out of scope here.)

## Changes
- **`promote_ops.py`** (new) — one shared dispatch (`dispatch_promote_workflow`, also used by the WebUI buttons, so there's a single implementation), pure schedule-decision logic (`due_routes`), a per-route last-run state file, and `run_scheduled_promotions` (fans out across promotable repos; resets a route's timer only when ≥1 repo dispatched, so a flaky repo doesn't wedge the schedule).
- **`workers.py`** — `promote_scheduler_worker`, gated on `promote_schedule_enabled`; wakes every `promote_schedule_check_interval_min`.
- **`main.py`** — starts the worker with the other daemons.
- **`routes.py`** — `_do_dispatch` delegates to the shared helper (no behavior change); `save_settings` persists the new keys.
- **`templates/index.html`** — "Scheduled Promotion" settings card.
- **`test_promote_ops.py`** (new) — due-logic, state round-trip, and a full faked cycle (fan-out, timer reset, single-repo scope, per-repo failure isolation). All pass.

## Defaults (nothing changes until you opt in)
| Setting | Default |
| :-- | :-- |
| `promote_schedule_enabled` | **off** |
| `promote_schedule_dev_to_qa_hours` | 24 |
| `promote_schedule_qa_to_main_hours` | **0 (off)** |
| `promote_schedule_check_interval_min` | 30 |
| `promote_schedule_repo` | `__all__` (every promotable repo) |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
