### PR TITLE
feat(release-lock): hold auto-merge into locked branches without blocking review

### DIFF
--- a/branch_policy.py
+++ b/branch_policy.py
@@ -130,6 +130,27 @@ def auto_branch_prefixes(config=None):
     return tuple(configured) if configured else DEFAULT_AUTO_PREFIXES
 
 
+def release_locked_branches(config=None):
+    """Branches under a manual release lock.
+
+    While a branch is locked, AppBuilder keeps reviewing PRs but must NOT
+    auto-merge into it: changes stack up as open PRs so a human can finish
+    testing/validation, and they are processed once the lock is released. This
+    is orthogonal to protection/cleanup — it gates the unattended MERGE only,
+    not deletion, force-push, or review. Empty by default (no locks).
+
+    Config key: ``release_locked_branches`` (list, or comma/space/newline
+    string from the Settings form).
+    """
+    cfg = config or {}
+    return {n.lower() for n in parse_names(cfg.get("release_locked_branches")) if n}
+
+
+def is_release_locked(ref, config=None):
+    """True if ``ref`` is under a manual release lock (see release_locked_branches)."""
+    return str(ref or "").strip().lower() in release_locked_branches(config)
+
+
 def is_protected(ref, config=None, repo_default_branch=None):
     return str(ref or "").strip().lower() in protected_branches(config, repo_default_branch)
 

--- a/pr_review.py
+++ b/pr_review.py
@@ -70,7 +70,7 @@ from github_ops import get_monitored_repos
 from app_state import update_task_state, record_pr_review, update_pr_review, mark_pr_approved, state
 import feature_boundary
 import feature_allowlist
-from branch_policy import AUTO_BRANCH_PREFIXES_BY_KIND
+from branch_policy import AUTO_BRANCH_PREFIXES_BY_KIND, is_release_locked
 from pr_actions import approve_pr, merge_pr
 from secrets_scan import check_secrets
 from check_tooltips import find_missing_tooltips_in_files
@@ -1055,6 +1055,17 @@ def _automerge_decision(rec, changed_paths, config, pr_meta, state_flags=None, c
         return False, (f"target branch {_base_ref!r} is a release branch — never eligible for "
                        "auto-merge at any confidence, even if listed in "
                        "feature_automerge_target_branches (merges into it are owner-only)")
+
+    # Manual release lock (Settings → "Release lock"). While a branch is locked,
+    # AppBuilder keeps REVIEWING PRs but must not auto-merge into it: changes
+    # stack up as open PRs so a human can finish testing/validation, and they
+    # are processed on the next scan once the lock is released. Checked before
+    # the target-branch allowlist so a locked branch holds even when it is
+    # otherwise an eligible auto-merge target. Only auto-merge is held; humans
+    # can still merge manually.
+    if is_release_locked(_base_ref, config):
+        return False, (f"target branch {_base_ref!r} is under a release lock — holding "
+                       "(reviewed but not merged) until the lock is released")
 
     if _base_ref not in (config.get("feature_automerge_target_branches") or []):
         return False, ("target branch %r is not in feature_automerge_target_branches "

--- a/routes.py
+++ b/routes.py
@@ -2621,6 +2621,10 @@ async def save_settings(request: Request):
         # them directly; the form supplies a comma-separated string.
         "protected_branches": parse_branch_names,
         "auto_branch_prefixes": parse_branch_names,
+        # Release lock: branches AppBuilder must NOT auto-merge into until
+        # unlocked (review still runs; PRs stack up). Stored as a list so
+        # branch_policy.is_release_locked can consume it directly.
+        "release_locked_branches": parse_branch_names,
         # GITHUB_TOKEN is handled after this loop: the form no longer renders
         # the saved PAT, so an empty field means "unchanged", not "clear it".
         # Leaving it here would let a plain Save wipe the token.

--- a/templates/index.html
+++ b/templates/index.html
@@ -963,6 +963,11 @@
                                             <p class="text-xs text-slate-500">Comma-separated prefixes. Leave blank to use the defaults.</p>
                                         </div>
                                     </div>
+                                    <div class="space-y-1">
+                                        <label class="text-sm font-medium text-slate-600">Release lock (hold auto-merge)</label>
+                                        <input type="text" name="release_locked_branches" title="Branches AppBuilder must not auto-merge into until you remove them here — PRs are still reviewed but held" value="{{ (settings.release_locked_branches or []) | join(', ') }}" placeholder="dev, qa" class="w-full p-2 rounded-lg outline-none focus:ring-2 focus:ring-[#01A982]">
+                                        <p class="text-xs text-slate-500">Comma-separated. While a branch is listed here, AppBuilder keeps reviewing PRs but will <span class="font-medium">not auto-merge</span> into it — changes stack up as open PRs for testing/validation and are processed once you remove it. Humans can still merge manually.</p>
+                                    </div>
                                 </div>
                             </div>
                             <div class="space-y-2 col-span-1 md:col-span-3">

--- a/test_branch_policy.py
+++ b/test_branch_policy.py
@@ -16,9 +16,11 @@ from branch_policy import (
     auto_branch_prefixes,
     is_auto_created,
     is_protected,
+    is_release_locked,
     may_delete,
     may_force_push,
     protected_branches,
+    release_locked_branches,
 )
 
 
@@ -239,3 +241,41 @@ def test_auto_branch_name_prefixes_match_the_recognition_table():
         name = auto_branch_name(kind, description="x")
         assert name.startswith(prefix)
         assert is_auto_created(name)
+
+
+# ── release lock: hold auto-merge into a branch without blocking review ──────
+
+def test_no_release_lock_by_default():
+    assert release_locked_branches({}) == set()
+    assert release_locked_branches(None) == set()
+    assert not is_release_locked("dev", {})
+    assert not is_release_locked("qa", {})
+
+
+@pytest.mark.parametrize("ref", ["dev", "qa"])
+def test_locked_branches_report_locked(ref):
+    cfg = {"release_locked_branches": ["dev", "qa"]}
+    assert is_release_locked(ref, cfg)
+    assert release_locked_branches(cfg) == {"dev", "qa"}
+
+
+def test_release_lock_is_case_insensitive_and_string_parsed():
+    # Settings supplies a comma-separated string; matching ignores case/space.
+    cfg = {"release_locked_branches": "Dev, QA"}
+    assert is_release_locked("dev", cfg)
+    assert is_release_locked("qa", cfg)
+    assert not is_release_locked("main", cfg)
+
+
+def test_unlisted_branch_is_not_locked():
+    cfg = {"release_locked_branches": ["dev"]}
+    assert is_release_locked("dev", cfg)
+    assert not is_release_locked("qa", cfg)
+
+
+def test_release_lock_does_not_affect_delete_or_protection():
+    # The lock gates auto-merge only — it must not change cleanup/force-push
+    # policy. A locked non-auto branch is still just "not AppBuilder's".
+    cfg = {"release_locked_branches": ["feature/x"]}
+    ok, _ = may_delete("feature/x", cfg)
+    assert not ok  # unchanged: not an auto-created branch, still undeletable

--- a/test_feature_automerge_gate.py
+++ b/test_feature_automerge_gate.py
@@ -40,8 +40,10 @@ def _load_ns():
             seg = ast.get_source_segment(src, node)
             break
     assert seg, "_automerge_decision not found in pr_review.py"
+    import branch_policy
     ns = {"feature_boundary": real_feature_boundary,
-          "feature_allowlist": real_feature_allowlist}
+          "feature_allowlist": real_feature_allowlist,
+          "is_release_locked": branch_policy.is_release_locked}
     exec(seg, ns)
     return ns
 
@@ -101,6 +103,18 @@ def main():
     # explicitly rather than just asserting it as a side effect. ─────────────
     should, reason = decide(_clean_rec(), ["some/file.py"], _clean_config(), _clean_pr_meta())
     ok &= _check("human PR, all conditions cleared -> auto-merge approved", should is True)
+
+    # ── release lock: a fully-cleared PR is HELD (not merged) while its target
+    # branch is locked, and flows again once the lock is lifted. Review still
+    # runs; only the unattended merge waits. ─────────────────────────────────
+    should, reason = decide(_clean_rec(), ["some/file.py"],
+                            _clean_config(release_locked_branches=["dev"]), _clean_pr_meta())
+    ok &= _check("target branch under release lock -> held (not merged)", should is False)
+    ok &= _check("release-lock reason names the lock",
+                 should is False and "release lock" in (reason or "").lower())
+    should, reason = decide(_clean_rec(), ["some/file.py"],
+                            _clean_config(release_locked_branches=["qa"]), _clean_pr_meta())
+    ok &= _check("a DIFFERENT branch locked -> this dev PR still flows", should is True)
 
     # ── two independent kill switches ────────────────────────────────────────
     should, reason = decide(_clean_rec(), [], _clean_config(feature_drive_enabled=False), _clean_pr_meta())


### PR DESCRIPTION
## What

Adds a per-branch **release lock**: while a branch is listed, AppBuilder keeps **reviewing** PRs but must **not auto-merge** into it. Changes stack up as open PRs so a human can finish testing/validation, and they are processed on the next scan once the lock is released. Humans can still merge manually — only the unattended merge is held.

## Changes

- **branch_policy.py** — `release_locked_branches()` / `is_release_locked()` (config key `release_locked_branches`, empty by default; case-insensitive; accepts list or comma/space string).
- **pr_review._automerge_decision** — returns `(False, …)` when the target branch is locked, checked **before** the target-branch allowlist so a locked branch holds even when otherwise an eligible auto-merge target. The review path is untouched.
- **routes.save_settings** — persists `release_locked_branches` (parsed as a list).
- **templates/index.html** — "Release lock" field in the branch-policy card (with a `title=` tooltip, so it does not trip `check_tooltips`).
- **tests** — branch_policy release-lock cases; a decision-level hold/flow case in the auto-merge gate self-test.

## Scope / safety

- Gates the **merge only** — not review, deletion, force-push, or protection.
- Default-off (no branches locked) → no behavior change unless configured.

## Validation

- test_branch_policy.py — 55 passed.
- test_feature_automerge_gate.py — all cases pass (incl. new lock hold/flow).
- test_automerge_settings_controls.py — all pass.

Note: this branch is based on dev, which currently carries the pre-existing test_promote_routes.py break (13 failures, fixed separately by #164). Those failures are unrelated to this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
