### PR TITLE
fix(promote): restore green on dev (follow-up to #160)

### DIFF
--- a/promote_ops.py
+++ b/promote_ops.py
@@ -73,8 +73,14 @@ def dispatch_promote_workflow(token, repo_name, source, target, is_override):
     """Dispatch promote.yml in ``repo_name`` for the ``source -> target`` hop.
 
     Returns the workflow URL on success and raises on failure. This ONLY opens a
-    PR -- it never merges. Shared with routes.promote_branch so the manual and
-    scheduled paths behave identically.
+    PR -- it never merges.
+
+    PARITY: this is the byte-for-byte twin of routes.promote_branch's nested
+    ``_do_dispatch`` (that one cannot be shared because it is a closure over the
+    request handler). Any change to the dispatch contract -- the `target`-only-
+    on-override rule, the default-branch ref, or the create_dispatch==False
+    handling -- must be made in BOTH. test_promote_ops.py covers this copy;
+    test_promote_routes.py covers the routes copy.
     """
     from github import Github
     repo = Github(token).get_repo(repo_name)

--- a/routes.py
+++ b/routes.py
@@ -725,10 +725,38 @@ async def promote_branch(request: Request):
         targets = [repo_name]
 
     def _do_dispatch(repo_name):
-        # Shared with the scheduled-promotion path (promote_ops) so the manual
-        # and scheduled dispatches are one implementation, not two that drift.
-        from promote_ops import dispatch_promote_workflow
-        return dispatch_promote_workflow(token, repo_name, source, target, is_override)
+        repo = Github(token).get_repo(repo_name)
+        wf = repo.get_workflow("promote.yml")
+        # workflow_dispatch always runs the workflow file as it exists on the
+        # ref it is dispatched from; the promotion logic lives on the default
+        # branch, which is also what promote.yml's concurrency note assumes.
+        ref = repo.default_branch
+        # Send `target` ONLY for the override. promote.yml in the sibling repos
+        # still has just the `source` input, and GitHub rejects a dispatch that
+        # carries an input the workflow does not declare -- so always sending
+        # `target` would break the ordinary dev->qa / qa->main buttons on every
+        # repo except this one. Omitting it reproduces the historical call
+        # exactly, and those repos keep working; dev->main is the only route
+        # that genuinely requires the newer workflow.
+        #
+        # NOTE: promote_ops.dispatch_promote_workflow is the byte-for-byte twin
+        # of this block for the scheduled-promotion path (it cannot reuse this
+        # nested closure). Keep the two in lockstep -- both are covered by tests
+        # (test_promote_routes.py here, test_promote_ops.py there).
+        inputs = {"source": source}
+        if is_override:
+            inputs["target"] = target
+        ok = wf.create_dispatch(ref, inputs)
+        # PyGithub returns False rather than raising when GitHub rejects the
+        # dispatch. Treat that as a failure instead of reporting a false
+        # success -- for the override the likeliest cause is a promote.yml on
+        # that repo that predates the `target` input.
+        if ok is False:
+            extra = (" This repo's promote.yml may predate the 'target' input "
+                     "that the dev -> main override requires.") if is_override else ""
+            raise RuntimeError(
+                f"GitHub rejected the workflow dispatch for {repo_name} (ref '{ref}').{extra}")
+        return f"https://github.com/{repo_name}/actions/workflows/promote.yml"
 
     async def _dispatch(name):
         # PyGithub is synchronous — see pr_review_approve's note; offload so a

--- a/test_promote_ops.py
+++ b/test_promote_ops.py
@@ -1,15 +1,40 @@
-"""Tests for promote_ops (scheduled promotion).
+#!/usr/bin/env python3
+"""Self-tests for promote_ops (scheduled promotion).
 
-main()-style like the rest of the AB suite (pytest collects 0 here; run with
-`python3 test_promote_ops.py`). Covers the pure schedule-decision logic, the
-last-run state round-trip, and one full scheduler cycle with GitHub/routes
-faked out, so nothing here touches the network or imports the real app.
+pytest-style (assert-based) so CI's `pytest -q .` runs and gates them, unlike
+the older main()-style files it collects nothing from. Also runnable directly:
+`python3 test_promote_ops.py`. Nothing here touches the network or imports the
+real app -- `main` is stubbed for CONFIG_DIR, `routes` is stubbed for the
+allowlist/repos, and GitHub is faked via a stub `github` module.
 """
 import os
 import sys
 import types
+import functools
 import tempfile
 from datetime import datetime, timedelta, timezone
+
+
+# Tests here temporarily replace real modules in sys.modules (main/routes/github
+# stubs, plus a freshly-imported promote_ops). Under the full `pytest .` run that
+# would leak into whatever test is collected next, so every test snapshots and
+# restores those entries via @_isolated.
+_ISOLATED_MODS = ("main", "routes", "github", "promote_ops")
+
+
+def _isolated(fn):
+    @functools.wraps(fn)
+    def wrapper(*a, **k):
+        saved = {m: sys.modules.get(m) for m in _ISOLATED_MODS}
+        try:
+            return fn(*a, **k)
+        finally:
+            for m, v in saved.items():
+                if v is None:
+                    sys.modules.pop(m, None)
+                else:
+                    sys.modules[m] = v
+    return wrapper
 
 
 def _fresh_promote_ops(config_dir):
@@ -25,70 +50,6 @@ def _now():
     return datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
 
 
-def test_due_routes():
-    po = _fresh_promote_ops(tempfile.mkdtemp())
-    now = _now()
-    fails = []
-
-    # Never-run + positive cadence => due.
-    cfg = {"promote_schedule_dev_to_qa_hours": 24, "promote_schedule_qa_to_main_hours": 0}
-    due = po.due_routes(cfg, {}, now)
-    if due != [("dev", "qa")]:
-        fails.append(f"never-run dev->qa should be the only due route, got {due}")
-
-    # qa->main cadence 0 => never scheduled even if never run.
-    if ("qa", "main") in due:
-        fails.append("qa->main with 0 hours must not be due")
-
-    # Within the interval => not due.
-    last = {"dev->qa": now - timedelta(hours=10)}
-    if po.due_routes(cfg, last, now) != []:
-        fails.append("dev->qa 10h after last run (24h cadence) must not be due")
-
-    # Exactly at/after the interval => due.
-    last = {"dev->qa": now - timedelta(hours=24)}
-    if po.due_routes(cfg, last, now) != [("dev", "qa")]:
-        fails.append("dev->qa exactly 24h later must be due")
-
-    # Both routes enabled and both overdue => stable order dev->qa, qa->main.
-    cfg2 = {"promote_schedule_dev_to_qa_hours": 24, "promote_schedule_qa_to_main_hours": 168}
-    last2 = {"dev->qa": now - timedelta(hours=48), "qa->main": now - timedelta(days=14)}
-    if po.due_routes(cfg2, last2, now) != [("dev", "qa"), ("qa", "main")]:
-        fails.append(f"both overdue routes should return in order, got {po.due_routes(cfg2, last2, now)}")
-
-    # Negative / garbage cadence treated as off.
-    if po.due_routes({"promote_schedule_dev_to_qa_hours": -5}, {}, now) != []:
-        fails.append("negative cadence must be treated as off")
-    if po.due_routes({"promote_schedule_dev_to_qa_hours": "oops"}, {}, now) != [("dev", "qa")]:
-        # 'oops' -> default 24 -> never run -> due
-        fails.append("garbage cadence should fall back to the default (24h), so a never-run route is due")
-
-    return fails
-
-
-def test_state_roundtrip():
-    d = tempfile.mkdtemp()
-    po = _fresh_promote_ops(d)
-    fails = []
-    now = _now()
-    po.save_schedule_state({"dev->qa": now, "qa->main": now - timedelta(hours=5)})
-    loaded = po.load_schedule_state()
-    if loaded.get("dev->qa") != now:
-        fails.append(f"round-trip lost dev->qa time: {loaded.get('dev->qa')} != {now}")
-    if loaded.get("qa->main") != now - timedelta(hours=5):
-        fails.append("round-trip lost qa->main time")
-    # Missing file => empty, not an error.
-    po2 = _fresh_promote_ops(tempfile.mkdtemp())
-    if po2.load_schedule_state() != {}:
-        fails.append("missing state file should load as {}")
-    # Corrupt file => empty, not a crash.
-    with open(os.path.join(d, "promote_schedule_state.json"), "w") as fh:
-        fh.write("{not json")
-    if po.load_schedule_state() != {}:
-        fails.append("corrupt state file should load as {}")
-    return fails
-
-
 def _install_fake_routes(promotable):
     """Stub the routes module promote_ops reaches into at runtime."""
     fake = types.ModuleType("routes")
@@ -98,11 +59,63 @@ def _install_fake_routes(promotable):
     sys.modules["routes"] = fake
 
 
+# --------------------------------------------------------------------------
+# Pure schedule-decision logic
+# --------------------------------------------------------------------------
+@_isolated
+def test_due_routes():
+    po = _fresh_promote_ops(tempfile.mkdtemp())
+    now = _now()
+
+    # Never-run + positive cadence => due; qa->main at 0h is never scheduled.
+    cfg = {"promote_schedule_dev_to_qa_hours": 24, "promote_schedule_qa_to_main_hours": 0}
+    assert po.due_routes(cfg, {}, now) == [("dev", "qa")]
+
+    # Within the interval => not due; at/after the interval => due.
+    assert po.due_routes(cfg, {"dev->qa": now - timedelta(hours=10)}, now) == []
+    assert po.due_routes(cfg, {"dev->qa": now - timedelta(hours=24)}, now) == [("dev", "qa")]
+
+    # Both routes overdue => stable order dev->qa, then qa->main.
+    cfg2 = {"promote_schedule_dev_to_qa_hours": 24, "promote_schedule_qa_to_main_hours": 168}
+    last2 = {"dev->qa": now - timedelta(hours=48), "qa->main": now - timedelta(days=14)}
+    assert po.due_routes(cfg2, last2, now) == [("dev", "qa"), ("qa", "main")]
+
+    # Negative => off; garbage => falls back to the default (24h), so due.
+    assert po.due_routes({"promote_schedule_dev_to_qa_hours": -5}, {}, now) == []
+    assert po.due_routes({"promote_schedule_dev_to_qa_hours": "oops"}, {}, now) == [("dev", "qa")]
+
+
+# --------------------------------------------------------------------------
+# Last-run state round-trip
+# --------------------------------------------------------------------------
+@_isolated
+def test_state_roundtrip():
+    d = tempfile.mkdtemp()
+    po = _fresh_promote_ops(d)
+    now = _now()
+    po.save_schedule_state({"dev->qa": now, "qa->main": now - timedelta(hours=5)})
+    loaded = po.load_schedule_state()
+    assert loaded.get("dev->qa") == now
+    assert loaded.get("qa->main") == now - timedelta(hours=5)
+
+    # Missing file => empty, not an error.
+    po2 = _fresh_promote_ops(tempfile.mkdtemp())
+    assert po2.load_schedule_state() == {}
+
+    # Corrupt file => empty, not a crash.
+    with open(os.path.join(d, "promote_schedule_state.json"), "w") as fh:
+        fh.write("{not json")
+    assert po.load_schedule_state() == {}
+
+
+# --------------------------------------------------------------------------
+# One full scheduler cycle (GitHub + routes faked)
+# --------------------------------------------------------------------------
+@_isolated
 def test_run_cycle():
     d = tempfile.mkdtemp()
     po = _fresh_promote_ops(d)
     _install_fake_routes(["own/a", "own/b"])
-    fails = []
     now = _now()
 
     calls = []
@@ -115,73 +128,126 @@ def test_run_cycle():
 
     # No token => short-circuit, nothing dispatched.
     r = po.run_scheduled_promotions({"promote_schedule_dev_to_qa_hours": 24}, now=now)
-    if r.get("reason") != "no-token" or calls:
-        fails.append("missing token must short-circuit with no dispatch")
+    assert r.get("reason") == "no-token" and not calls
 
-    # Token + due dev->qa across all promotable repos.
+    # Token + due dev->qa across all promotable repos, override flag never set.
     cfg = {"GITHUB_TOKEN": "t", "promote_schedule_dev_to_qa_hours": 24,
            "promote_schedule_qa_to_main_hours": 0, "promote_schedule_repo": "__all__"}
     r = po.run_scheduled_promotions(cfg, now=now)
-    if sorted(c[0] for c in calls) != ["own/a", "own/b"]:
-        fails.append(f"should dispatch to every promotable repo, got {calls}")
-    if any(c[3] for c in calls):
-        fails.append("scheduled dev->qa must never use the override flag")
-    if r["dispatched"] != 2:
-        fails.append(f"expected 2 dispatches, got {r['dispatched']}")
+    assert sorted(c[0] for c in calls) == ["own/a", "own/b"]
+    assert not any(c[3] for c in calls), "scheduled dev->qa must never use the override flag"
+    assert r["dispatched"] == 2
 
-    # Timer was reset => immediate re-run dispatches nothing new.
+    # Timer reset => immediate re-run dispatches nothing; after the interval it fires.
     calls.clear()
-    r = po.run_scheduled_promotions(cfg, now=now + timedelta(minutes=5))
-    if calls:
-        fails.append("route within its interval must not re-dispatch")
+    po.run_scheduled_promotions(cfg, now=now + timedelta(minutes=5))
+    assert calls == []
+    po.run_scheduled_promotions(cfg, now=now + timedelta(hours=25))
+    assert len(calls) == 2
 
-    # After the interval elapses it fires again.
-    r = po.run_scheduled_promotions(cfg, now=now + timedelta(hours=25))
-    if len(calls) != 2:
-        fails.append("route should re-dispatch after the interval elapses")
-
-    # Single-repo scope override.
+    # Single-repo scope.
     calls.clear()
-    cfg_one = dict(cfg, promote_schedule_repo="own/a")
-    po.run_scheduled_promotions(cfg_one, now=now + timedelta(hours=50))
-    if [c[0] for c in calls] != ["own/a"]:
-        fails.append(f"single-repo scope should dispatch only that repo, got {calls}")
+    po.run_scheduled_promotions(dict(cfg, promote_schedule_repo="own/a"), now=now + timedelta(hours=50))
+    assert [c[0] for c in calls] == ["own/a"]
 
-    # A per-repo failure must not abort the fan-out, and the timer still resets
-    # because at least one repo succeeded.
+
+@_isolated
+def test_run_cycle_isolates_repo_failures():
+    """A per-repo failure must not abort the fan-out, and the timer still resets
+    because at least one repo succeeded."""
+    po = _fresh_promote_ops(tempfile.mkdtemp())
     _install_fake_routes(["own/a", "own/b"])
-    d2 = tempfile.mkdtemp()
-    po2 = _fresh_promote_ops(d2)
-    _install_fake_routes(["own/a", "own/b"])
+    now = _now()
 
     def flaky(token, repo, src, tgt, is_override):
         if repo == "own/a":
             raise RuntimeError("boom")
         return "ok"
 
-    po2.dispatch_promote_workflow = flaky
-    r = po2.run_scheduled_promotions(dict(cfg), now=now)
-    oks = [x for x in r["results"] if x["ok"]]
-    bad = [x for x in r["results"] if not x["ok"]]
-    if len(oks) != 1 or len(bad) != 1:
-        fails.append(f"fan-out should report 1 ok + 1 failed, got {r['results']}")
-    if po2.load_schedule_state().get("dev->qa") != now:
-        fails.append("timer should reset when at least one repo dispatched")
+    po.dispatch_promote_workflow = flaky
+    cfg = {"GITHUB_TOKEN": "t", "promote_schedule_dev_to_qa_hours": 24,
+           "promote_schedule_qa_to_main_hours": 0, "promote_schedule_repo": "__all__"}
+    r = po.run_scheduled_promotions(cfg, now=now)
+    assert len([x for x in r["results"] if x["ok"]]) == 1
+    assert len([x for x in r["results"] if not x["ok"]]) == 1
+    assert po.load_schedule_state().get("dev->qa") == now
 
-    return fails
+
+# --------------------------------------------------------------------------
+# dispatch_promote_workflow safety contract (the routes twin is covered by
+# test_promote_routes.py; this covers the promote_ops copy).
+# --------------------------------------------------------------------------
+def _fake_github_module():
+    """A stub `github` module whose Github records create_dispatch calls."""
+    mod = types.ModuleType("github")
+    state = {"calls": [], "result": True, "raises": None, "default_branch": "main"}
+
+    class _Wf:
+        def create_dispatch(self, ref, inputs):
+            state["calls"].append((ref, inputs))
+            if state["raises"]:
+                raise state["raises"]
+            return state["result"]
+
+    class _Repo:
+        def __init__(self, name):
+            self.default_branch = state["default_branch"]
+
+        def get_workflow(self, name):
+            assert name == "promote.yml"
+            return _Wf()
+
+    class _Github:
+        def __init__(self, token):
+            pass
+
+        def get_repo(self, name):
+            return _Repo(name)
+
+    mod.Github = _Github
+    return mod, state
+
+
+@_isolated
+def test_dispatch_contract():
+    po = _fresh_promote_ops(tempfile.mkdtemp())
+    mod, state = _fake_github_module()
+    sys.modules["github"] = mod
+
+    # Normal route omits the `target` input; ref is the repo default branch.
+    state["calls"].clear()
+    url = po.dispatch_promote_workflow("tok", "o/r", "dev", "qa", is_override=False)
+    assert state["calls"] == [("main", {"source": "dev"})]
+    assert url == "https://github.com/o/r/actions/workflows/promote.yml"
+
+    # Override sends the explicit `target`.
+    state["calls"].clear()
+    po.dispatch_promote_workflow("tok", "o/r", "dev", "main", is_override=True)
+    assert state["calls"] == [("main", {"source": "dev", "target": "main"})]
+
+    # create_dispatch returning False is an ERROR, not a false success.
+    state["result"] = False
+    try:
+        po.dispatch_promote_workflow("tok", "o/r", "dev", "qa", is_override=False)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("a rejected dispatch (False) must raise, not report success")
 
 
 def main():
-    all_fails = []
-    for fn in (test_due_routes, test_state_roundtrip, test_run_cycle):
-        fs = fn()
-        for f in fs:
-            print(f"FAIL [{fn.__name__}] {f}")
-        all_fails.extend(fs)
-        if not fs:
+    tests = [test_due_routes, test_state_roundtrip, test_run_cycle,
+             test_run_cycle_isolates_repo_failures, test_dispatch_contract]
+    failures = 0
+    for fn in tests:
+        try:
+            fn()
             print(f"PASS {fn.__name__}")
-    if all_fails:
-        print(f"\n{len(all_fails)} failure(s)")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {fn.__name__}: {e}")
+    if failures:
+        print(f"\n{failures} failure(s)")
         return 1
     print("\nall promote_ops tests passed")
     return 0


### PR DESCRIPTION
**Follow-up to #160, which merged before its fix commit landed.** #160's PR merged the first commit (`0992b40`) while its CI was still red, so `dev` currently fails `test_promote_routes.py` (and `test_promote_ops.py` leaked module stubs into the full run). This restores green.

- Revert the routes→promote_ops dispatch delegation: `routes.promote_branch._do_dispatch` stays inline (its safety-contract tests stub the dispatch at the `routes.Github` seam). `promote_ops.dispatch_promote_workflow` keeps its own twin for the scheduler; both carry a PARITY note and each has test coverage.
- Rewrite `test_promote_ops.py` assert-based (pytest-clean, no return-value warnings) with an `@_isolated` decorator that snapshots/restores `sys.modules` (main/routes/github) so stubs can't leak. Adds `test_dispatch_contract` for the promote_ops twin.

Full suite: **364 passed** (was 349 passed / 13 failed on `dev`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
