### PR TITLE
Hide per-issue Claude button when no claude_cli slot is configured

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -910,10 +910,20 @@ async def dashboard(request: Request):
 
     pr_items.sort(key=get_priority)
 
+    # Whether a local Claude CLI provider slot is configured — the per-issue
+    # "Claude" fix button is hidden when it isn't, since triggerFix(..., 'claude')
+    # would otherwise fail with "no claude_cli provider is configured".
+    try:
+        from llm_client import _find_claude_cli_slot
+        claude_enabled = _find_claude_cli_slot(load_config()) is not None
+    except Exception:
+        claude_enabled = False
+
     return templates.TemplateResponse(request=request, name="index.html", context={
         "view": "status",
         "state": {**state, "processed": recent_processed},
-        "sorted_pr_reviews": pr_items
+        "sorted_pr_reviews": pr_items,
+        "claude_enabled": claude_enabled
     })
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -569,7 +569,9 @@
                                 {% else %}
                                 <button onclick="triggerFix('{{ issue_id }}', 'retry')" class="btn-sec text-[10px] px-2 py-0.5 rounded font-bold whitespace-nowrap">Retry</button>
                                 <button onclick="reopenIssue('{{ issue_id }}')" class="text-[10px] px-2 py-0.5 rounded font-bold whitespace-nowrap bg-sky-100 hover:bg-sky-200 text-sky-700 border border-sky-200 transition-colors" title="Reopen on GitHub + re-queue — for when AppBuilder marked it fixed but the fix didn't actually land">Reopen</button>
+                                {% if claude_enabled %}
                                 <button onclick="triggerFix('{{ issue_id }}', 'claude')" class="text-[10px] px-2 py-0.5 rounded font-bold whitespace-nowrap bg-orange-100 hover:bg-orange-200 text-orange-700 border border-orange-200 transition-colors" title="Attempt fix using local Claude CLI">Claude</button>
+                                {% endif %}
                                 <button onclick="deleteIssue('{{ issue_id }}', this)" class="btn-danger text-[10px] px-2 py-0.5 rounded font-bold whitespace-nowrap" title="Dismiss: label ab-dismissed on GitHub and close (won't be re-filed)">Dismiss</button>
                                 <button onclick="resolveIssue('{{ issue_id }}')" class="btn-primary text-[10px] px-2 py-0.5 rounded font-bold whitespace-nowrap" title="Mark as resolved: close on GitHub and move to Closed">Resolved</button>
                                 {% endif %}


### PR DESCRIPTION
## What
Hides the per-issue **Claude** action button on the dashboard when no `claude_cli` provider slot is configured in AppBuilder.

## Why
The button calls `triggerFix(issue_id, 'claude')`, which sets `llm_preference='claude'`. When no `claude_cli` slot exists, the fix engine rejects it (`fix_engine.py`: "Claude CLI fix requested but no claude_cli provider is configured"). Showing a button that can only fail is misleading — this matches the existing backend gate.

## How
- `routes.py` (`dashboard`): compute `claude_enabled = _find_claude_cli_slot(load_config()) is not None` and pass it to the template. Falls back to `False` on any error.
- `templates/index.html`: wrap the Claude button in `{% if claude_enabled %}…{% endif %}`. Undefined is falsy in Jinja, so the button stays hidden in any context that doesn't set the flag.

The Retry / Reopen / Dismiss / Resolved actions are unaffected. Rows are server-rendered and the dashboard auto-refreshes via full page reload, so no JS change is needed.

## Validation
- `routes.py` compiles; `index.html` Jinja-parses.
