### PR TITLE
feat(fix-engine): mark already-fixed issues resolved instead of failed

### DIFF
--- a/fix_engine.py
+++ b/fix_engine.py
@@ -1915,6 +1915,114 @@ def _norm_confidence(value):
     return max(0.0, min(1.0, c))
 
 
+#: Failure kinds where NO accepted change was produced because the model either
+#: found nothing to change (``no_edits``) or produced something the reviewers did
+#: not accept (``review_rejected`` / ``low_confidence``). These are the only states
+#: where "the code is already correct" is a plausible explanation, so they are the
+#: only ones worth an already-resolved check. Mechanical output failures (bad or
+#: truncated JSON, missed edit anchors, unsafe rewrite) and ``qa_failed`` (a change
+#: WAS made and broke tests) are never evidence of an already-fixed tree.
+_RESOLVED_CHECK_KINDS = frozenset({"no_edits", "review_rejected", "low_confidence"})
+
+
+def _should_check_already_resolved(last_failure, config):
+    """Pure gate (no LLM/network): run the already-resolved verification only for
+    failure kinds that mean 'the model engaged but produced no accepted change',
+    and only when the feature is enabled (config ``verify_already_resolved``,
+    default on)."""
+    if not (config or {}).get("verify_already_resolved", True):
+        return False
+    kind = (last_failure or {}).get("kind") or "unknown"
+    return kind in _RESOLVED_CHECK_KINDS
+
+
+def _resolved_gate(result, config):
+    """Pure decision: given the verifier's parsed result, decide whether to mark
+    the issue resolved. Deliberately strict — requires an explicit ``resolved`` is
+    true, non-empty ``evidence``, and a ``confidence`` at/above the configured
+    threshold (config ``resolved_confidence_threshold``, default 0.85) — so an
+    unsure or hallucinated verdict falls through to the normal failure path."""
+    if not isinstance(result, dict) or not result.get("resolved"):
+        return False
+    if not str(result.get("evidence") or "").strip():
+        return False
+    try:
+        conf = float(result.get("confidence"))
+    except (TypeError, ValueError):
+        return False
+    try:
+        threshold = float((config or {}).get("resolved_confidence_threshold", 0.85))
+    except (TypeError, ValueError):
+        threshold = 0.85
+    return conf >= threshold
+
+
+def verify_already_resolved(repo_path, issue_body, config, task_id=None):
+    """Ask a model whether the reported problem is ALREADY absent from the current
+    code — i.e. the run produced no accepted fix because there is nothing left to
+    fix (a re-filed/duplicate report, or a fix already merged), not because the fix
+    could not be found. Returns the parsed dict
+    ``{"resolved": bool, "confidence": float, "evidence": str}`` or ``{}`` on any
+    failure.
+
+    Best-effort and side-effect-free: a provider/cooldown/parse error yields ``{}``
+    so the caller falls through to the normal failure path and never emits a false
+    'resolved'. Judges ONLY from the current file contents on disk (the tree is
+    pristine at HEAD by the time a run is declared failed)."""
+    try:
+        files = identify_files_to_fix(repo_path, issue_body) or []
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"already-resolved check: file identification failed: {e}")
+        return {}
+    blobs, budget = [], 24000
+    for rel in files[:6]:
+        full = _safe_repo_target(repo_path, rel, what="already-resolved read")
+        if not full:
+            continue
+        try:
+            with open(full, "r", encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        take = text[:budget]
+        blobs.append(f"=== {rel} ===\n{take}")
+        budget -= len(take)
+        if budget <= 0:
+            break
+    if not blobs:
+        return {}
+    prompt = (
+        f"Reported problem:\n{issue_body}\n\n"
+        "Current code (the files most relevant to this problem):\n\n"
+        + "\n\n".join(blobs)
+        + "\n\nQuestion: Is the reported problem ALREADY resolved in the current code shown "
+          "above — i.e. is there NO code change left to make because the code already behaves "
+          "correctly? Judge ONLY from the code shown. If the fix is clearly already present, "
+          "quote the specific current-code lines that prove it. If you are unsure, or the "
+          "problem still appears present, answer resolved=false.\n"
+          "Return ONLY a JSON object: {\"resolved\": boolean, \"confidence\": number between 0 "
+          "and 1, \"evidence\": \"the specific current-code lines proving it, or empty\"}"
+    )
+    try:
+        from model_selection import LlmRequirements
+        reqs = LlmRequirements(complexity="small", needs_structured_output=True,
+                               min_context_tokens=len(prompt) // 4)
+        res = call_llm(prompt, system_prompt="You are a strict verification bot. Only return a JSON object.",
+                       requirements=reqs, task_id=task_id)
+        import re
+        match = re.search(r'\{.*\}', res or "", re.DOTALL)
+        if not match:
+            return {}
+        data = _robust_json_loads(match.group())
+        return data if isinstance(data, dict) else {}
+    except Exception as e:  # noqa: BLE001
+        if is_llm_cooldown_error(e):
+            logger.warning(f"already-resolved check deferred — LLM providers cooling down: {e}")
+        else:
+            logger.warning(f"already-resolved check failed: {e}")
+        return {}
+
+
 def _safe_repo_target(repo_root, filepath, what="apply fix"):
     """Resolve *filepath* under *repo_root*, rejecting absolute paths, ``..``
     traversal, and symlinks that escape the repo. Returns the absolute path or
@@ -3122,6 +3230,60 @@ def process_single_issue(repo_name, issue_num, llm_preference=None):
                     continue
 
             if not success:
+                # "Failure" must mean "I could not fix it" — NOT "there was nothing
+                # to fix". Before recording a failure, for the kinds where no accepted
+                # change was produced, verify whether the reported problem is ALREADY
+                # resolved in the current tree (a re-filed/duplicate report, or a fix
+                # already merged). If so, mark the issue resolved instead of failed.
+                if _should_check_already_resolved(last_failure, config):
+                    try:
+                        _verdict = verify_already_resolved(
+                            repo_git.working_dir, issue.body or "", config, task_id=issue_id)
+                    except Exception as _ve:  # noqa: BLE001
+                        logger.warning(f"already-resolved check errored for {issue_id}: {_ve}")
+                        _verdict = {}
+                    if _resolved_gate(_verdict, config):
+                        _evidence = str(_verdict.get("evidence") or "").strip()
+                        _conf = _norm_confidence(_verdict.get("confidence"))
+                        logger.info(f"{issue_id}: no fix was needed — already resolved in tree "
+                                    f"(confidence {_conf:.0%}); marking resolved, not failed.")
+                        try:
+                            issue.create_comment(
+                                "✅ **AppBuilder — already resolved**\n\n"
+                                "I found no code change to make because the reported problem does "
+                                "not appear to be present in the current code — it looks like this "
+                                f"was already fixed (verification confidence {_conf:.0%}).\n\n"
+                                f"**Evidence:**\n{_evidence[:1500]}\n\n"
+                                "Marking this as resolved. Reopen if it recurs.")
+                        except Exception as ce:  # noqa: BLE001
+                            logger.warning(f"could not post already-resolved comment to {issue_id}: {ce}")
+                        try:
+                            issue.add_to_labels("ab-already-resolved")
+                        except Exception:  # noqa: BLE001
+                            pass
+                        try:
+                            issue.edit(state="closed")
+                        except Exception as ce:  # noqa: BLE001
+                            logger.warning(f"could not close already-resolved issue {issue_id}: {ce}")
+                        processed = load_processed()
+                        processed[f"{repo_name}:{issue_num}"] = {
+                            "status": "resolved",
+                            "timestamp": datetime.now().isoformat(),
+                            "resolution": "already_fixed",
+                            "evidence": _evidence[:1000],
+                            "confidence": _conf,
+                            "attempts": max_attempts,
+                            "original_body": issue.body,
+                        }
+                        save_processed(processed)
+                        state["processed"] = processed
+                        try:
+                            recompute_issue_counters(processed)
+                        except Exception:  # noqa: BLE001
+                            pass
+                        update_task_state(task_id=issue_id, action="end")
+                        return True, "Already resolved (no code change needed)"
+
                 state["failure_count"] += 1
                 # Lead with the CAUSE. This string is shown truncated in the
                 # status table, and the old form spent its first 72 characters on

--- a/routes.py
+++ b/routes.py
@@ -2228,6 +2228,12 @@ async def settings_page(request: Request):
     config.setdefault("pr_review_state_logic_enabled", False)
     config.setdefault("batch_enabled", False)
     config.setdefault("prompt_caching_enabled", True)
+    # Already-resolved verification: when a fix run produces no accepted change,
+    # check whether the reported problem is already fixed in the tree and mark the
+    # issue RESOLVED (not "failed") if so. Default ON. Threshold is the minimum
+    # verifier confidence required before auto-resolving/closing.
+    config.setdefault("verify_already_resolved", True)
+    config.setdefault("resolved_confidence_threshold", 0.85)
     # Source knobs (default ON keeps the LM bug-fix pipeline working; the per-
     # module log grid + fix-log-detected are opt-in, default OFF, so the operator
     # enables noisy sources one at a time).
@@ -2769,6 +2775,9 @@ async def save_settings(request: Request):
     config_data["pr_test_regression_enabled"] = data.get("pr_test_regression_enabled") == "on"
     config_data["batch_enabled"] = data.get("batch_enabled") == "on"
     config_data["prompt_caching_enabled"] = data.get("prompt_caching_enabled") == "on"
+    # Mark already-fixed issues RESOLVED instead of "failed" when a run produces no
+    # accepted change and the problem is verified already-present in the tree.
+    config_data["verify_already_resolved"] = data.get("verify_already_resolved") == "on"
     # File-a-Bug toggle (defaults on so the footer button works out of the box).
     config_data["bug_report_enabled"] = data.get("bug_report_enabled") != "off"
     config_data["qa_enabled"] = data.get("qa_enabled") == "on"

--- a/templates/index.html
+++ b/templates/index.html
@@ -1765,6 +1765,12 @@
                                     Heartbeat Triage (file issues for missing heartbeats)
                                 </label>
                             </div>
+                            <div class="flex items-center gap-3 p-4 bg-slate-50 rounded-lg border border-slate-200">
+                                <input type="checkbox" name="verify_already_resolved" id="verify_already_resolved" {{ 'checked' if settings.verify_already_resolved else '' }} class="w-4 h-4 text-[#01A982] focus:ring-[#01A982]" title="On by default. When a fix run produces no accepted change (the model found nothing to change, or its change was rejected as unnecessary), AppBuilder verifies whether the reported problem is ALREADY fixed in the current code. If a model confirms it with evidence at/above the confidence threshold, the issue is marked RESOLVED and closed (with an evidence comment) instead of posting an 'AppBuilder Failure'. Failure is reserved for 'I could not fix it', not 'there was nothing to fix'. Reversible: reopen if it recurs.">
+                                <label for="verify_already_resolved" class="text-xs font-medium text-slate-700" title="On by default. When a fix run produces no accepted change (the model found nothing to change, or its change was rejected as unnecessary), AppBuilder verifies whether the reported problem is ALREADY fixed in the current code. If a model confirms it with evidence at/above the confidence threshold, the issue is marked RESOLVED and closed (with an evidence comment) instead of posting an 'AppBuilder Failure'. Failure is reserved for 'I could not fix it', not 'there was nothing to fix'. Reversible: reopen if it recurs.">
+                                    Mark already-fixed issues resolved (not failed)
+                                </label>
+                            </div>
                         </div>
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-6">
                             <div class="space-y-2">

--- a/test_already_resolved.py
+++ b/test_already_resolved.py
@@ -1,0 +1,117 @@
+"""Selftest for fix_engine's already-resolved gating.
+
+WHY: "Failure" must mean "I could not fix it", not "there was nothing to fix".
+When a fix run produces no accepted change AND the reported problem is already
+present-and-correct in the tree (a re-filed/duplicate report, or a fix already
+merged — exactly lm#486 and lm#487, which were fixed in #489/854698a8 yet kept
+being retried and reported as AppBuilder Failures), the issue should be marked
+RESOLVED, not failed.
+
+The two decision points are pure and tested here:
+  * _should_check_already_resolved(last_failure, config) — WHICH failure kinds are
+    even eligible for the check (and the on/off gate), and
+  * _resolved_gate(verifier_result, config) — whether the verifier's verdict is
+    strong enough (explicit resolved=true, evidence present, confidence >= thresh)
+    to auto-resolve.
+
+fix_engine imports the app (circular at import time), so the pure helpers are
+extracted with ast — the same harness pattern the other selftests use.
+"""
+import ast
+
+_WANT_FUNCS = {"_should_check_already_resolved", "_resolved_gate"}
+_WANT_ASSIGNS = {"_RESOLVED_CHECK_KINDS"}
+
+
+def _load():
+    tree = ast.parse(open("fix_engine.py").read())
+    ns = {}
+    mod = ast.Module(body=[], type_ignores=[])
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in _WANT_FUNCS:
+            mod.body.append(node)
+        elif isinstance(node, ast.Assign) and any(
+                getattr(t, "id", None) in _WANT_ASSIGNS for t in node.targets):
+            mod.body.append(node)
+    exec(compile(mod, "fix_engine_extract", "exec"), ns)
+    missing = sorted((_WANT_FUNCS | _WANT_ASSIGNS) - set(ns))
+    if missing:
+        raise AssertionError("extraction incomplete, missing: %s" % ", ".join(missing))
+    return ns
+
+
+def _check(label, cond):
+    print(("  PASS  " if cond else "  FAIL  ") + label)
+    return bool(cond)
+
+
+def main():
+    ns = _load()
+    should = ns["_should_check_already_resolved"]
+    gate = ns["_resolved_gate"]
+    ON = {}  # empty config → feature defaults ON
+    ok = True
+
+    print("which failure kinds are eligible for the already-resolved check:")
+    ok &= _check("no_edits is eligible (model found nothing to change)",
+                 should({"kind": "no_edits"}, ON) is True)
+    ok &= _check("review_rejected is eligible (fix deemed unnecessary/fragile)",
+                 should({"kind": "review_rejected"}, ON) is True)
+    ok &= _check("low_confidence is eligible",
+                 should({"kind": "low_confidence"}, ON) is True)
+    ok &= _check("qa_failed is NOT eligible (a change was made and broke tests)",
+                 should({"kind": "qa_failed"}, ON) is False)
+    ok &= _check("invalid_json is NOT eligible (mechanical output failure)",
+                 should({"kind": "invalid_json"}, ON) is False)
+    ok &= _check("edit_anchor_miss is NOT eligible",
+                 should({"kind": "edit_anchor_miss"}, ON) is False)
+    ok &= _check("error is NOT eligible",
+                 should({"kind": "error"}, ON) is False)
+    ok &= _check("a missing/unknown kind is NOT eligible",
+                 should({}, ON) is False and should(None, ON) is False)
+
+    print("the feature can be turned off:")
+    ok &= _check("verify_already_resolved=false disables the check entirely",
+                 should({"kind": "no_edits"}, {"verify_already_resolved": False}) is False)
+    ok &= _check("verify_already_resolved=true keeps it on",
+                 should({"kind": "no_edits"}, {"verify_already_resolved": True}) is True)
+
+    print("the verifier verdict gate (strict — must be confident, evidenced, explicit):")
+    ok &= _check("resolved + high confidence + evidence passes",
+                 gate({"resolved": True, "confidence": 0.95, "evidence": "line 1702: _mdFilter.tenant = tenant"}, ON) is True)
+    ok &= _check("resolved=false never passes",
+                 gate({"resolved": False, "confidence": 0.99, "evidence": "x"}, ON) is False)
+    ok &= _check("resolved=true but NO evidence fails",
+                 gate({"resolved": True, "confidence": 0.99, "evidence": ""}, ON) is False)
+    ok &= _check("resolved=true but whitespace-only evidence fails",
+                 gate({"resolved": True, "confidence": 0.99, "evidence": "   "}, ON) is False)
+    ok &= _check("confidence below the default 0.85 threshold fails",
+                 gate({"resolved": True, "confidence": 0.5, "evidence": "x"}, ON) is False)
+    ok &= _check("confidence exactly at threshold passes",
+                 gate({"resolved": True, "confidence": 0.85, "evidence": "x"}, ON) is True)
+    ok &= _check("a custom higher threshold is honored",
+                 gate({"resolved": True, "confidence": 0.9, "evidence": "x"},
+                      {"resolved_confidence_threshold": 0.95}) is False)
+    ok &= _check("non-numeric confidence fails safely",
+                 gate({"resolved": True, "confidence": "very", "evidence": "x"}, ON) is False)
+    ok &= _check("missing confidence fails safely",
+                 gate({"resolved": True, "evidence": "x"}, ON) is False)
+    ok &= _check("a non-dict verdict fails safely",
+                 gate(None, ON) is False and gate("resolved", ON) is False)
+    ok &= _check("an empty verdict ({}) fails safely",
+                 gate({}, ON) is False)
+    ok &= _check("a garbage threshold falls back to 0.85 (still passes a 0.9 verdict)",
+                 gate({"resolved": True, "confidence": 0.9, "evidence": "x"},
+                      {"resolved_confidence_threshold": "high"}) is True)
+
+    print()
+    if ok:
+        print("ALL CASES PASSED")
+        return 0
+    print("ONE OR MORE CASES FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
## What changed

AppBuilder now distinguishes **"there was nothing to fix"** from **"I could not fix it."** When a fix run ends without an accepted change *and* the reported problem is already fixed in the tree, the issue is marked **resolved** (with an evidence comment) instead of posting an **AppBuilder Failure**.

### Motivation
lm#486 and lm#487 were both fixed in #489 (`854698a8`, verified live in prod), yet every retry kept posting "🤖 AppBuilder Failure — I attempted to fix this issue 3 times." The model correctly found nothing to change (or reviewers rejected a redundant/doc-only change), but that was reported as a failure. Failure should mean "I could not fix it," not "it's already fixed."

### How it works (`fix_engine.py`)
On the failure path in `process_single_issue`, **before** recording a failure:
- **`_should_check_already_resolved(last_failure, config)`** — only eligible failure kinds trigger the check: `no_edits`, `review_rejected`, `low_confidence` (states where no accepted change was produced). Mechanical failures (`invalid_json`, `edit_anchor_miss`, `unsafe_rewrite`, `truncated_json`, `error`) and `qa_failed` (a change was made and broke tests) are **excluded** — they're never evidence of an already-fixed tree.
- **`verify_already_resolved(...)`** — re-localizes the relevant files (reusing `identify_files_to_fix`), reads them from the pristine-at-HEAD clone, and asks a model: *"Is this problem already resolved in the current code? Quote the evidence."* Best-effort — any provider/cooldown/parse error returns `{}` and falls through to the normal failure path (never a false resolve).
- **`_resolved_gate(result, config)`** — strict: requires explicit `resolved=true`, non-empty `evidence`, and `confidence >= resolved_confidence_threshold` (default `0.85`).

When it passes: posts a **✅ AppBuilder — already resolved** comment with the evidence, adds label `ab-already-resolved`, closes the issue, records status `resolved` (`resolution: already_fixed`), and returns success. Reversible — "reopen if it recurs."

### Config (both default-safe)
- `verify_already_resolved` (bool, **default true**) — new Settings toggle ("Mark already-fixed issues resolved (not failed)").
- `resolved_confidence_threshold` (float, default `0.85`).

### Tests
`test_already_resolved.py` — 23 cases (AST-extraction harness, matching the repo's other pure-helper selftests) covering kind eligibility, the on/off gate, and the strict verdict gate (evidence required, threshold boundary, malformed inputs). All pass.

Only affects the already-failing path — successful fixes and the auto-merge pipeline are untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
